### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | How to run | Notes |
+|---|---|---|
+| **supagraf** (Python ETL) | `uv run python -m supagraf --help` | Python 3.10, deps via `uv sync` |
+| **frontend** (Next.js 16) | `cd frontend && pnpm dev` | Runs on http://localhost:3000 |
+
+### Environment setup
+
+- Python 3.10 is required (`.python-version`). Install via `uv python install 3.10` if missing.
+- `uv sync` installs the supagraf package in editable mode automatically.
+- Frontend uses `pnpm install` (lockfile: `frontend/pnpm-lock.yaml`).
+- Both services require `.env` (root) and `frontend/.env.local` populated from secrets (`SUPABASE_URL`, `SUPABASE_KEY`, `SUPABASE_SERVICE_ROLE_KEY`). See `.env.example`.
+
+### Running tests
+
+- **Python unit tests**: `uv run pytest tests/supagraf/unit -q --ignore=tests/supagraf/unit/test_pdf_extract.py`
+  - `test_pdf_extract.py` has a stale import (`_resolve_ocr_backend`) — skip it.
+  - Some unit tests have pre-existing mock signature mismatches (61 failures as of May 2026) — these are not caused by env issues.
+- **E2E tests** (hit live Supabase): `RUN_E2E=1 uv run pytest tests/supagraf/e2e -q`
+- **Frontend lint**: `cd frontend && pnpm lint` (23 pre-existing errors, mostly React hooks warnings)
+
+### Gotchas
+
+- The Supabase project (`krtdwpbkzlyxzwpeqzww`) can return PGRST002 ("schema cache") errors intermittently. This resolves on its own — retry or wait.
+- The Python `SUPABASE_KEY` in `.env` should be the **service_role** JWT (not the publishable key) for ETL write operations. The frontend uses the publishable/anon key.
+- `uv run python -m supagraf` loads `.env` from workspace root automatically via `supagraf/db.py:load_dotenv()`.
+- Next.js 16 is a canary release — read `node_modules/next/dist/docs/` before modifying frontend code.
+- The `msw` build script warning during `pnpm install` is benign (ignored build script).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a root-level `AGENTS.md` with Cursor Cloud specific instructions covering:

- Services overview table (supagraf ETL + Next.js frontend)
- Environment setup notes (Python 3.10, uv, pnpm, `.env` files)
- Test running instructions with known skip/failure context
- Gotchas discovered during setup (PGRST002 intermittent errors, key types, Next.js 16 canary caveats)

**Evidence of working dev environment:**

[Tygodnik Sejmowy homepage with live data](https://cursor.com/agents/bc-94543069-7cbf-4da9-b6b8-6ca348e4f665/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_tygodnik_sejmowy.webp)
[Atlas page with MP district map](https://cursor.com/agents/bc-94543069-7cbf-4da9-b6b8-6ca348e4f665/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fatlas_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94543069-7cbf-4da9-b6b8-6ca348e4f665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94543069-7cbf-4da9-b6b8-6ca348e4f665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

