### PR TITLE
Fix /sondaze series history and clarify non-additive polling totals

### DIFF
--- a/frontend/app/sondaze/_components/Average30dGrid.tsx
+++ b/frontend/app/sondaze/_components/Average30dGrid.tsx
@@ -1,4 +1,5 @@
 import type { PollAverageRow } from "@/lib/db/polls";
+import { NON_ADDITIVE_SERIES_NOTE } from "@/lib/polls/series";
 import { partyColor, partyLabel, partyLogoSrc, RESIDUAL_CODES } from "./partyMeta";
 
 function daysAgo(iso: string): string {
@@ -20,6 +21,7 @@ export function Average30dGrid({ rows }: { rows: PollAverageRow[] }) {
   const main = rows.filter((r) => !RESIDUAL_CODES.has(r.party_code));
   const residual = rows.filter((r) => RESIDUAL_CODES.has(r.party_code));
   const max = Math.max(1, ...main.map((r) => r.percentage_avg));
+  const total = rows.reduce((sum, r) => sum + r.percentage_avg, 0);
 
   return (
     <section>
@@ -104,6 +106,10 @@ export function Average30dGrid({ rows }: { rows: PollAverageRow[] }) {
           ))}
         </div>
       )}
+
+      <p className="mt-4 font-mono text-[10px] text-muted-foreground tracking-wide leading-relaxed">
+        Suma wszystkich pokazanych serii: {fmtPct(total)}%. {NON_ADDITIVE_SERIES_NOTE}
+      </p>
     </section>
   );
 }

--- a/frontend/app/sondaze/_components/QuarterlyTrendChart.tsx
+++ b/frontend/app/sondaze/_components/QuarterlyTrendChart.tsx
@@ -1,4 +1,5 @@
 import type { PollTrendRow } from "@/lib/db/polls";
+import { NON_ADDITIVE_SERIES_NOTE } from "@/lib/polls/series";
 import { partyColor, partyLabel } from "./partyMeta";
 
 const VB_W = 920;
@@ -75,7 +76,8 @@ export function QuarterlyTrendChart({ rows }: { rows: PollTrendRow[] }) {
           <h2 className="font-serif font-medium m-0 leading-[1.05] text-[clamp(1.5rem,5.5vw,2.25rem)] tracking-[-0.01em]">Trendy kwartalne</h2>
           <p className="font-serif m-0 mt-2 text-secondary-foreground leading-[1.5] max-w-[720px] text-[15px] sm:text-base">
             Średnia kwartalna z wszystkich sondaży w danym kwartale. Każdy punkt — jeden kwartał.
-            Pokazujemy partie z bieżącą średnią ≥ 3% (w tym KKP Brauna i Razem — poza Sejmem, ale silnie sondażowane).
+            Pokazujemy partie z bieżącą średnią ≥ 3%; nowe szyldy (np. Razem, KKP) startują dopiero od kwartału,
+            w którym realnie pojawiły się jako osobne byty polityczne.
           </p>
         </div>
       </header>
@@ -190,6 +192,9 @@ export function QuarterlyTrendChart({ rows }: { rows: PollTrendRow[] }) {
       </div>
       <p className="mt-3 font-mono text-[10px] text-muted-foreground italic tracking-wide">
         Dystans pionowy 0–50%. Najechanie na punkt pokaże dokładną wartość i liczbę sondaży w kwartale.
+      </p>
+      <p className="mt-2 font-mono text-[10px] text-muted-foreground tracking-wide leading-relaxed">
+        {NON_ADDITIVE_SERIES_NOTE}
       </p>
     </section>
   );

--- a/frontend/components/statement/AnnotatedTranscript.tsx
+++ b/frontend/components/statement/AnnotatedTranscript.tsx
@@ -3,6 +3,7 @@ import { stripSpeechBoilerplate } from "@/lib/labels";
 import {
   applyHighlights,
   extractStageDirections,
+  type ParagraphSegment,
   type StageDirection,
   type StageDirectionKind,
 } from "@/lib/transcript-annotate";
@@ -21,24 +22,16 @@ function readingTime(text: string): number {
   return Math.max(1, Math.round(words / 200));
 }
 
-function MarginDirections({ directions }: { directions: StageDirection[] }) {
-  if (directions.length === 0) return null;
+function MarginDirection({ direction }: { direction: StageDirection }) {
+  const Icon = DIRECTION_ICON[direction.kind];
   return (
-    <ul className="m-0 p-0 list-none space-y-1.5">
-      {directions.map((d, i) => {
-        const Icon = DIRECTION_ICON[d.kind];
-        return (
-          <li
-            key={i}
-            className="flex items-start gap-1.5 font-mono text-[10px] tracking-wide uppercase text-muted-foreground leading-snug"
-            title={d.label}
-          >
-            <Icon aria-hidden size={11} strokeWidth={1.75} className="text-destructive mt-[1px] shrink-0" />
-            <span className="italic normal-case font-serif text-[12px]">{d.label}</span>
-          </li>
-        );
-      })}
-    </ul>
+    <div
+      className="flex items-start gap-1.5 font-mono text-[10px] tracking-wide uppercase text-muted-foreground leading-snug"
+      title={direction.label}
+    >
+      <Icon aria-hidden size={11} strokeWidth={1.75} className="text-destructive mt-[1px] shrink-0" />
+      <span className="italic normal-case font-serif text-[12px]">{direction.label}</span>
+    </div>
   );
 }
 
@@ -46,9 +39,10 @@ function MarginDirections({ directions }: { directions: StageDirection[] }) {
 // two-column grid on desktop: prose left, stage-direction chips right.
 //
 // Stage directions ((Oklaski), (Wesołość na sali), etc.) render only on
-// desktop in the right margin column. On mobile they are dropped to keep
-// the reading column clean — per design decision 2026-05-10. If we want
-// them on mobile later, render them inline as italic muted text instead.
+// desktop in the right margin column. Unlike the first pass, we keep them
+// as ordered segment markers so each badge sits next to the exact moment in
+// the speech instead of collapsing into one stack at the paragraph start.
+// On mobile they are still dropped to keep the reading column clean.
 //
 // Highlights wrap viral_quote + key_claims substrings (>=12 chars,
 // whitespace-normalized, case-insensitive) so the reader sees what the
@@ -95,36 +89,53 @@ export function AnnotatedTranscript({
 
       <div className="pt-6">
         {paragraphs.map((p, i) => {
-          const spans = applyHighlights(p.cleanedText, needles);
           return (
-            <div
-              key={i}
-              className="md:grid md:grid-cols-[1fr_180px] md:gap-6 md:items-start mb-5"
-            >
-              <p
-                className="m-0 font-serif text-secondary-foreground"
-                style={{ fontSize: 17, lineHeight: 1.75, textWrap: "pretty" }}
-              >
-                {spans.map((s, j) =>
-                  s.kind === "mark" ? (
-                    <mark
+            <div key={i} className="mb-5 space-y-2.5">
+              {p.segments.map((segment: ParagraphSegment, j) => {
+                if (segment.kind === "direction") {
+                  return (
+                    <div
                       key={j}
-                      className="bg-muted text-foreground px-0.5 rounded-[2px]"
-                      style={{
-                        boxShadow: "inset 0 -0.42em 0 color-mix(in srgb, var(--destructive) 14%, transparent)",
-                      }}
+                      className="hidden md:grid md:grid-cols-[1fr_180px] md:gap-6 md:items-start"
                     >
-                      {s.content}
-                    </mark>
-                  ) : (
-                    <span key={j}>{s.content}</span>
-                  ),
-                )}
-              </p>
-              {/* margin column — desktop only */}
-              <div className="hidden md:block pt-1">
-                <MarginDirections directions={p.directions} />
-              </div>
+                      <div aria-hidden />
+                      <div className="pt-1">
+                        <MarginDirection direction={segment.direction} />
+                      </div>
+                    </div>
+                  );
+                }
+
+                const spans = applyHighlights(segment.text, needles);
+                return (
+                  <div
+                    key={j}
+                    className="md:grid md:grid-cols-[1fr_180px] md:gap-6 md:items-start"
+                  >
+                    <p
+                      className="m-0 font-serif text-secondary-foreground"
+                      style={{ fontSize: 17, lineHeight: 1.75, textWrap: "pretty" }}
+                    >
+                      {spans.map((s, k) =>
+                        s.kind === "mark" ? (
+                          <mark
+                            key={k}
+                            className="bg-muted text-foreground px-0.5 rounded-[2px]"
+                            style={{
+                              boxShadow: "inset 0 -0.42em 0 color-mix(in srgb, var(--destructive) 14%, transparent)",
+                            }}
+                          >
+                            {s.content}
+                          </mark>
+                        ) : (
+                          <span key={k}>{s.content}</span>
+                        ),
+                      )}
+                    </p>
+                    <div className="hidden md:block" aria-hidden />
+                  </div>
+                );
+              })}
             </div>
           );
         })}

--- a/frontend/lib/db/polls.ts
+++ b/frontend/lib/db/polls.ts
@@ -99,17 +99,20 @@ export async function getRecentPolls(limit = 20): Promise<RecentPollRow[]> {
   const rows = polls ?? [];
   if (rows.length === 0) return [];
   const pollsterCodes = Array.from(new Set(rows.map((p) => (p.pollster as string) ?? "").filter(Boolean)));
-  const { data: pollsters, error: eNames } = await sb
-    .from("pollsters")
-    .select("code, name_full")
-    .in("code", pollsterCodes);
-  if (eNames) throw eNames;
-  const pollsterNames = new Map<string, string>(
-    (pollsters ?? []).map((r) => [
-      r.code as string,
-      ((r.name_full as string) ?? (r.code as string) ?? "").trim(),
-    ]),
-  );
+  const pollsterNames = new Map<string, string>();
+  if (pollsterCodes.length > 0) {
+    const { data: pollsters, error: eNames } = await sb
+      .from("pollsters")
+      .select("code, name_full")
+      .in("code", pollsterCodes);
+    if (eNames) throw eNames;
+    for (const r of pollsters ?? []) {
+      pollsterNames.set(
+        r.code as string,
+        ((r.name_full as string) ?? (r.code as string) ?? "").trim(),
+      );
+    }
+  }
   const ids = rows.map((p) => p.id as number);
   const { data: results, error: e2 } = await sb
     .from("poll_results")

--- a/frontend/lib/db/polls.ts
+++ b/frontend/lib/db/polls.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { supabase } from "@/lib/supabase";
+import { isQuarterVisibleForParty } from "@/lib/polls/series";
 
 // E3: polls dashboard data layer. Reads matviews populated by E2 ETL
 // (poll_average_30d_mv, poll_trend_quarterly_mv) plus raw polls/poll_results
@@ -27,6 +28,7 @@ export type PollTrendRow = {
 export type RecentPollRow = {
   poll_id: number;
   pollster: string;
+  pollster_code: string;
   conducted_at_start: string;
   conducted_at_end: string;
   sample_size: number | null;
@@ -82,7 +84,7 @@ export async function getPollTrendQuarterly(parties: string[] = [...TREND_DEFAUL
     percentage_min: toNum(r.percentage_min),
     percentage_max: toNum(r.percentage_max),
     n_polls: r.n_polls as number,
-  }));
+  })).filter((r) => isQuarterVisibleForParty(r.party_code, r.quarter_start));
 }
 
 export async function getRecentPolls(limit = 20): Promise<RecentPollRow[]> {
@@ -96,6 +98,18 @@ export async function getRecentPolls(limit = 20): Promise<RecentPollRow[]> {
   if (error) throw error;
   const rows = polls ?? [];
   if (rows.length === 0) return [];
+  const pollsterCodes = Array.from(new Set(rows.map((p) => (p.pollster as string) ?? "").filter(Boolean)));
+  const { data: pollsters, error: eNames } = await sb
+    .from("pollsters")
+    .select("code, name_full")
+    .in("code", pollsterCodes);
+  if (eNames) throw eNames;
+  const pollsterNames = new Map<string, string>(
+    (pollsters ?? []).map((r) => [
+      r.code as string,
+      ((r.name_full as string) ?? (r.code as string) ?? "").trim(),
+    ]),
+  );
   const ids = rows.map((p) => p.id as number);
   const { data: results, error: e2 } = await sb
     .from("poll_results")
@@ -114,7 +128,8 @@ export async function getRecentPolls(limit = 20): Promise<RecentPollRow[]> {
   }
   return rows.map((p) => ({
     poll_id: p.id as number,
-    pollster: (p.pollster as string) ?? "",
+    pollster: pollsterNames.get((p.pollster as string) ?? "") ?? ((p.pollster as string) ?? ""),
+    pollster_code: (p.pollster as string) ?? "",
     conducted_at_start: p.conducted_at_start as string,
     conducted_at_end: p.conducted_at_end as string,
     sample_size: (p.sample_size as number | null) ?? null,

--- a/frontend/lib/polls/series.ts
+++ b/frontend/lib/polls/series.ts
@@ -1,0 +1,28 @@
+type PartySeriesMeta = {
+  // Date from which the party should be allowed to appear on the quarterly
+  // history chart. We compare against quarter END, not quarter START, so a
+  // party launched mid-quarter can still appear for that quarter.
+  chartActiveFrom?: string;
+};
+
+const POLL_PARTY_META: Record<string, PartySeriesMeta> = {
+  // Razem left the parliamentary club of Lewica in late Oct 2024; earlier
+  // quarters should not render a standalone Razem line.
+  Razem: { chartActiveFrom: "2024-10-28" },
+  // KKP existed earlier as Braun's formation, but became meaningfully polled
+  // as a standalone post-Konfederacja split in 2025.
+  KKP: { chartActiveFrom: "2025-01-01" },
+};
+
+export function isQuarterVisibleForParty(code: string, quarterStart: string): boolean {
+  const activeFrom = POLL_PARTY_META[code]?.chartActiveFrom;
+  if (!activeFrom) return true;
+  const quarterEnd = new Date(`${quarterStart}T00:00:00Z`);
+  quarterEnd.setUTCMonth(quarterEnd.getUTCMonth() + 3);
+  quarterEnd.setUTCDate(quarterEnd.getUTCDate() - 1);
+  const activeFromDate = new Date(`${activeFrom}T00:00:00Z`);
+  return quarterEnd >= activeFromDate;
+}
+
+export const NON_ADDITIVE_SERIES_NOTE =
+  "Suma serii nie musi dawać 100%: część pracowni pyta o całe bloki, a część o odłamy (np. Lewica/Razem, Konfederacja/KKP).";

--- a/frontend/lib/transcript-annotate.ts
+++ b/frontend/lib/transcript-annotate.ts
@@ -24,9 +24,14 @@ export type StageDirection = {
   label: string;
 };
 
+export type ParagraphSegment =
+  | { kind: "text"; text: string }
+  | { kind: "direction"; direction: StageDirection };
+
 export type ExtractedParagraph = {
   cleanedText: string;
   directions: StageDirection[];
+  segments: ParagraphSegment[];
 };
 
 // Map a parenthesized phrase (already lowercased, sans diacritics) to its
@@ -44,22 +49,58 @@ const STAGE_PATTERNS: Array<{ test: RegExp; kind: StageDirectionKind }> = [
 
 const PAREN_RE = /\(([^()]{2,80})\)/g;
 
+function cleanProseText(text: string): string {
+  return text.replace(/[ \t]{2,}/g, " ").replace(/\s+([,.;:!?])/g, "$1").trim();
+}
+
 export function extractStageDirections(paragraph: string): ExtractedParagraph {
   const directions: StageDirection[] = [];
-  const cleanedText = paragraph.replace(PAREN_RE, (full, inner: string) => {
+  const segments: ParagraphSegment[] = [];
+  let cursor = 0;
+  PAREN_RE.lastIndex = 0;
+
+  const pushText = (raw: string) => {
+    const text = cleanProseText(raw);
+    if (!text) return;
+    const prev = segments[segments.length - 1];
+    if (prev?.kind === "text") {
+      prev.text = cleanProseText(`${prev.text} ${text}`);
+      return;
+    }
+    segments.push({ kind: "text", text });
+  };
+
+  let match: RegExpExecArray | null;
+  while ((match = PAREN_RE.exec(paragraph)) !== null) {
+    const [full, inner] = match;
+    pushText(paragraph.slice(cursor, match.index));
     const trimmed = inner.trim();
+    let mapped: StageDirection | null = null;
     for (const { test, kind } of STAGE_PATTERNS) {
       if (test.test(trimmed)) {
-        directions.push({ kind, label: trimmed });
-        return ""; // strip from prose
+        mapped = { kind, label: trimmed };
+        break;
       }
     }
-    return full; // unknown parenthetical — leave alone
-  });
-  // Collapse double-spaces left behind by stripping a parenthetical mid-line.
+    if (mapped) {
+      directions.push(mapped);
+      segments.push({ kind: "direction", direction: mapped });
+    } else {
+      pushText(full);
+    }
+    cursor = match.index + full.length;
+  }
+  pushText(paragraph.slice(cursor));
+
   return {
-    cleanedText: cleanedText.replace(/[ \t]{2,}/g, " ").replace(/\s+([,.;:!?])/g, "$1").trim(),
+    cleanedText: cleanProseText(
+      segments
+        .filter((s): s is Extract<ParagraphSegment, { kind: "text" }> => s.kind === "text")
+        .map((s) => s.text)
+        .join(" "),
+    ),
     directions,
+    segments,
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- clamp standalone `Razem` and `KKP` quarterly series so they only appear from the quarter when they became separate political entities
- explain on `/sondaze` that mixed umbrella/split-party polling series are not additive, so the visible percentages do not necessarily sum to 100%
- resolve recent-polls pollster labels through the pollster registry instead of showing raw codes
- keep speech reaction markers (`Oklaski`, `Głos z sali`, etc.) in transcript order so each badge renders at the actual point in the speech instead of stacking at the paragraph start

## Testing
- ✅ `node --input-type=module ... isQuarterVisibleForParty(...)` verified the new history gate for `Razem` and `KKP`
- ✅ `node --input-type=module ... extractStageDirections(...)` verified ordered transcript segmentation: text → reaction → text → reaction → text
- ✅ `curl http://127.0.0.1:3000/sondaze` plus route-output inspection confirmed the new non-additive totals note is present in the rendered response
- ⚠️ `pnpm build` compiled and finished TypeScript, but prerender later hit an existing Supabase `PGRST002` schema-cache failure on unrelated routes (`/komisja`, intermittently `/mowa/[id]`), so full end-to-end route verification was limited by the environment

[sondaze_verification.txt](https://cursor.com/agents/bc-d6d9437a-1041-4dec-a7db-583b04a716f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsondaze_verification.txt)
[mowa_stage_direction_segments.txt](https://cursor.com/agents/bc-d6d9437a-1041-4dec-a7db-583b04a716f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmowa_stage_direction_segments.txt)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6d9437a-1041-4dec-a7db-583b04a716f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6d9437a-1041-4dec-a7db-583b04a716f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

