### PR TITLE
Fix ISAP act links to resolve PDFs

### DIFF
--- a/frontend/app/api/isap/acts/[publisher]/[year]/[position]/route.ts
+++ b/frontend/app/api/isap/acts/[publisher]/[year]/[position]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import {
+  buildActApiUrl,
+  buildIsapAddress,
+  buildIsapDocDetailsUrl,
+  buildIsapDocDetailsUrlFromAddress,
+  buildIsapPdfUrlFromAddress,
+  parseActRef,
+} from "@/lib/isap";
+
+type ApiActText = {
+  fileName?: string;
+  type?: string;
+};
+
+type ApiActDetail = {
+  address?: string;
+  textPDF?: boolean;
+  texts?: ApiActText[];
+};
+
+function pickPdfText(texts: ApiActText[] | undefined): ApiActText | null {
+  const candidates = (texts ?? []).filter((text) =>
+    typeof text.fileName === "string" && /\.pdf$/i.test(text.fileName),
+  );
+  if (candidates.length === 0) return null;
+  const rank = (type: string | undefined): number => {
+    switch (type) {
+      case "O": return 0;
+      case "I": return 1;
+      case "T": return 2;
+      default: return 3;
+    }
+  };
+  candidates.sort((a, b) => rank(a.type) - rank(b.type));
+  return candidates[0];
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ publisher: string; year: string; position: string }> },
+) {
+  const { publisher, year, position } = await params;
+  const ref = parseActRef(`${publisher}/${year}/${position}`);
+  if (!ref) return new NextResponse("bad act id", { status: 400 });
+
+  try {
+    const upstream = await fetch(buildActApiUrl(ref), { next: { revalidate: 3600 } });
+    if (!upstream.ok) {
+      return NextResponse.redirect(buildIsapDocDetailsUrl(ref), 307);
+    }
+
+    const detail = await upstream.json() as ApiActDetail;
+    const address = detail.address || buildIsapAddress(ref);
+    const pdf = pickPdfText(detail.texts);
+
+    if (detail.textPDF !== false && pdf?.fileName) {
+      return NextResponse.redirect(buildIsapPdfUrlFromAddress(address, pdf.fileName), 307);
+    }
+
+    return NextResponse.redirect(buildIsapDocDetailsUrlFromAddress(address), 307);
+  } catch {
+    return NextResponse.redirect(buildIsapDocDetailsUrl(ref), 307);
+  }
+}

--- a/frontend/lib/db/events.ts
+++ b/frontend/lib/db/events.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { unstable_cache } from "next/cache";
 import { supabase } from "@/lib/supabase";
+import { normalizeActSourceUrl } from "@/lib/isap";
 import {
   topicsFromDb,
   SECTION_LIMITS,
@@ -118,7 +119,12 @@ async function loadEventsBySitting(term: number, sittingNum: number): Promise<We
         sittingNum: r.sitting_num,
         eventDate: r.event_date,
         impactScore: r.impact_score ?? 0,
-        sourceUrl: r.source_url,
+        sourceUrl: r.event_type === "eli_inforce"
+          ? (normalizeActSourceUrl(
+              r.source_url,
+              (r.payload as { eli_id?: string | null })?.eli_id,
+            ) ?? r.source_url)
+          : r.source_url,
         payload: r.payload as never,
       } as WeeklyEvent);
     }

--- a/frontend/lib/db/prints.ts
+++ b/frontend/lib/db/prints.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { normalizeActSourceUrl } from "@/lib/isap";
 import { supabase } from "@/lib/supabase";
 import { dbTagsToPersonas, type PersonaId } from "@/lib/personas";
 import { dbTagsToTopics, type TopicId } from "@/lib/topics";
@@ -296,7 +297,10 @@ export async function getPrint(term: number, number: string): Promise<PrintWithS
           displayAddress: (proc.display_address as string) ?? "",
           title: (actRow.title as string) ?? null,
           status: (actRow.status as string) ?? null,
-          sourceUrl: (actRow.source_url as string) ?? null,
+          sourceUrl: normalizeActSourceUrl(
+            (actRow.source_url as string) ?? null,
+            (actRow.eli_id as string) ?? null,
+          ),
           publishedAt: (actRow.promulgation_date as string) ?? null,
         };
       }

--- a/frontend/lib/db/threads.ts
+++ b/frontend/lib/db/threads.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { normalizeActSourceUrl } from "@/lib/isap";
 import { supabase } from "@/lib/supabase";
 
 // Voting tally rendered inline next to a stage row (yes/no/abstain pill).
@@ -268,7 +269,10 @@ export async function getThread(term: number, number: string): Promise<ThreadDet
         displayAddress: (proc.display_address as string) ?? "",
         title: (actRow.title as string) ?? null,
         status: (actRow.status as string) ?? null,
-        sourceUrl: (actRow.source_url as string) ?? null,
+        sourceUrl: normalizeActSourceUrl(
+          (actRow.source_url as string) ?? null,
+          (actRow.eli_id as string) ?? null,
+        ),
         publishedAt: (actRow.promulgation_date as string) ?? null,
       };
     }

--- a/frontend/lib/isap.ts
+++ b/frontend/lib/isap.ts
@@ -1,0 +1,54 @@
+type SupportedPublisher = "DU" | "MP";
+
+export type ActRef = {
+  publisher: SupportedPublisher;
+  year: string;
+  position: string;
+};
+
+const ELI_ACT_RE = /^(DU|MP)\/(\d{4})\/(\d+)$/;
+
+export function parseActRef(eliId: string | null | undefined): ActRef | null {
+  if (!eliId) return null;
+  const match = ELI_ACT_RE.exec(eliId.trim().toUpperCase());
+  if (!match) return null;
+  return {
+    publisher: match[1] as SupportedPublisher,
+    year: match[2],
+    position: match[3],
+  };
+}
+
+export function buildActApiUrl(ref: ActRef): string {
+  return `https://api.sejm.gov.pl/eli/acts/${ref.publisher}/${ref.year}/${ref.position}`;
+}
+
+export function buildIsapAddress(ref: ActRef): string {
+  const prefix = ref.publisher === "MP" ? "WMP" : "WDU";
+  return `${prefix}${ref.year}${ref.position.padStart(7, "0")}`;
+}
+
+export function buildIsapDocDetailsUrlFromAddress(address: string): string {
+  return `https://isap.sejm.gov.pl/isap.nsf/DocDetails.xsp?id=${encodeURIComponent(address)}`;
+}
+
+export function buildIsapDocDetailsUrl(ref: ActRef): string {
+  return buildIsapDocDetailsUrlFromAddress(buildIsapAddress(ref));
+}
+
+export function buildIsapPdfUrlFromAddress(address: string, fileName: string): string {
+  return `https://isap.sejm.gov.pl/isap.nsf/download.xsp/${encodeURIComponent(address)}/O/${encodeURIComponent(fileName)}`;
+}
+
+export function buildActTextHref(eliId: string | null | undefined): string | null {
+  const ref = parseActRef(eliId);
+  if (!ref) return null;
+  return `/api/isap/acts/${ref.publisher}/${ref.year}/${ref.position}`;
+}
+
+export function normalizeActSourceUrl(
+  sourceUrl: string | null | undefined,
+  eliId: string | null | undefined,
+): string | null {
+  return buildActTextHref(eliId) ?? sourceUrl ?? null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- route act links through a frontend redirect that resolves live ELI metadata to the published ISAP PDF when available
- use the shared act-link helper for weekly events, thread pages, and druk/thread act cards instead of linking to the raw ELI JSON endpoint
- fall back to the human ISAP details page when an act does not expose a PDF

## Testing
- runtime redirect checks logged in `<TextReference path="/opt/cursor/artifacts/isap_link_checks.log" start={1} end={9} alt="ISAP redirect verification log" ></TextReference>`
- manual browser verification on `http://localhost:3001/tygodnik/p/56`

## Walkthrough
[isap_act_link_pdf_redirect_demo.mp4](https://cursor.com/agents/bc-f45835c0-3e7c-492f-bc4f-eadf6c6fd96a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fisap_act_link_pdf_redirect_demo.mp4)
[ISAP act card before click](https://cursor.com/agents/bc-f45835c0-3e7c-492f-bc4f-eadf6c6fd96a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fisap_link_before_click.webp)
[ISAP PDF loaded](https://cursor.com/agents/bc-f45835c0-3e7c-492f-bc4f-eadf6c6fd96a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fisap_pdf_loaded.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f45835c0-3e7c-492f-bc4f-eadf6c6fd96a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f45835c0-3e7c-492f-bc4f-eadf6c6fd96a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

