### PR TITLE
Fix sondaze trend parsing and align speech reaction badges

### DIFF
--- a/frontend/app/sondaze/_components/QuarterlyTrendChart.tsx
+++ b/frontend/app/sondaze/_components/QuarterlyTrendChart.tsx
@@ -1,13 +1,12 @@
 import type { PollTrendRow } from "@/lib/db/polls";
-import { NON_ADDITIVE_SERIES_NOTE } from "@/lib/polls/series";
 import { partyColor, partyLabel } from "./partyMeta";
 
-const VB_W = 920;
-const VB_H = 320;
-const M_LEFT = 40;
-const M_RIGHT = 20;
-const M_TOP = 20;
-const M_BOTTOM = 30;
+const VB_W = 980;
+const VB_H = 360;
+const M_LEFT = 42;
+const M_RIGHT = 170;
+const M_TOP = 18;
+const M_BOTTOM = 28;
 const Y_MIN = 0;
 const Y_MAX = 50;
 
@@ -19,10 +18,8 @@ function quarterLabel(iso: string): string {
   return `'${y} Q${q}`;
 }
 
-function quarterKey(iso: string): string {
-  const d = new Date(iso + "T00:00:00Z");
-  const q = Math.floor(d.getUTCMonth() / 3) + 1;
-  return `${d.getUTCFullYear()}-Q${q}`;
+function labelWidth(label: string): number {
+  return Math.max(68, Math.min(150, 16 + label.length * 6.4));
 }
 
 export function QuarterlyTrendChart({ rows }: { rows: PollTrendRow[] }) {
@@ -64,32 +61,58 @@ export function QuarterlyTrendChart({ rows }: { rows: PollTrendRow[] }) {
   }
 
   const yTicks = [0, 10, 20, 30, 40, 50];
+  const labelData = Array.from(byParty.entries())
+    .map(([party, points]) => {
+      const last = points[points.length - 1];
+      return {
+        party,
+        label: partyLabel(party),
+        color: partyColor(party),
+        pct: last.percentage_avg,
+        x: xFor(last.quarter_start),
+        y: yFor(last.percentage_avg),
+      };
+    })
+    .sort((a, b) => a.y - b.y);
+
+  const labelHeight = 22;
+  const minGap = 10;
+  const topBound = M_TOP + labelHeight / 2;
+  const bottomBound = VB_H - M_BOTTOM - labelHeight / 2;
+  let prevBottom = topBound - labelHeight - minGap;
+  const placedLabels = labelData.map((item) => {
+    let centerY = Math.max(item.y, prevBottom + labelHeight + minGap);
+    centerY = Math.min(centerY, bottomBound);
+    prevBottom = centerY + labelHeight / 2;
+    return { ...item, centerY };
+  }).reverse().map((item, idx, arr) => {
+    const nextTop = idx === 0 ? bottomBound + labelHeight / 2 : arr[idx - 1].centerY - labelHeight - minGap;
+    const centerY = Math.min(item.centerY, nextTop);
+    return { ...item, centerY: Math.max(centerY, topBound) };
+  }).reverse();
+  const labelX = VB_W - M_RIGHT + 14;
 
   return (
     <section>
-      <header className="mb-6 pb-3.5 border-b border-rule grid min-w-0 items-start gap-4 sm:items-baseline sm:gap-5 [grid-template-columns:minmax(0,44px)_minmax(0,1fr)] sm:[grid-template-columns:minmax(0,60px)_minmax(0,1fr)]">
+      <header className="mb-5 pb-3 border-b border-rule grid min-w-0 items-start gap-4 sm:items-baseline sm:gap-5 [grid-template-columns:minmax(0,44px)_minmax(0,1fr)] sm:[grid-template-columns:minmax(0,60px)_minmax(0,1fr)]">
         <div className="font-serif italic font-normal text-destructive leading-[0.9] text-[clamp(2.25rem,9vw,3.5rem)] sm:text-[56px]">C</div>
         <div className="min-w-0">
           <div className="font-sans text-[10px] sm:text-[11px] tracking-[0.12em] sm:tracking-[0.16em] uppercase text-muted-foreground mb-1.5">
             Trzy lata, {byParty.size} {byParty.size === 1 ? "partia" : byParty.size < 5 ? "partie" : "partii"}
           </div>
           <h2 className="font-serif font-medium m-0 leading-[1.05] text-[clamp(1.5rem,5.5vw,2.25rem)] tracking-[-0.01em]">Trendy kwartalne</h2>
-          <p className="font-serif m-0 mt-2 text-secondary-foreground leading-[1.5] max-w-[720px] text-[15px] sm:text-base">
-            Średnia kwartalna z wszystkich sondaży w danym kwartale. Każdy punkt — jeden kwartał.
-            Pokazujemy partie z bieżącą średnią ≥ 3%; nowe szyldy (np. Razem, KKP) startują dopiero od kwartału,
-            w którym realnie pojawiły się jako osobne byty polityczne.
-          </p>
         </div>
       </header>
 
       <div className="bg-muted border border-border p-2 sm:p-4 min-w-0 overflow-x-auto">
         <svg viewBox={`0 0 ${VB_W} ${VB_H}`} className="w-full min-w-[320px] h-auto block" role="img" aria-label={`Wykres trendu kwartalnego ${byParty.size} partii`}>
-          {/* Y gridlines + labels */}
+          <rect x={M_LEFT} y={M_TOP} width={innerW} height={innerH} fill="var(--background)" opacity={0.38} rx={8} />
+
           {yTicks.map((t) => {
             const y = yFor(t);
             return (
               <g key={t}>
-                <line x1={M_LEFT} y1={y} x2={VB_W - M_RIGHT} y2={y} stroke="var(--border)" strokeWidth={0.75} />
+                <line x1={M_LEFT} y1={y} x2={VB_W - M_RIGHT} y2={y} stroke="var(--border)" strokeWidth={0.8} strokeDasharray={t === 0 ? undefined : "3 5"} opacity={t === 0 ? 0.75 : 0.55} />
                 <text x={M_LEFT - 6} y={y + 3} className="font-mono" fontSize={10} fill="var(--muted-foreground)" textAnchor="end">
                   {t}%
                 </text>
@@ -97,7 +120,6 @@ export function QuarterlyTrendChart({ rows }: { rows: PollTrendRow[] }) {
             );
           })}
 
-          {/* X labels (every 2nd if many) */}
           {quarters.map((q, i) => {
             const stride = xCount > 8 ? 2 : 1;
             if (i % stride !== 0 && i !== xCount - 1) return null;
@@ -109,54 +131,71 @@ export function QuarterlyTrendChart({ rows }: { rows: PollTrendRow[] }) {
             );
           })}
 
-          {/* Lines per party */}
           {Array.from(byParty.entries()).map(([party, points]) => {
             const color = partyColor(party);
             const poly = points.map((p) => `${xFor(p.quarter_start)},${yFor(p.percentage_avg)}`).join(" ");
+            const last = points[points.length - 1];
             return (
               <g key={party}>
-                <polyline points={poly} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
-                {points.map((p) => (
+                <polyline points={poly} fill="none" stroke={color} strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" />
+                {points.map((p, idx) => (
                   <circle
                     key={`${party}-${p.quarter_start}`}
                     cx={xFor(p.quarter_start)}
                     cy={yFor(p.percentage_avg)}
-                    r={3}
+                    r={p.quarter_start === last.quarter_start ? 4.2 : 2.2}
                     fill="var(--background)"
                     stroke={color}
-                    strokeWidth={1.5}
-                  >
-                    <title>
-                      {partyLabel(party)} — {quarterKey(p.quarter_start)}: {p.percentage_avg.toFixed(1)}% (n={p.n_polls})
-                    </title>
-                  </circle>
+                    strokeWidth={p.quarter_start === last.quarter_start ? 2.4 : 1.6}
+                    opacity={idx === points.length - 1 ? 1 : 0.9}
+                  />
                 ))}
               </g>
             );
           })}
 
+          {placedLabels.map((item) => {
+            const text = `${item.label} ${item.pct.toFixed(1)}%`;
+            const w = labelWidth(text);
+            const x = labelX;
+            const y = item.centerY - labelHeight / 2;
+            return (
+              <g key={item.party}>
+                <line
+                  x1={item.x + 6}
+                  y1={item.y}
+                  x2={x - 8}
+                  y2={item.centerY}
+                  stroke={item.color}
+                  strokeWidth={1.2}
+                  opacity={0.65}
+                />
+                <rect
+                  x={x}
+                  y={y}
+                  rx={10}
+                  ry={10}
+                  width={w}
+                  height={labelHeight}
+                  fill="var(--background)"
+                  stroke={item.color}
+                  strokeWidth={1.2}
+                />
+                <text
+                  x={x + 10}
+                  y={item.centerY + 4}
+                  fontSize={11}
+                  fill={item.color}
+                  fontFamily="var(--font-jetbrains-mono)"
+                  fontWeight={600}
+                >
+                  {text}
+                </text>
+              </g>
+            );
+          })}
         </svg>
       </div>
-      <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-        {Array.from(byParty.entries()).map(([party, points]) => {
-          const last = points[points.length - 1];
-          return (
-            <div key={party} className="flex items-center gap-2.5 min-w-0">
-              <span className="shrink-0 inline-block w-6 h-0.5 rounded-full" style={{ background: partyColor(party) }} />
-              <span className="font-serif text-[13px] text-foreground truncate">{partyLabel(party)}</span>
-              <span className="ml-auto font-mono text-[11px] text-muted-foreground tabular-nums shrink-0">
-                {last.percentage_avg.toFixed(1)}%
-              </span>
-            </div>
-          );
-        })}
-      </div>
-      <p className="mt-3 font-mono text-[10px] text-muted-foreground italic tracking-wide">
-        Dystans pionowy 0–50%. Najechanie na punkt pokaże dokładną wartość i liczbę sondaży w kwartale.
-      </p>
-      <p className="mt-2 font-mono text-[10px] text-muted-foreground tracking-wide leading-relaxed">
-        {NON_ADDITIVE_SERIES_NOTE}
-      </p>
     </section>
   );
 }

--- a/frontend/lib/db/polls.ts
+++ b/frontend/lib/db/polls.ts
@@ -226,7 +226,7 @@ export async function getRecentPolls(limit = 20): Promise<RecentPollRow[]> {
     const { data: pollsters, error: eNames } = await withSupabaseRetry(async () => await sb
       .from("pollsters")
       .select("code, name_full")
-      .in("code", pollsterCodes);
+      .in("code", pollsterCodes));
     if (eNames) throw eNames;
     for (const r of pollsters ?? []) {
       pollsterNames.set(

--- a/frontend/lib/db/polls.ts
+++ b/frontend/lib/db/polls.ts
@@ -83,6 +83,28 @@ function quarterStartOf(dateIso: string): string {
 function normalizeTrendRowResults(dateIso: string, source: Map<string, number>): Map<string, number> {
   const out = new Map(source);
 
+  // Some stale pre-fix rows already carry KKP as a separate series, but the
+  // Konfederacja column is still shifted into Razem because Polska2050+PSL was
+  // parsed as two standalone cells. Remap only that known broken layout.
+  if (dateIso < "2025-06-17"
+    && out.has("Polska2050")
+    && out.has("PSL")
+    && out.has("Lewica")
+    && out.has("Razem")
+    && out.has("KKP")
+    && !out.has("Konfederacja")) {
+    const p2050 = out.get("Polska2050");
+    const psl = out.get("PSL");
+    const lewica = out.get("Lewica");
+    const razem = out.get("Razem");
+    if (p2050 != null) out.set("TD", p2050);
+    if (psl != null) out.set("Lewica", psl);
+    if (lewica != null) out.set("Razem", lewica);
+    if (razem != null) out.set("Konfederacja", razem);
+    out.delete("Polska2050");
+    out.delete("PSL");
+  }
+
   // Pre-2025-06-17 Wikipedia rows often collapse Polska2050+PSL into one TD
   // cell via colspan=2. Historical rows already loaded before the parser fix
   // are shifted right from that point onward, which is how Razem inherited


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep speech reaction markers (`Oklaski`, `Głos z sali`, etc.) in transcript order so each badge renders at the actual point in the speech instead of stacking at the paragraph start
- fix the actual historical polling bug: Wikipedia rows with `colspan=2` were shifting later party columns, so `Konfederacja` ~15% was being imported and charted as `Razem`
- add a frontend read-path correction for already-imported stale rows so the quarterly trend is fixed even before the ETL is rerun successfully
- handle the remaining stale layout where pre-fix rows already have `KKP` but still drop `Konfederacja`, shifting that value into `Razem`
- simplify the `/sondaze` quarterly chart itself: remove the extra subtitle/note chrome and switch to a cleaner direct-label layout inside the graphic
- resolve recent-polls pollster labels through the pollster registry instead of showing raw codes

## Testing
- ✅ `uv run pytest tests/supagraf/unit/test_polls_stage.py -q` verifies the colspan parser for both `Polska2050+PSL -> TD` and `Lewica+Razem -> Lewica`
- ✅ `python3 ...` source-derived quarterly series now show `Razem` at `2025-Q2 avg= 4.08` while `Konfederacja` owns the `~15%` band (`2025-Q2 avg= 15.49`)
- ✅ direct live-data check against Supabase project `wtvjmhthpheoimuuljin` now returns no pre-launch standalone `Razem` / `KKP` quarters, `2025-Q2` as `Konfederacja=14.45`, `Razem=7.64`, and resolved pollster names
- ✅ isolated `/sondaze` route fetch from a temp Next server wired to `wtvjmhthpheoimuuljin` returns the chart heading plus resolved pollster labels with no `PGRST002` / load-error marker in the HTML
- ⚠️ `pnpm build` compiles and passes TypeScript, but prerender still fails on the unrelated transient Supabase `PGRST002` schema-cache error for `/komisja`
- ⚠️ live `/sondaze` rendering is still intermittently falling back to `Brak danych trendu` when Supabase returns `PGRST002`, so visual validation of the chart remains partially environment-limited
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6d9437a-1041-4dec-a7db-583b04a716f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6d9437a-1041-4dec-a7db-583b04a716f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

