### PR TITLE
Add shared analytics events and instrument nav/external links + module entries

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { trackModuleEntry, trackNavClick } from "@/lib/analytics-events";
 import { useProfile } from "@/lib/profile";
 import { PERSONAS, PERSONA_IDS, type PersonaId } from "@/lib/personas";
 import { TOPICS, TOPIC_IDS, type TopicId } from "@/lib/topics";
@@ -22,6 +23,14 @@ export default function Landing() {
     hydrated,
   } = useProfile();
   const [lookupErr, setLookupErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    trackModuleEntry("tygodnik");
+    trackModuleEntry("atlas");
+    trackModuleEntry("obietnice");
+    trackModuleEntry("posel");
+    trackModuleEntry("sondaze");
+  }, []);
 
   useEffect(() => {
     if (!hydrated) return;
@@ -237,6 +246,12 @@ export default function Landing() {
               href={c.href}
               target={c.href.startsWith("http") ? "_blank" : undefined}
               rel={c.href.startsWith("http") ? "noopener noreferrer" : undefined}
+              onClick={() => trackNavClick({
+                fromPath: "/",
+                targetPath: c.href,
+                navArea: "homepage_pillar",
+                label: c.h,
+              })}
               className="cursor-pointer font-sans text-[12px] text-destructive tracking-wide border-b border-destructive pb-px"
             >
               {c.cta}

--- a/frontend/components/chrome/Masthead.tsx
+++ b/frontend/components/chrome/Masthead.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, useRef, useEffect } from "react";
+import { trackExternalLinkClick, trackNavClick } from "@/lib/analytics-events";
 import { useProfile } from "@/lib/profile";
 import { MobileNav } from "./MobileNav";
 import { ThemeToggle } from "./ThemeToggle";
@@ -82,6 +83,12 @@ export function Masthead() {
               <Link
                 key={item.href}
                 href={item.href}
+                onClick={() => trackNavClick({
+                  fromPath: pathname,
+                  targetPath: item.href,
+                  navArea: "masthead_primary",
+                  label: item.label,
+                })}
                 className="px-3 xl:px-4 py-2 rounded-full whitespace-nowrap transition-all duration-150 hover:bg-muted"
                 style={{
                   color: on ? "var(--background)" : "var(--secondary-foreground)",
@@ -131,7 +138,15 @@ export function Masthead() {
                     <Link
                       key={s.href}
                       href={s.href}
-                      onClick={() => setMoreOpen(false)}
+                      onClick={() => {
+                        trackNavClick({
+                          fromPath: pathname,
+                          targetPath: s.href,
+                          navArea: "masthead_secondary",
+                          label: s.label,
+                        });
+                        setMoreOpen(false);
+                      }}
                       className="block w-full px-3 py-2 rounded transition-colors hover:bg-muted"
                       style={{
                         color: on ? "var(--destructive)" : "var(--secondary-foreground)",
@@ -171,6 +186,7 @@ export function Masthead() {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="Wesprzyj"
+            onClick={() => trackExternalLinkClick({ destinationDomain: "patronite.pl", placement: "masthead_support_desktop" })}
             className="hidden sm:inline-flex px-4 py-2 rounded-full bg-foreground text-background text-[12.5px] font-medium tracking-wide items-center gap-1.5 transition-colors hover:bg-destructive"
           >
             Wesprzyj
@@ -183,6 +199,7 @@ export function Masthead() {
             rel="noopener noreferrer"
             aria-label="Wesprzyj"
             title="Wesprzyj"
+            onClick={() => trackExternalLinkClick({ destinationDomain: "patronite.pl", placement: "masthead_support_mobile_icon" })}
             className="sm:hidden w-9 h-9 inline-flex items-center justify-center rounded-full bg-foreground text-background"
           >
             <svg className="size-5 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">

--- a/frontend/components/chrome/MobileNav.tsx
+++ b/frontend/components/chrome/MobileNav.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from "@/components/ui/sheet";
+import { trackExternalLinkClick, trackNavClick } from "@/lib/analytics-events";
 import { TygodnikLogoMark } from "./TygodnikLogoMark";
 import { useProfile } from "@/lib/profile";
 import { ThemeToggle } from "./ThemeToggle";
@@ -67,7 +68,15 @@ export function MobileNav({ alertsCount = 0 }: { alertsCount?: number }) {
               <Link
                 key={item.href}
                 href={item.href}
-                onClick={close}
+                onClick={() => {
+                  trackNavClick({
+                    fromPath: pathname,
+                    targetPath: item.href,
+                    navArea: "mobile_nav",
+                    label: item.label,
+                  });
+                  close();
+                }}
                 className="block px-3 py-3 rounded-md font-sans text-[15px] transition-colors"
                 style={{
                   color: on ? "var(--background)" : "var(--foreground)",
@@ -89,7 +98,15 @@ export function MobileNav({ alertsCount = 0 }: { alertsCount?: number }) {
               <Link
                 key={s.href}
                 href={s.href}
-                onClick={close}
+                onClick={() => {
+                  trackNavClick({
+                    fromPath: pathname,
+                    targetPath: s.href,
+                    navArea: "mobile_nav",
+                    label: s.label,
+                  });
+                  close();
+                }}
                 className="flex items-baseline justify-between gap-3 px-3 py-2.5 rounded-md transition-colors hover:bg-muted"
                 style={{
                   color: on ? "var(--destructive)" : "var(--secondary-foreground)",
@@ -108,7 +125,15 @@ export function MobileNav({ alertsCount = 0 }: { alertsCount?: number }) {
           <ThemeToggle variant="mobile" />
           <Link
             href="/alerty"
-            onClick={close}
+            onClick={() => {
+              trackNavClick({
+                fromPath: pathname,
+                targetPath: "/alerty",
+                navArea: "mobile_nav",
+                label: "Alerty",
+              });
+              close();
+            }}
             className="relative flex-1 inline-flex items-center justify-center gap-2 px-3 py-2.5 border border-border rounded-full text-secondary-foreground text-[13px]"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -126,7 +151,10 @@ export function MobileNav({ alertsCount = 0 }: { alertsCount?: number }) {
             href="https://patronite.pl/tygodniksejmowy"
             target="_blank"
             rel="noopener noreferrer"
-            onClick={close}
+            onClick={() => {
+              trackExternalLinkClick({ destinationDomain: "patronite.pl", placement: "mobile_nav_support" });
+              close();
+            }}
             className="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2.5 rounded-full bg-foreground text-background text-[13px] font-medium"
           >
             Wesprzyj

--- a/frontend/docs/analytics-events.md
+++ b/frontend/docs/analytics-events.md
@@ -1,0 +1,32 @@
+# Analytics events (shared)
+
+This document defines shared event names and parameters used across navigation and module entry points.
+
+## `nav_click`
+Tracks internal navigation clicks.
+
+**Parameters**
+- `from_path` (string): current pathname where click happened.
+- `target_path` (string): destination pathname or URL.
+- `nav_area` (enum): one of:
+  - `masthead_primary`
+  - `masthead_secondary`
+  - `mobile_nav`
+  - `homepage_pillar`
+- `label` (string): visible link/button label shown to user.
+
+## `external_link_click`
+Tracks outbound clicks to external destinations (e.g. Patronite).
+
+**Parameters**
+- `destination_domain` (string): destination domain only, e.g. `patronite.pl`.
+- `placement` (string): semantic placement identifier for where the link appeared.
+
+## `module_entry`
+Tracks first view entry for high-level product modules to build cohorts.
+
+**When fired**
+- On first page view of homepage session shell (single mount of `frontend/app/page.tsx`).
+
+**Parameters**
+- `module` (enum): one of `tygodnik`, `atlas`, `obietnice`, `posel`, `sondaze`.

--- a/frontend/lib/analytics-events.ts
+++ b/frontend/lib/analytics-events.ts
@@ -1,0 +1,46 @@
+"use client";
+
+export type NavArea = "masthead_primary" | "masthead_secondary" | "mobile_nav" | "homepage_pillar";
+export type ModuleName = "tygodnik" | "atlas" | "obietnice" | "posel" | "sondaze";
+
+type AnalyticsValue = string | number | boolean;
+type AnalyticsParams = Record<string, AnalyticsValue>;
+
+declare global {
+  interface Window {
+    gtag?: (command: "event", eventName: string, params?: AnalyticsParams) => void;
+  }
+}
+
+function emitEvent(eventName: string, params: AnalyticsParams) {
+  if (typeof window === "undefined" || typeof window.gtag !== "function") return;
+  window.gtag("event", eventName, params);
+}
+
+export function trackNavClick(params: {
+  fromPath: string;
+  targetPath: string;
+  navArea: NavArea;
+  label: string;
+}) {
+  emitEvent("nav_click", {
+    from_path: params.fromPath,
+    target_path: params.targetPath,
+    nav_area: params.navArea,
+    label: params.label,
+  });
+}
+
+export function trackExternalLinkClick(params: {
+  destinationDomain: string;
+  placement: string;
+}) {
+  emitEvent("external_link_click", {
+    destination_domain: params.destinationDomain,
+    placement: params.placement,
+  });
+}
+
+export function trackModuleEntry(module: ModuleName) {
+  emitEvent("module_entry", { module });
+}


### PR DESCRIPTION
### Motivation
- Provide a single, typed place for emitting analytics so nav actions and module impressions are reported consistently.
- Capture internal navigation clicks, outbound clicks (e.g. Patronite), and high-level module entry events to enable stable cohorting and reporting.

### Description
- Added a client helper `frontend/lib/analytics-events.ts` that exposes typed wrappers `trackNavClick`, `trackExternalLinkClick`, and `trackModuleEntry` with constrained enums `NavArea` and `ModuleName`.
- Instrumented masthead primary and secondary nav links to call `trackNavClick` and masthead Patronite buttons to call `trackExternalLinkClick` in `frontend/components/chrome/Masthead.tsx`.
- Instrumented mobile nav primary/secondary links, alerts link, and mobile Patronite button to call the same tracking helpers in `frontend/components/chrome/MobileNav.tsx`.
- Emitted `module_entry` on homepage mount for modules `tygodnik`, `atlas`, `obietnice`, `posel`, and `sondaze`, and instrumented homepage pillar CTAs to call `trackNavClick` in `frontend/app/page.tsx`.
- Added a canonical documentation file `frontend/docs/analytics-events.md` describing event names and parameter contracts for stable reporting.

### Testing
- Ran frontend lint with `cd frontend && pnpm lint`; the run failed due to pre-existing unrelated lint errors in the repository and not due to the analytics changes.
- No analytics-specific runtime checks were added; the tracking helper guards against server-side usage by checking `window.gtag` before emitting events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ce81ff20832f837d40da255a215e)