### PR TITLE
Instrument recoverable client errors and empty-state telemetry

### DIFF
--- a/frontend/app/atlas/_components/NajwolniejsiMinistrowie.tsx
+++ b/frontend/app/atlas/_components/NajwolniejsiMinistrowie.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SectionHead } from "./SectionHead";
 import type { SlowMinisters, MinisterRow } from "@/lib/db/atlas";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { emitEmptyStateShown } from "@/lib/analytics";
 
 type SortKey = "avgDays" | "overdueRate" | "count";
 type FilterKey = "all" | "overdue" | "ontime";
@@ -42,6 +43,14 @@ export function NajwolniejsiMinistrowie({ data }: { data: SlowMinisters }) {
   }, [data.rows, sort, filter, limit]);
 
   const max = Math.max(1, ...filtered.map((m) => m.avgDays));
+
+  useEffect(() => {
+    if (filtered.length !== 0) return;
+    emitEmptyStateShown({
+      context: "atlas_key_list",
+      active_filters: { sort, filter, limit_days: limit },
+    });
+  }, [filtered.length, sort, filter, limit]);
   const totalInterp = data.rows.reduce((s, m) => s + m.count, 0);
 
   return (

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useProfile } from "@/lib/profile";
 import { PERSONAS, PERSONA_IDS, type PersonaId } from "@/lib/personas";
 import { TOPICS, TOPIC_IDS, type TopicId } from "@/lib/topics";
+import { emitApiRouteError, emitUiError } from "@/lib/analytics";
 
 export default function Landing() {
   const router = useRouter();
@@ -30,12 +31,29 @@ export default function Landing() {
     const id = setTimeout(async () => {
       try {
         const r = await fetch(`/api/postcode?p=${encodeURIComponent(postcode)}`, { signal: ctrl.signal });
-        if (!r.ok) { setDistrict(null); setLookupErr(null); return; }
+        if (!r.ok) {
+          emitApiRouteError({
+            context: "postcode_lookup",
+            route: "/api/postcode",
+            status_code: r.status,
+            is_retryable: r.status >= 500 || r.status === 429,
+          });
+          setDistrict(null);
+          setLookupErr(null);
+          return;
+        }
         const j = await r.json();
         if (j?.district) { setDistrict(j.district); setLookupErr(null); }
         else { setDistrict(null); }
       } catch (e) {
-        if ((e as Error).name !== "AbortError") setLookupErr("nie udało się sprawdzić kodu");
+        if ((e as Error).name !== "AbortError") {
+          emitUiError({
+            context: "postcode_lookup",
+            route: "/api/postcode",
+            is_retryable: true,
+          });
+          setLookupErr("nie udało się sprawdzić kodu");
+        }
       }
     }, 250);
     return () => { ctrl.abort(); clearTimeout(id); };

--- a/frontend/app/posel/_components/DistrictMpsClient.tsx
+++ b/frontend/app/posel/_components/DistrictMpsClient.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useProfile } from "@/lib/profile";
 import type { MpListItem } from "@/lib/db/mps";
+import { emitApiRouteError } from "@/lib/analytics";
 
 export function DistrictMpsClient() {
   const { district, hydrated } = useProfile();
@@ -16,7 +17,18 @@ export function DistrictMpsClient() {
     setLoading(true);
     const ctrl = new AbortController();
     fetch(`/api/mps-by-district?num=${district.num}`, { signal: ctrl.signal })
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) {
+          emitApiRouteError({
+            context: "mps_by_district",
+            route: "/api/mps-by-district",
+            status_code: r.status,
+            is_retryable: r.status >= 500 || r.status === 429,
+          });
+          throw new Error("non-ok response");
+        }
+        return r.json();
+      })
       .then((j) => setMps(j.mps ?? []))
       .catch(() => setMps([]))
       .finally(() => setLoading(false));

--- a/frontend/app/posel/_components/PoselIndexClient.tsx
+++ b/frontend/app/posel/_components/PoselIndexClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useProfile } from "@/lib/profile";
 import type { MpListItem } from "@/lib/db/mps";
+import { emitApiRouteError } from "@/lib/analytics";
 import { MPCardGrid } from "@/components/posel/MPCardGrid";
 
 function MpGrid({ mps }: { mps: MpListItem[] }) {
@@ -45,7 +46,18 @@ export function PoselIndexClient({
     setDistrictLoading(true);
     const ctrl = new AbortController();
     fetch(`/api/mps-by-district?num=${district.num}`, { signal: ctrl.signal })
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) {
+          emitApiRouteError({
+            context: "mps_by_district",
+            route: "/api/mps-by-district",
+            status_code: r.status,
+            is_retryable: r.status >= 500 || r.status === 429,
+          });
+          throw new Error("non-ok response");
+        }
+        return r.json();
+      })
       .then((j) => setDistrictMps(j.mps ?? []))
       .catch(() => setDistrictMps([]))
       .finally(() => setDistrictLoading(false));

--- a/frontend/app/tygodnik/_components/BriefList.tsx
+++ b/frontend/app/tygodnik/_components/BriefList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useProfile } from "@/lib/profile";
 import { PERSONAS, type PersonaId } from "@/lib/personas";
 import { TOPICS, type TopicId } from "@/lib/topics";
@@ -36,6 +36,7 @@ import {
   type FooterLink,
 } from "@/components/tygodnik/atoms";
 import { FilterBar } from "./FilterBar";
+import { emitEmptyStateShown } from "@/lib/analytics";
 
 function formatDate(iso: string | null): string {
   if (!iso) return "—";
@@ -585,6 +586,19 @@ export function BriefList({
   }, [printItems, topics, personas, showAll]);
 
   const filterActive = topics.length > 0 || personas.length > 0;
+
+  useEffect(() => {
+    if (!(filteredPrints.length === 0 && partitioned.prints.length > 0)) return;
+    emitEmptyStateShown({
+      context: "tygodnik_key_list",
+      active_filters: {
+        topics: topics.join(","),
+        personas: personas.join(","),
+        show_all: showAll,
+      },
+    });
+  }, [filteredPrints.length, partitioned.prints.length, topics, personas, showAll]);
+
 
   const sittingIdx = sittings.findIndex((s) => s.sittingNum === sitting.sittingNum);
   const newerSitting = sittingIdx > 0

--- a/frontend/lib/analytics.ts
+++ b/frontend/lib/analytics.ts
@@ -1,0 +1,35 @@
+export type ErrorEventPayload = {
+  context: string;
+  route?: string;
+  status_code?: number;
+  is_retryable: boolean;
+};
+
+export type EmptyStatePayload = {
+  context: string;
+  active_filters: Record<string, string | number | boolean | null>;
+};
+
+function emit(name: string, params: Record<string, unknown>) {
+  if (typeof window === "undefined") return;
+  const gtag = (window as Window & { gtag?: (...args: unknown[]) => void }).gtag;
+  if (typeof gtag === "function") {
+    gtag("event", name, params);
+    return;
+  }
+  const dlWindow = window as Window & { dataLayer?: unknown[] };
+  dlWindow.dataLayer = dlWindow.dataLayer || [];
+  dlWindow.dataLayer.push({ event: name, ...params });
+}
+
+export function emitUiError(payload: ErrorEventPayload) {
+  emit("ui_error", payload);
+}
+
+export function emitApiRouteError(payload: ErrorEventPayload) {
+  emit("api_route_error", payload);
+}
+
+export function emitEmptyStateShown(payload: EmptyStatePayload) {
+  emit("empty_state_shown", payload);
+}


### PR DESCRIPTION
### Motivation
- Provide consistent telemetry for recoverable client-side failures so dashboards can separate product confusion from backend instability.
- Capture empty-state impressions in key list components to measure UX friction from active filters.
- Normalize error payload schema (`context`, `route`, `status_code`, `is_retryable`) so events are queryable and comparable across flows.

### Description
- Added a small analytics helper `frontend/lib/analytics.ts` that exposes `emitUiError`, `emitApiRouteError`, and `emitEmptyStateShown` and defines the normalized payload types.  
- Instrumented postcode lookup in the landing page (`frontend/app/page.tsx`) to emit `api_route_error` on non-OK `/api/postcode` responses and `ui_error` on fetch failures with `context: "postcode_lookup"`.  
- Instrumented district-MP client handlers (`frontend/app/posel/_components/DistrictMpsClient.tsx` and `frontend/app/posel/_components/PoselIndexClient.tsx`) to emit `api_route_error` for non-OK responses from `/api/mps-by-district` including route, status, and retryability.  
- Instrumented empty-state telemetry in Tygodnik (`frontend/app/tygodnik/_components/BriefList.tsx`) and Atlas key list (`frontend/app/atlas/_components/NajwolniejsiMinistrowie.tsx`) to emit `empty_state_shown` with `context` and the active filter values when no results are shown.

### Testing
- Ran file-targeted ESLint via `pnpm exec eslint` against the changed frontend files to validate the edits, which surfaced existing `react-hooks/set-state-in-effect` errors in MP list components; the lint run failed due to those pre-existing hook warnings.  
- No new automated unit or integration tests were added for telemetry in this change set.  
- The emitted event payload shapes are defined in `frontend/lib/analytics.ts` and can be validated via QA or in staging once client builds are deployed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ce8673a4832fae60850db664d9b0)