### PR TITLE
Fix publication status fallbacks on druk and wątek pages

### DIFF
--- a/frontend/app/druk/[term]/[number]/page.tsx
+++ b/frontend/app/druk/[term]/[number]/page.tsx
@@ -11,6 +11,7 @@ import { VotingRow } from "@/components/voting/VotingRow";
 import { PrintCard } from "@/components/print/PrintCard";
 import { HemicycleChart } from "@/components/tygodnik/HemicycleChart";
 import { NotFoundPage } from "@/components/chrome/NotFoundPage";
+import { getPassedProcessBanner, publicationJournalLabel } from "@/lib/process-status";
 
 
 export async function generateMetadata({
@@ -116,6 +117,10 @@ export default async function DrukPage({
   const totalFiles = attachments.length + subPrints.reduce((n, s) => n + s.attachments.length, 0);
 
   const topLevelStages = stages.filter((s) => s.depth === 0);
+  const pendingPassedBanner =
+    outcome?.passed && !outcome.act
+      ? getPassedProcessBanner(topLevelStages, outcome.closureDate)
+      : null;
   const lastDoneIdx = (() => {
     for (let i = topLevelStages.length - 1; i >= 0; i--) {
       if (topLevelStages[i].stageDate) return i;
@@ -382,7 +387,7 @@ export default async function DrukPage({
                 style={{ borderColor: "var(--success)", background: "var(--muted)" }}
               >
                 <div className="font-sans text-[10px] tracking-[0.16em] uppercase text-success mb-1.5">
-                  ✓ W Dzienniku Ustaw
+                  ✓ W {publicationJournalLabel(outcome.act.displayAddress)}
                 </div>
                 <div className="font-serif text-[16px] text-foreground leading-snug mb-1">
                   {outcome.act.displayAddress}
@@ -402,20 +407,20 @@ export default async function DrukPage({
                     rel="noopener noreferrer"
                     className="font-sans text-[12px] text-destructive underline decoration-dotted underline-offset-4 hover:decoration-solid"
                   >
-                    ↗ Zobacz tekst ustawy w ISAP
+                    ↗ Zobacz tekst aktu w ISAP
                   </a>
                 )}
               </div>
             )}
 
-            {outcome?.passed && !outcome.act && (
+            {pendingPassedBanner && (
               <div
                 className="mt-7 px-4 py-3 border-l-2 font-sans text-[12px] text-secondary-foreground leading-[1.55]"
                 style={{ borderColor: "var(--warning)", background: "var(--muted)" }}
               >
-                <span className="font-medium text-foreground">Uchwalono</span> —
-                {" "}oczekuje na publikację w Dz.U.
-                {outcome.closureDate ? ` (${formatDate(outcome.closureDate)})` : ""}
+                <span className="font-medium text-foreground">{pendingPassedBanner.title}</span> —
+                {" "}{pendingPassedBanner.detail}
+                {pendingPassedBanner.date ? ` (${formatDate(pendingPassedBanner.date)})` : ""}
               </div>
             )}
 

--- a/frontend/app/watek/[id]/page.tsx
+++ b/frontend/app/watek/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { getThread, type ThreadStage, type ThreadStageVoting } from "@/lib/db/threads";
+import { getPassedProcessBanner, publicationJournalLabel } from "@/lib/process-status";
 import { stageLabel } from "@/lib/stages";
 import { PageHeading } from "@/components/chrome/PageHeading";
 import { NotFoundPage } from "@/components/chrome/NotFoundPage";
@@ -140,6 +141,10 @@ export default async function WatekDetailPage({
   // Top-level only — sub-stages (depth>0) are committee internals; we surface
   // them via decision text on the parent row to keep the timeline single-thread.
   const events = thread.stages.filter((s) => s.depth === 0);
+  const pendingPassedBanner =
+    thread.passed && !thread.act
+      ? getPassedProcessBanner(events, thread.closureDate)
+      : null;
 
   // The "current" event is the first one without a stage_date (i.e. pending),
   // unless every stage is dated — then highlight the last dated one.
@@ -211,7 +216,7 @@ export default async function WatekDetailPage({
             style={{ borderColor: "var(--success)", background: "var(--muted)" }}
           >
             <div className="font-sans text-[10px] tracking-[0.16em] uppercase text-success mb-1.5">
-              ✓ Opublikowana w Dzienniku Ustaw
+              ✓ Opublikowano w {publicationJournalLabel(thread.act.displayAddress)}
             </div>
             <div className="font-serif text-[17px] text-foreground leading-snug mb-1">
               {thread.act.displayAddress}
@@ -229,19 +234,20 @@ export default async function WatekDetailPage({
                 rel="noopener noreferrer"
                 className="font-sans text-[12px] text-destructive underline decoration-dotted underline-offset-4"
               >
-                ↗ Tekst ustawy w ISAP
+                ↗ Tekst aktu w ISAP
               </a>
             )}
           </div>
         )}
 
-        {thread.passed && !thread.act && (
+        {pendingPassedBanner && (
           <div
             className="mb-9 px-4 py-3 border-l-2 font-sans text-[12px] text-secondary-foreground leading-[1.55]"
             style={{ borderColor: "var(--warning)", background: "var(--muted)" }}
           >
-            <span className="font-medium text-foreground">Uchwalono</span> — oczekuje na
-            publikację w Dz.U.{thread.closureDate ? ` (${formatLongDate(thread.closureDate)})` : ""}
+            <span className="font-medium text-foreground">{pendingPassedBanner.title}</span> —
+            {" "}{pendingPassedBanner.detail}
+            {pendingPassedBanner.date ? ` (${formatLongDate(pendingPassedBanner.date)})` : ""}
           </div>
         )}
 

--- a/frontend/lib/db/prints.ts
+++ b/frontend/lib/db/prints.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { normalizeActSourceUrl } from "@/lib/isap";
+import { buildActDisplayAddress, normalizeActSourceUrl } from "@/lib/isap";
 import { supabase } from "@/lib/supabase";
 import { dbTagsToPersonas, type PersonaId } from "@/lib/personas";
 import { dbTagsToTopics, type TopicId } from "@/lib/topics";
@@ -285,6 +285,9 @@ export async function getPrint(term: number, number: string): Promise<PrintWithS
   let outcome: ProcessOutcome | null = null;
   if (proc) {
     const eliActId = (proc.eli_act_id as number | null) ?? null;
+    const procEli = (proc.eli as string | null) ?? null;
+    const procDisplayAddress =
+      (proc.display_address as string | null) ?? buildActDisplayAddress(procEli);
     let act: ProcessAct | null = null;
     if (eliActId) {
       // Real column name is promulgation_date (date of publication in
@@ -298,7 +301,7 @@ export async function getPrint(term: number, number: string): Promise<PrintWithS
       if (actRow) {
         act = {
           eliId: (actRow.eli_id as string) ?? "",
-          displayAddress: (proc.display_address as string) ?? "",
+          displayAddress: procDisplayAddress ?? "",
           title: (actRow.title as string) ?? null,
           status: (actRow.status as string) ?? null,
           sourceUrl: normalizeActSourceUrl(
@@ -308,6 +311,16 @@ export async function getPrint(term: number, number: string): Promise<PrintWithS
           publishedAt: (actRow.promulgation_date as string) ?? null,
         };
       }
+    }
+    if (!act && (procEli || procDisplayAddress)) {
+      act = {
+        eliId: procEli ?? "",
+        displayAddress: procDisplayAddress ?? "",
+        title: null,
+        status: null,
+        sourceUrl: normalizeActSourceUrl(null, procEli),
+        publishedAt: null,
+      };
     }
     const us = (proc.urgency_status as string | null) ?? null;
     outcome = {

--- a/frontend/lib/db/threads.ts
+++ b/frontend/lib/db/threads.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { normalizeActSourceUrl } from "@/lib/isap";
+import { buildActDisplayAddress, normalizeActSourceUrl } from "@/lib/isap";
 import { supabase } from "@/lib/supabase";
 
 // Voting tally rendered inline next to a stage row (yes/no/abstain pill).
@@ -258,7 +258,7 @@ export async function getThread(term: number, number: string): Promise<ThreadDet
   const { data: proc, error: pe } = await sb
     .from("processes")
     .select(
-      "id, term, number, title, passed, closure_date, last_refreshed_at, eli_act_id, display_address",
+      "id, term, number, title, passed, closure_date, last_refreshed_at, eli, eli_act_id, display_address",
     )
     .eq("term", term)
     .eq("number", number)
@@ -343,6 +343,9 @@ export async function getThread(term: number, number: string): Promise<ThreadDet
 
   // Resolve outcome act if linked.
   let act: ThreadAct | null = null;
+  const procEli = (proc.eli as string | null) ?? null;
+  const procDisplayAddress =
+    (proc.display_address as string | null) ?? buildActDisplayAddress(procEli);
   const eliActId = (proc.eli_act_id as number | null) ?? null;
   if (eliActId) {
     const { data: actRow } = await sb
@@ -354,7 +357,7 @@ export async function getThread(term: number, number: string): Promise<ThreadDet
     if (actRow) {
       act = {
         eliId: (actRow.eli_id as string) ?? "",
-        displayAddress: (proc.display_address as string) ?? "",
+        displayAddress: procDisplayAddress ?? "",
         title: (actRow.title as string) ?? null,
         status: (actRow.status as string) ?? null,
         sourceUrl: normalizeActSourceUrl(
@@ -364,6 +367,16 @@ export async function getThread(term: number, number: string): Promise<ThreadDet
         publishedAt: (actRow.promulgation_date as string) ?? null,
       };
     }
+  }
+  if (!act && (procEli || procDisplayAddress)) {
+    act = {
+      eliId: procEli ?? "",
+      displayAddress: procDisplayAddress ?? "",
+      title: null,
+      status: null,
+      sourceUrl: normalizeActSourceUrl(null, procEli),
+      publishedAt: null,
+    };
   }
 
   const stages: ThreadStage[] = ((stagesRows ?? []) as Array<{

--- a/frontend/lib/isap.ts
+++ b/frontend/lib/isap.ts
@@ -36,6 +36,12 @@ export function buildIsapDocDetailsUrl(ref: ActRef): string {
   return buildIsapDocDetailsUrlFromAddress(buildIsapAddress(ref));
 }
 
+export function buildActDisplayAddress(eliId: string | null | undefined): string | null {
+  const ref = parseActRef(eliId);
+  if (!ref) return null;
+  return `${ref.publisher === "MP" ? "M.P." : "Dz.U."} ${ref.year} poz. ${Number(ref.position)}`;
+}
+
 export function buildIsapPdfUrlFromAddress(address: string, fileName: string): string {
   return `https://isap.sejm.gov.pl/isap.nsf/download.xsp/${encodeURIComponent(address)}/O/${encodeURIComponent(fileName)}`;
 }

--- a/frontend/lib/process-status.ts
+++ b/frontend/lib/process-status.ts
@@ -1,0 +1,93 @@
+import { stageLabel } from "@/lib/stages";
+
+type StageLike = {
+  depth?: number;
+  stageType: string | null;
+  stageName: string;
+  stageDate: string | null;
+};
+
+export type PassedProcessBanner = {
+  title: string;
+  detail: string;
+  date: string | null;
+};
+
+const POST_SEJM_STAGE_TYPES = new Set([
+  "SenatePosition",
+  "SenatePositionConsideration",
+  "SenateAmendments",
+  "ToPresident",
+  "PresidentSignature",
+  "PresidentVeto",
+  "Veto",
+  "PresidentMotionConsideration",
+  "ConstitutionalTribunal",
+  "Promulgation",
+]);
+
+function latestTopLevelStage(stages: StageLike[]): StageLike | null {
+  for (let i = stages.length - 1; i >= 0; i--) {
+    const stage = stages[i];
+    if ((stage.depth ?? 0) !== 0) continue;
+    if (stage.stageDate) return stage;
+  }
+  return null;
+}
+
+function isSejmPassageStage(stage: StageLike | null): boolean {
+  if (!stage) return false;
+  if (stage.stageType !== "SejmReading") return false;
+  const normalized = stage.stageName.toLowerCase();
+  return normalized.includes("iii czytanie") || normalized.includes("uchwal");
+}
+
+export function getPassedProcessBanner(
+  stages: StageLike[],
+  closureDate: string | null,
+): PassedProcessBanner {
+  const latest = latestTopLevelStage(stages);
+  const date = latest?.stageDate ?? closureDate;
+
+  if (!latest || isSejmPassageStage(latest)) {
+    return {
+      title: "Uchwalono w Sejmie",
+      detail: "kolejne etapy: Senat i Prezydent",
+      date,
+    };
+  }
+
+  if (latest.stageType === "PresidentSignature") {
+    return {
+      title: "Podpisana przez Prezydenta",
+      detail: "oczekuje na publikację w dzienniku urzędowym",
+      date,
+    };
+  }
+
+  if (latest.stageType === "Promulgation") {
+    return {
+      title: "Opublikowano",
+      detail: "ogłoszenie aktu jest już odnotowane w przebiegu procesu",
+      date,
+    };
+  }
+
+  if (POST_SEJM_STAGE_TYPES.has(latest.stageType ?? "")) {
+    return {
+      title: "Prace po uchwaleniu w Sejmie",
+      detail: latest.stageName || stageLabel(latest.stageType),
+      date,
+    };
+  }
+
+  return {
+    title: "Po uchwaleniu w Sejmie",
+    detail: latest.stageName || stageLabel(latest.stageType),
+    date,
+  };
+}
+
+export function publicationJournalLabel(displayAddress: string | null | undefined): string {
+  return displayAddress?.startsWith("M.P.") ? "Monitorze Polskim" : "Dzienniku Ustaw";
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- use `processes.eli` / `display_address` as a publication fallback when the `eli_act_id` backfill has not landed yet
- replace the hard-coded "awaiting publication in Dz.U." banner with a stage-aware post-Sejm status banner on both `/druk` and `/watek`
- generalize publication copy so Monitor Polski entries are labeled correctly and still link to ISAP

## Testing
- typecheck and build the frontend
- manually verify `/druk/10/2294` and `/watek/2294` render the new status copy instead of the misleading publication wait state
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f8179bf-ed83-47cc-9290-b2c9ea351bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f8179bf-ed83-47cc-9290-b2c9ea351bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

