### PR TITLE
Add coalition voting cohesion metrics to scenarios

### DIFF
--- a/frontend/app/sondaze/_components/KoalicjeStub.tsx
+++ b/frontend/app/sondaze/_components/KoalicjeStub.tsx
@@ -1,8 +1,38 @@
 import type { PollAverageRow } from "@/lib/db/polls";
+import type { KlubPairAgreement } from "@/lib/db/coalition_agreement";
+import { pollCodeToKlubShort } from "@/lib/db/coalition_agreement";
 import { projectSeatsMap } from "@/lib/polls/seats";
 import { partyColor, partyLabel, partyLogoSrc, SEJM_SEATS, SEJM_THRESHOLD_PCT } from "./partyMeta";
 
 const MAJORITY = 231;
+
+// Mean pairwise voting agreement across distinct klub pairs in the bloc.
+// Returns null when the scenario has fewer than 2 klubs with parliamentary
+// voting record (single-member blocs, or members that aren't in any Sejm
+// klub — KKP/PJJ — give nothing to average).
+function meanAgreement(
+  memberCodes: string[],
+  agreement: KlubPairAgreement,
+): { mean: number; pairsCounted: number; minVotings: number } | null {
+  const shorts = Array.from(
+    new Set(memberCodes.map(pollCodeToKlubShort).filter((s): s is string => s != null)),
+  );
+  if (shorts.length < 2) return null;
+  let sum = 0;
+  let n = 0;
+  let minVotings = Infinity;
+  for (let i = 0; i < shorts.length; i++) {
+    for (let j = i + 1; j < shorts.length; j++) {
+      const cell = agreement.byPair.get(`${shorts[i]}|${shorts[j]}`);
+      if (!cell) continue;
+      sum += cell.agreement;
+      n += 1;
+      if (cell.votings < minVotings) minVotings = cell.votings;
+    }
+  }
+  if (n === 0) return null;
+  return { mean: sum / n, pairsCounted: n, minVotings: minVotings === Infinity ? 0 : minVotings };
+}
 
 // Coalition scenarios are pure arithmetic over the current projection.
 // No party-alignment inference, no LLM — just bloc sums of who-could-form-government.
@@ -41,7 +71,13 @@ const SCENARIOS: Scenario[] = [
   },
 ];
 
-export function KoalicjeStub({ rows }: { rows: PollAverageRow[] }) {
+export function KoalicjeStub({
+  rows,
+  agreement,
+}: {
+  rows: PollAverageRow[];
+  agreement: KlubPairAgreement;
+}) {
   const seats = projectSeatsMap(rows);
 
   const scenarios = SCENARIOS.map((s) => {
@@ -59,7 +95,12 @@ export function KoalicjeStub({ rows }: { rows: PollAverageRow[] }) {
       };
     });
     const total = members.reduce((sum, m) => sum + (m.qualified ? m.seats : 0), 0);
-    return { ...s, members, total, viable: total >= MAJORITY };
+    // Cohesion is computed over the editorial member list (not just those
+    // currently above the polling threshold). The scenarios *define* a bloc;
+    // whether one component happens to fall sub-threshold this week doesn't
+    // change how often the underlying klubs voted together in this term.
+    const cohesion = meanAgreement(s.members, agreement);
+    return { ...s, members, total, viable: total >= MAJORITY, cohesion };
   });
 
   return (
@@ -178,7 +219,26 @@ export function KoalicjeStub({ rows }: { rows: PollAverageRow[] }) {
                 />
               </div>
 
-              <p className="font-serif italic text-[12.5px] sm:text-[13px] text-muted-foreground mt-3 mb-0 leading-snug">
+              {s.cohesion ? (
+                <div className="mt-3 flex items-baseline gap-2 font-mono text-[10.5px] tracking-[0.04em] uppercase text-muted-foreground">
+                  <span>Spójność głosowań</span>
+                  <span
+                    className="tabular-nums font-semibold"
+                    style={{ color: "var(--foreground)" }}
+                  >
+                    {Math.round(s.cohesion.mean * 100)}%
+                  </span>
+                  <span className="normal-case tracking-normal lowercase">
+                    średnia z {s.cohesion.pairsCounted} {s.cohesion.pairsCounted === 1 ? "pary" : "par"} klubów · kadencja 10
+                  </span>
+                </div>
+              ) : (
+                <div className="mt-3 font-mono text-[10.5px] tracking-[0.04em] uppercase text-muted-foreground">
+                  Spójność głosowań — brak danych (jeden klub lub partie spoza Sejmu)
+                </div>
+              )}
+
+              <p className="font-serif italic text-[12.5px] sm:text-[13px] text-muted-foreground mt-2 mb-0 leading-snug">
                 {s.description}
               </p>
             </article>
@@ -187,8 +247,10 @@ export function KoalicjeStub({ rows }: { rows: PollAverageRow[] }) {
       </div>
 
       <p className="mt-6 font-serif text-[13px] text-muted-foreground leading-[1.55] max-w-[760px] italic">
-        Te bloki to redakcyjne definicje historycznych podziałów. Bardziej precyzyjna symulacja — liczona z faktycznych
-        wzorców głosowań, nie z deklaracji — pojawi się tu wkrótce.
+        Bloki to redakcyjne definicje. „Spójność głosowań” liczona z{" "}
+        <code className="not-italic font-mono text-[12px]">klub_pair_agreement_mv</code> — odsetek głosowań, w których
+        większość obu klubów zagłosowała tak samo, uśredniony po wszystkich parach klubów w bloku (kadencja 10).
+        Mówi, jak często deklarowany sojusz faktycznie chodzi w jednym szyku — nie czy jest politycznie realny.
       </p>
     </section>
   );

--- a/frontend/app/sondaze/_components/KoalicjeStub.tsx
+++ b/frontend/app/sondaze/_components/KoalicjeStub.tsx
@@ -13,25 +13,23 @@ const MAJORITY = 231;
 function meanAgreement(
   memberCodes: string[],
   agreement: KlubPairAgreement,
-): { mean: number; pairsCounted: number; minVotings: number } | null {
+): { mean: number; pairsCounted: number } | null {
   const shorts = Array.from(
     new Set(memberCodes.map(pollCodeToKlubShort).filter((s): s is string => s != null)),
   );
   if (shorts.length < 2) return null;
   let sum = 0;
   let n = 0;
-  let minVotings = Infinity;
   for (let i = 0; i < shorts.length; i++) {
     for (let j = i + 1; j < shorts.length; j++) {
       const cell = agreement.byPair.get(`${shorts[i]}|${shorts[j]}`);
       if (!cell) continue;
       sum += cell.agreement;
       n += 1;
-      if (cell.votings < minVotings) minVotings = cell.votings;
     }
   }
   if (n === 0) return null;
-  return { mean: sum / n, pairsCounted: n, minVotings: minVotings === Infinity ? 0 : minVotings };
+  return { mean: sum / n, pairsCounted: n };
 }
 
 // Coalition scenarios are pure arithmetic over the current projection.
@@ -74,11 +72,14 @@ const SCENARIOS: Scenario[] = [
 export function KoalicjeStub({
   rows,
   agreement,
+  term,
 }: {
   rows: PollAverageRow[];
   agreement: KlubPairAgreement;
+  term: number;
 }) {
   const seats = projectSeatsMap(rows);
+  const agreementAvailable = agreement.byPair.size > 0;
 
   const scenarios = SCENARIOS.map((s) => {
     // Keep every named candidate visible — sub-threshold parties (Razem, PJJ
@@ -229,12 +230,14 @@ export function KoalicjeStub({
                     {Math.round(s.cohesion.mean * 100)}%
                   </span>
                   <span className="normal-case tracking-normal lowercase">
-                    średnia z {s.cohesion.pairsCounted} {s.cohesion.pairsCounted === 1 ? "pary" : "par"} klubów · kadencja 10
+                    średnia z {s.cohesion.pairsCounted} {s.cohesion.pairsCounted === 1 ? "pary" : "par"} klubów · kadencja {term}
                   </span>
                 </div>
               ) : (
                 <div className="mt-3 font-mono text-[10.5px] tracking-[0.04em] uppercase text-muted-foreground">
-                  Spójność głosowań — brak danych (jeden klub lub partie spoza Sejmu)
+                  {agreementAvailable
+                    ? "Spójność głosowań — n/d (jeden klub lub partie spoza Sejmu)"
+                    : "Spójność głosowań — dane niedostępne"}
                 </div>
               )}
 
@@ -249,7 +252,7 @@ export function KoalicjeStub({
       <p className="mt-6 font-serif text-[13px] text-muted-foreground leading-[1.55] max-w-[760px] italic">
         Bloki to redakcyjne definicje. „Spójność głosowań” liczona z{" "}
         <code className="not-italic font-mono text-[12px]">klub_pair_agreement_mv</code> — odsetek głosowań, w których
-        większość obu klubów zagłosowała tak samo, uśredniony po wszystkich parach klubów w bloku (kadencja 10).
+        większość obu klubów zagłosowała tak samo, uśredniony po wszystkich parach klubów w bloku (kadencja {term}).
         Mówi, jak często deklarowany sojusz faktycznie chodzi w jednym szyku — nie czy jest politycznie realny.
       </p>
     </section>

--- a/frontend/app/sondaze/page.tsx
+++ b/frontend/app/sondaze/page.tsx
@@ -5,7 +5,7 @@ import {
   getPollsterSummary,
   TREND_DEFAULT_PARTIES,
 } from "@/lib/db/polls";
-import { getKlubPairAgreement } from "@/lib/db/coalition_agreement";
+import { getKlubPairAgreement, DEFAULT_TERM as COHESION_TERM } from "@/lib/db/coalition_agreement";
 import { RESIDUAL_CODES } from "./_components/partyMeta";
 import { Average30dGrid } from "./_components/Average30dGrid";
 import { QuarterlyTrendChart } from "./_components/QuarterlyTrendChart";
@@ -46,7 +46,7 @@ export default async function SondazePage() {
     safe(getPollTrendQuarterly(trendParties), []),
     safe(getRecentPolls(20), []),
     safe(getPollsterSummary(), []),
-    safe(getKlubPairAgreement(10), { byPair: new Map() }),
+    safe(getKlubPairAgreement(COHESION_TERM), { byPair: new Map() }),
   ]);
 
   const mainCount = averages.filter((r) => !RESIDUAL_CODES.has(r.party_code)).length;
@@ -70,7 +70,7 @@ export default async function SondazePage() {
             panels={{
               teraz: <Average30dGrid rows={averages} />,
               trend: <QuarterlyTrendChart rows={trend} />,
-              koalicje: <KoalicjeStub rows={averages} agreement={agreement} />,
+              koalicje: <KoalicjeStub rows={averages} agreement={agreement} term={COHESION_TERM} />,
               lista: (
                 <div className="space-y-12 sm:space-y-16">
                   <RecentPollsList rows={recent} averages={averages} />

--- a/frontend/app/sondaze/page.tsx
+++ b/frontend/app/sondaze/page.tsx
@@ -5,6 +5,7 @@ import {
   getPollsterSummary,
   TREND_DEFAULT_PARTIES,
 } from "@/lib/db/polls";
+import { getKlubPairAgreement } from "@/lib/db/coalition_agreement";
 import { RESIDUAL_CODES } from "./_components/partyMeta";
 import { Average30dGrid } from "./_components/Average30dGrid";
 import { QuarterlyTrendChart } from "./_components/QuarterlyTrendChart";
@@ -41,10 +42,11 @@ export default async function SondazePage() {
     return eligible.length > 0 ? eligible : [...TREND_DEFAULT_PARTIES];
   })();
 
-  const [trend, recent, pollsters] = await Promise.all([
+  const [trend, recent, pollsters, agreement] = await Promise.all([
     safe(getPollTrendQuarterly(trendParties), []),
     safe(getRecentPolls(20), []),
     safe(getPollsterSummary(), []),
+    safe(getKlubPairAgreement(10), { byPair: new Map() }),
   ]);
 
   const mainCount = averages.filter((r) => !RESIDUAL_CODES.has(r.party_code)).length;
@@ -68,7 +70,7 @@ export default async function SondazePage() {
             panels={{
               teraz: <Average30dGrid rows={averages} />,
               trend: <QuarterlyTrendChart rows={trend} />,
-              koalicje: <KoalicjeStub rows={averages} />,
+              koalicje: <KoalicjeStub rows={averages} agreement={agreement} />,
               lista: (
                 <div className="space-y-12 sm:space-y-16">
                   <RecentPollsList rows={recent} averages={averages} />

--- a/frontend/lib/db/coalition_agreement.ts
+++ b/frontend/lib/db/coalition_agreement.ts
@@ -2,6 +2,8 @@ import "server-only";
 
 import { supabase } from "@/lib/supabase";
 
+export const DEFAULT_TERM = 10;
+
 // Poll-code → Sejm club_short mapping. Polls use slightly finer codes than
 // what shows up as a parliamentary club (PSL and TD sit in one PSL-TD klub;
 // KKP/PJJ aren't separate Sejm clubs at all, so they have no voting record
@@ -30,7 +32,7 @@ export type KlubPairAgreement = {
 
 // Reads klub_pair_agreement_mv (mig 0051). Returns 0..1 agreement +
 // joint-voting count per unordered pair of Sejm club shorts.
-export async function getKlubPairAgreement(term = 10): Promise<KlubPairAgreement> {
+export async function getKlubPairAgreement(term: number = DEFAULT_TERM): Promise<KlubPairAgreement> {
   const sb = supabase();
   const { data, error } = await sb
     .from("klub_pair_agreement_mv")

--- a/frontend/lib/db/coalition_agreement.ts
+++ b/frontend/lib/db/coalition_agreement.ts
@@ -1,0 +1,58 @@
+import "server-only";
+
+import { supabase } from "@/lib/supabase";
+
+// Poll-code → Sejm club_short mapping. Polls use slightly finer codes than
+// what shows up as a parliamentary club (PSL and TD sit in one PSL-TD klub;
+// KKP/PJJ aren't separate Sejm clubs at all, so they have no voting record
+// and contribute nothing to a coalition's cohesion score).
+const POLL_TO_KLUB_SHORT: Record<string, string | null> = {
+  KO: "KO",
+  PiS: "PiS",
+  Konfederacja: "Konfederacja",
+  Lewica: "Lewica",
+  Razem: "Razem",
+  Polska2050: "Polska2050",
+  PSL: "PSL-TD",
+  TD: "PSL-TD",
+  KKP: null,
+  PJJ: null,
+};
+
+export function pollCodeToKlubShort(code: string): string | null {
+  return POLL_TO_KLUB_SHORT[code] ?? null;
+}
+
+export type KlubPairAgreement = {
+  // Symmetric lookup: both `${a}|${b}` and `${b}|${a}` populated.
+  byPair: Map<string, { agreement: number; votings: number }>;
+};
+
+// Reads klub_pair_agreement_mv (mig 0051). Returns 0..1 agreement +
+// joint-voting count per unordered pair of Sejm club shorts.
+export async function getKlubPairAgreement(term = 10): Promise<KlubPairAgreement> {
+  const sb = supabase();
+  const { data, error } = await sb
+    .from("klub_pair_agreement_mv")
+    .select("club_a_short, club_b_short, votings_with_both, agreement_pct")
+    .eq("term", term);
+  if (error) throw error;
+
+  type Row = {
+    club_a_short: string;
+    club_b_short: string;
+    votings_with_both: number | null;
+    agreement_pct: number | string | null;
+  };
+
+  const byPair = new Map<string, { agreement: number; votings: number }>();
+  for (const r of (data ?? []) as Row[]) {
+    if (r.club_a_short === r.club_b_short) continue;
+    const pct = typeof r.agreement_pct === "string" ? parseFloat(r.agreement_pct) : r.agreement_pct;
+    if (pct == null || Number.isNaN(pct)) continue;
+    const entry = { agreement: pct / 100, votings: r.votings_with_both ?? 0 };
+    byPair.set(`${r.club_a_short}|${r.club_b_short}`, entry);
+    byPair.set(`${r.club_b_short}|${r.club_a_short}`, entry);
+  }
+  return { byPair };
+}


### PR DESCRIPTION
## Summary
This PR adds voting cohesion analysis to coalition scenarios by integrating parliamentary voting agreement data. Each scenario now displays the mean pairwise voting agreement across its member clubs, showing how often they voted together in practice during the current term.

## Key Changes
- **New module** `frontend/lib/db/coalition_agreement.ts`: Queries the `klub_pair_agreement_mv` materialized view to fetch pairwise voting agreement data between Sejm clubs, with proper mapping from poll codes to parliamentary club identifiers
- **Cohesion calculation**: Added `meanAgreement()` function that computes the average voting agreement across all distinct club pairs in a coalition scenario, filtering out single-club blocs and non-parliamentary parties (KKP/PJJ)
- **UI display**: Coalition scenarios now show a "Spójność głosowań" (voting cohesion) metric with the percentage agreement and metadata (number of club pairs, term number), or a fallback message when data is unavailable
- **Data flow**: Updated `KoalicjeStub` component to accept `KlubPairAgreement` data and compute cohesion for each scenario; updated `sondaze/page.tsx` to fetch agreement data and pass it through

## Implementation Details
- Poll-to-klub mapping handles PSL/TD merging into a single parliamentary club and excludes KKP/PJJ (which have no Sejm voting record)
- Cohesion is computed over the editorial member list regardless of current polling threshold, since the scenarios define blocs whose underlying voting patterns don't change week-to-week
- Agreement data is symmetric in the lookup map for efficient pair queries
- UI uses monospace typography and uppercase labels to distinguish cohesion metrics from descriptive text

https://claude.ai/code/session_01G3dZLjyzxpZQh8534vPCp6