### PR TITLE
Improve Patronite error handling and refine feature previews

### DIFF
--- a/frontend/app/_components/FeatureTile.tsx
+++ b/frontend/app/_components/FeatureTile.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
 
 type Props = {
   num: string;
@@ -9,6 +10,7 @@ type Props = {
   preview: ReactNode;
   href: string | null;
   ctaLabel?: string;
+  comingSoon?: boolean;
   className?: string;
 };
 
@@ -20,9 +22,10 @@ export function FeatureTile({
   preview,
   href,
   ctaLabel,
+  comingSoon = false,
   className = "",
 }: Props) {
-  const isLive = href !== null;
+  const isLive = href !== null && !comingSoon;
 
   return (
     <article
@@ -32,9 +35,19 @@ export function FeatureTile({
         <span className="font-mono text-[11px] tracking-[0.18em] text-muted-foreground">
           {num}
         </span>
-        <span className="font-mono text-[10px] tracking-[0.18em] uppercase text-destructive">
-          {kicker}
-        </span>
+        <div className="flex items-baseline gap-2">
+          {comingSoon ? (
+            <Badge
+              variant="outline"
+              className="font-mono text-[9.5px] tracking-[0.18em] uppercase"
+            >
+              wkrótce
+            </Badge>
+          ) : null}
+          <span className="font-mono text-[10px] tracking-[0.18em] uppercase text-destructive">
+            {kicker}
+          </span>
+        </div>
       </header>
 
       <h2 className="font-serif text-[28px] md:text-[32px] font-medium tracking-[-0.02em] leading-none m-0 mb-5">
@@ -54,6 +67,13 @@ export function FeatureTile({
             className="font-sans text-[11.5px] tracking-wide text-destructive hover:underline"
           >
             {ctaLabel ?? "otwórz →"}
+          </Link>
+        ) : href ? (
+          <Link
+            href={href}
+            className="font-sans text-[11.5px] tracking-wide text-muted-foreground hover:text-destructive hover:underline"
+          >
+            {ctaLabel ?? "co planujemy →"}
           </Link>
         ) : (
           <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">

--- a/frontend/app/_components/FeatureTileGrid.tsx
+++ b/frontend/app/_components/FeatureTileGrid.tsx
@@ -33,7 +33,7 @@ const STAGES = [
   { key: "kom", label: "komisje" },
   { key: "ii", label: "II czyt." },
   { key: "iii", label: "III czyt." },
-  { key: "eli", label: "ELI" },
+  { key: "eli", label: "Dz.U." },
 ] as const;
 
 // Map a stage_type from process_stages into one of the 6 timeline buckets.
@@ -75,14 +75,11 @@ export async function FeatureTileGrid() {
   const standing = committees.filter((c) => c.type === "STANDING").length;
   const totalMembers = committees.reduce((s, c) => s + c.memberCount, 0);
 
-  // ── 07 Alerty — static keyword stub ───────────────────────────────────
-  const alertKeywords = [
-    { label: "najem instytucjonalny", n: 12, hot: true },
-    { label: "składka zdrowotna", n: 5, hot: false },
-    { label: "okręg 13", n: 2, hot: false },
-    { label: "kwota wolna", n: 8, hot: false },
-    { label: "jawność wynagrodzeń", n: 3, hot: true },
-  ];
+  // ── 07 Alerty — honest "what we plan" preview; feature is wkrótce ─────
+  // Mirrors the plannedFeatures list on /alerty/page.tsx so the landing
+  // teaser matches the actual coming-soon page (no fake counts).
+  const alertTriggers = ["fraza", "poseł", "klub", "okręg", "druk", "akt"];
+  const alertChannels = ["e-mail", "RSS", "push", "ICS"];
 
   return (
     <section className="px-4 md:px-8 lg:px-14 py-12 md:py-16 border-b border-rule">
@@ -221,7 +218,7 @@ export async function FeatureTileGrid() {
             num="03"
             kicker="PEŁEN CYKL"
             title="Wątek"
-            description="Każda ustawa — od druku przez czytania, komisje, głosowania, aż po publikację w ELI."
+            description="Każda ustawa — od druku przez czytania, komisje, głosowania, aż po publikację w Dzienniku Ustaw."
             preview={
               <div>
                 <div className="font-serif italic text-[13.5px] leading-snug text-foreground line-clamp-2 mb-3">
@@ -267,13 +264,15 @@ export async function FeatureTileGrid() {
             title="Mowa"
             description="Wystąpienia z mównicy. Wyszukiwanie pełnotekstowe i semantyczne. Każde zdanie z linkiem do nagrania."
             preview={
-              <div className="border-l-2 border-destructive pl-3 py-1">
+              <div className="border-l-2 border-muted-foreground pl-3 py-1">
                 <div className="font-serif italic text-[13px] leading-snug text-muted-foreground">
                   „…poznasz, co konkretnie który poseł powiedział z mównicy — z minutą wideo i kontekstem debaty.&rdquo;
                 </div>
               </div>
             }
-            href={null}
+            href="/mowa"
+            ctaLabel="co planujemy →"
+            comingSoon
             className="lg:col-span-3"
           />
 
@@ -362,24 +361,42 @@ export async function FeatureTileGrid() {
             title="Alerty"
             description="Powiadomienia, gdy w Sejmie padnie konkretne słowo — albo gdy Twój poseł zagłosuje wbrew klubowi."
             preview={
-              <div className="flex flex-wrap gap-1.5">
-                {alertKeywords.map((k) => (
-                  <span
-                    key={k.label}
-                    className="inline-flex items-center gap-1.5 font-sans text-[11px] px-2.5 py-1 border"
-                    style={
-                      k.hot
-                        ? { background: "var(--destructive)", color: "var(--destructive-foreground)", borderColor: "var(--destructive)" }
-                        : { background: "var(--background)", color: "var(--secondary-foreground)", borderColor: "var(--border)" }
-                    }
-                  >
-                    „{k.label}&rdquo;
-                    <span className="font-mono text-[9.5px] opacity-70">{k.n}</span>
-                  </span>
-                ))}
+              <div className="space-y-3">
+                <div>
+                  <div className="font-mono text-[9.5px] tracking-[0.16em] uppercase text-muted-foreground mb-1.5">
+                    wyzwalacze
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {alertTriggers.map((t) => (
+                      <span
+                        key={t}
+                        className="font-sans text-[11px] px-2 py-0.5 border border-border bg-background text-secondary-foreground rounded-sm"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <div className="font-mono text-[9.5px] tracking-[0.16em] uppercase text-muted-foreground mb-1.5">
+                    kanały
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {alertChannels.map((c) => (
+                      <span
+                        key={c}
+                        className="font-mono text-[10.5px] px-2 py-0.5 border border-dashed border-border text-muted-foreground rounded-sm"
+                      >
+                        {c}
+                      </span>
+                    ))}
+                  </div>
+                </div>
               </div>
             }
-            href={null}
+            href="/alerty"
+            ctaLabel="co planujemy →"
+            comingSoon
             className="lg:col-span-3"
           />
         </div>

--- a/frontend/app/_components/LandingHero.tsx
+++ b/frontend/app/_components/LandingHero.tsx
@@ -5,6 +5,22 @@ import { useRouter } from "next/navigation";
 import { useProfile } from "@/lib/profile";
 import { PERSONAS, PERSONA_IDS, type PersonaId } from "@/lib/personas";
 import { TOPICS, TOPIC_IDS, type TopicId } from "@/lib/topics";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from "@/components/ui/input-otp";
+
+// Polish postcode = NN-NNN. Profile + /api/postcode expect the dashed
+// form; the OTP component edits raw digits, so we marshal at the boundary.
+function digitsToPostcode(digits: string): string {
+  const d = digits.replace(/\D/g, "").slice(0, 5);
+  return d.length > 2 ? `${d.slice(0, 2)}-${d.slice(2)}` : d;
+}
+function postcodeToDigits(pc: string): string {
+  return pc.replace(/\D/g, "").slice(0, 5);
+}
 
 export function LandingHero() {
   const router = useRouter();
@@ -77,17 +93,30 @@ export function LandingHero() {
 
         {/* Right — entry form */}
         <div className="bg-muted border border-rule rounded-lg p-5 md:p-6">
-          <label className="block">
+          <div className="block">
             <div className="font-sans text-[10px] tracking-[0.16em] uppercase text-muted-foreground mb-2">
               Kod pocztowy
             </div>
-            <div className="flex items-baseline gap-3 border-b border-rule pb-1.5 mb-1">
-              <input
-                value={postcode}
-                onChange={(e) => setPostcode(e.target.value)}
-                placeholder="00–000"
-                className="font-serif text-[22px] font-medium border-0 outline-none flex-1 bg-transparent text-foreground min-w-0"
-              />
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <InputOTP
+                maxLength={5}
+                inputMode="numeric"
+                pattern="^\d*$"
+                value={postcodeToDigits(postcode)}
+                onChange={(v) => setPostcode(digitsToPostcode(v))}
+                aria-label="Kod pocztowy"
+              >
+                <InputOTPGroup>
+                  <InputOTPSlot index={0} className="size-10 text-[18px] font-serif" />
+                  <InputOTPSlot index={1} className="size-10 text-[18px] font-serif" />
+                </InputOTPGroup>
+                <InputOTPSeparator />
+                <InputOTPGroup>
+                  <InputOTPSlot index={2} className="size-10 text-[18px] font-serif" />
+                  <InputOTPSlot index={3} className="size-10 text-[18px] font-serif" />
+                  <InputOTPSlot index={4} className="size-10 text-[18px] font-serif" />
+                </InputOTPGroup>
+              </InputOTP>
               {district && (
                 <span className="font-serif text-[13px] italic text-destructive truncate">
                   okręg <strong className="not-italic font-semibold">{district.num}</strong> · {district.name}
@@ -100,7 +129,7 @@ export function LandingHero() {
                 <span className="font-mono text-[10px] text-destructive">{lookupErr}</span>
               )}
             </div>
-          </label>
+          </div>
 
           {/* Primary chip row — topical buckets ("Czego dotyczy"). Most
               Sejm legislation is institutional/topical (sądy, obrona, podatki),
@@ -192,7 +221,7 @@ export function LandingHero() {
           </button>
 
           <div className="mt-3 font-sans text-[10.5px] text-muted-foreground tracking-wide text-center">
-            Bez konta · Bez śledzenia · Profil zostaje na Twoim urządzeniu
+            Bez konta · Profil zostaje na Twoim urządzeniu
           </div>
           <div className="mt-2 font-serif text-[12.5px] leading-[1.55] text-secondary-foreground text-center max-w-[34rem] mx-auto">
             Źródła publiczne. Przetwarzanie jawne. Każdy skrót da się sprawdzić u podstaw.

--- a/frontend/app/_components/LandingMethod.tsx
+++ b/frontend/app/_components/LandingMethod.tsx
@@ -18,7 +18,7 @@ const SOURCE_TAGS = [
   "głosowania",
   "komisje",
   "stenogramy",
-  "ELI",
+  "Dz.U./MP",
 ] as const;
 
 export function LandingMethod() {

--- a/frontend/app/o-projekcie/page.tsx
+++ b/frontend/app/o-projekcie/page.tsx
@@ -43,19 +43,7 @@ function fmtPL(n: number): string {
   return n.toLocaleString("pl-PL");
 }
 
-function MockChip() {
-  return (
-    <span
-      className="font-mono text-[10px] tracking-[0.1em] uppercase px-1.5 py-0.5 border ml-3 align-middle"
-      style={{ borderColor: "var(--warning)", color: "var(--warning)" }}
-      title="Dane poglądowe — tabela jeszcze pusta, pokazujemy modelowe liczby"
-    >
-      przykładowo
-    </span>
-  );
-}
-
-function MockNotice() {
+function PatroniteUnavailableNotice() {
   return (
     <aside
       className="mb-12 px-5 py-4 border-l-4"
@@ -68,13 +56,22 @@ function MockNotice() {
         className="font-mono text-[10px] tracking-[0.18em] uppercase mb-1.5"
         style={{ color: "var(--warning)" }}
       >
-        ✶ &nbsp; Uwaga &nbsp; ✶
+        ✶ &nbsp; Wpływy chwilowo niedostępne &nbsp; ✶
       </div>
       <p
         className="font-serif text-[15px] leading-[1.55] m-0 text-foreground"
         style={{ maxWidth: 720 }}
       >
-        Wpływy z Patronite i koszty miesięczne są realne. Pierwsza pełna księga z fakturami w czerwcu 2026.
+        Nie udało się pobrać danych z Patronite. Aktualny stan wpływów sprawdzisz wprost na{" "}
+        <a
+          href="https://patronite.pl/tygodniksejmowy"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-destructive hover:underline"
+        >
+          patronite.pl/tygodniksejmowy
+        </a>
+        . Pierwsza pełna księga z fakturami: czerwiec 2026.
       </p>
     </aside>
   );
@@ -111,9 +108,7 @@ export default async function AboutProjectPage() {
     ? Math.min(100, Math.round((monthlyIncome / costsTotal) * 100))
     : 0;
 
-  const headlineIsMock = !patron.ok;
-  const incomeIsMock = !patron.ok;
-  const anyMock = headlineIsMock || incomeIsMock;
+  const patroniteUnavailable = !patron.ok;
 
   return (
     <main className="bg-background text-foreground font-serif px-4 sm:px-8 md:px-14 pt-10 sm:pt-12 pb-24 sm:pb-28">
@@ -214,7 +209,7 @@ export default async function AboutProjectPage() {
 
         <Ornament />
 
-        {anyMock ? <MockNotice /> : null}
+        {patroniteUnavailable ? <PatroniteUnavailableNotice /> : null}
 
         <section className="mb-16">
           <SectionTitle
@@ -228,29 +223,28 @@ export default async function AboutProjectPage() {
             wpływy, miesięczny burn i to, z czego składa się utrzymanie projektu.
           </p>
 
-          <section className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
-            <BigStat
-              kicker={patron.ok ? "Patroni · aktywni" : "Patroni · od początku"}
-              value={fmtPL(patron.ok ? patronCount : 0)}
-              unit={patron.ok && totalEverCount > patronCount
-                ? `aktywni · ${fmtPL(totalEverCount)} kiedykolwiek`
-                : "osób"}
-              mock={headlineIsMock}
-            />
-            <BigStat
-              kicker="Bieżące wpływy"
-              value={fmtPL(monthlyIncome)}
-              unit="zł / mc"
-              accent
-              mock={headlineIsMock}
-            />
-            <BigStat
-              kicker="Pokrycie kosztów"
-              value={`${coveragePct}%`}
-              unit={`z ${fmtPL(costsTotal)} zł/mc`}
-              mock={headlineIsMock}
-            />
-          </section>
+          {patron.ok ? (
+            <section className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
+              <BigStat
+                kicker="Patroni · aktywni"
+                value={fmtPL(patronCount)}
+                unit={totalEverCount > patronCount
+                  ? `aktywni · ${fmtPL(totalEverCount)} kiedykolwiek`
+                  : "osób"}
+              />
+              <BigStat
+                kicker="Bieżące wpływy"
+                value={fmtPL(monthlyIncome)}
+                unit="zł / mc"
+                accent
+              />
+              <BigStat
+                kicker="Pokrycie kosztów"
+                value={`${coveragePct}%`}
+                unit={`z ${fmtPL(costsTotal)} zł/mc`}
+              />
+            </section>
+          ) : null}
 
           <div className="grid md:grid-cols-2 gap-10">
             <div>
@@ -285,9 +279,8 @@ export default async function AboutProjectPage() {
             </div>
 
             <div>
-              <h3 className="font-serif text-[18px] font-medium m-0 mb-3 pb-2 border-b border-rule flex items-baseline">
-                <span>Skąd wpływy</span>
-                {incomeIsMock ? <MockChip /> : null}
+              <h3 className="font-serif text-[18px] font-medium m-0 mb-3 pb-2 border-b border-rule">
+                Skąd wpływy
               </h3>
               {patron.ok ? (
                 <>
@@ -305,9 +298,9 @@ export default async function AboutProjectPage() {
                 </>
               ) : (
                 <IncomeRow
-                  label="Patronite — brak tokena (PATRONITE_TOKEN)"
+                  label="Patronite — dane chwilowo niedostępne"
                   value="—"
-                  mock
+                  muted
                 />
               )}
               <p
@@ -332,19 +325,13 @@ function BigStat({
   value,
   unit,
   accent = false,
-  mock = false,
 }: {
   kicker: string;
   value: string;
   unit: string;
   accent?: boolean;
-  mock?: boolean;
 }) {
-  const valueColor = mock
-    ? "text-muted-foreground italic"
-    : accent
-      ? "text-destructive italic"
-      : "text-foreground";
+  const valueColor = accent ? "text-destructive italic" : "text-foreground";
   return (
     <div
       className="bg-background border-2 border-foreground p-6"
@@ -352,14 +339,6 @@ function BigStat({
     >
       <div className="font-mono text-[10px] tracking-[0.16em] uppercase text-muted-foreground mb-2">
         {kicker}
-        {mock ? (
-          <span
-            className="ml-2 normal-case tracking-normal"
-            style={{ color: "var(--warning)" }}
-          >
-            (przykładowo)
-          </span>
-        ) : null}
       </div>
       <div
         className={`font-serif font-normal leading-none ${valueColor}`}
@@ -395,23 +374,17 @@ function IncomeRow({
   label,
   value,
   muted = false,
-  mock = false,
 }: {
   label: string;
   value: string;
   muted?: boolean;
-  mock?: boolean;
 }) {
   return (
     <div
       className={`flex items-baseline justify-between gap-3 py-2 border-b border-dotted border-border ${muted ? "text-muted-foreground" : ""}`}
     >
       <span className="font-serif text-[15px]">{label}</span>
-      <span
-        className={`font-mono text-[13px] tabular-nums ${mock ? "italic text-muted-foreground" : ""}`}
-      >
-        {value}
-      </span>
+      <span className="font-mono text-[13px] tabular-nums">{value}</span>
     </div>
   );
 }

--- a/frontend/components/chrome/SiteFooter.tsx
+++ b/frontend/components/chrome/SiteFooter.tsx
@@ -86,6 +86,17 @@ export async function SiteFooter() {
               github.com/miskibin/tygodnik-sejmowy →
             </a>
           </p>
+          <p className="m-0 mb-3">
+            Zgłoś błąd lub pomysł:{" "}
+            <a
+              href="https://github.com/miskibin/tygodnik-sejmowy/issues/new"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-destructive hover:underline"
+            >
+              github.com/.../issues →
+            </a>
+          </p>
           <p className="m-0 text-border">
             © {year} Tygodnik Sejmowy · public-good infrastructure
           </p>


### PR DESCRIPTION
## Summary
This PR improves error handling for Patronite data unavailability, removes mock data indicators, refines feature tile previews on the landing page, and enhances the postcode input UX with a dedicated OTP component.

## Key Changes

**Patronite Error Handling & UI**
- Renamed `MockNotice()` to `PatroniteUnavailableNotice()` with updated messaging that directs users to patronite.pl when data fetch fails
- Removed `MockChip` component and mock data indicators throughout the about page
- Simplified state management by replacing `headlineIsMock`, `incomeIsMock`, and `anyMock` flags with a single `patroniteUnavailable` boolean
- Conditionally render the stats section only when Patronite data is available
- Updated `BigStat` and `IncomeRow` components to remove mock-related props and styling

**Feature Tile Improvements**
- Added `comingSoon` prop to `FeatureTile` component with visual "wkrótce" badge
- Updated "Mowa" (Speeches) tile: now links to `/mowa` with coming-soon styling
- Updated "Alerty" (Alerts) tile: now links to `/alerty` with coming-soon styling
- Redesigned Alerty preview to show planned alert triggers (fraza, poseł, klub, okręg, druk, akt) and channels (e-mail, RSS, push, ICS) instead of fake keyword counts
- Changed ELI references to "Dz.U." (Dziennik Ustaw / Official Journal) for accuracy

**Postcode Input Enhancement**
- Replaced plain text input with `InputOTP` component for better UX
- Added helper functions `digitsToPostcode()` and `postcodeToDigits()` to marshal between OTP's digit format and the API's dashed format (NN-NNN)
- Improved visual presentation with separate digit groups and separator

**Footer & Copy Updates**
- Added GitHub issues link in footer for bug reports and feature requests
- Removed "Bez śledzenia" (No tracking) from hero footer copy for accuracy
- Updated source tags from "ELI" to "Dz.U./MP"

## Implementation Details
- The Patronite unavailability notice now provides actionable guidance with a direct link to the Patronite page
- Feature tiles with `comingSoon={true}` display a badge but remain clickable to preview pages
- Postcode input now uses a structured OTP component with proper digit validation and formatting at component boundaries

https://claude.ai/code/session_01P8TzzWm7Rn1H733N8raFFx