### PR TITLE
voting: square 1:1 PNG capture with both titles + compact rows

### DIFF
--- a/frontend/app/glosowanie/[id]/page.tsx
+++ b/frontend/app/glosowanie/[id]/page.tsx
@@ -43,7 +43,12 @@ export default async function VotingDetailPage({
     <main className="bg-background text-foreground font-serif min-h-screen">
       <VotingHero data={data} />
       <VotingMeaning linkedPrint={linkedPrint} clubs={clubs} passed={passed} />
-      <ClubBreakdownTable clubs={clubs} header={header} shortTitle={linkedPrint?.short_title ?? null} />
+      <ClubBreakdownTable
+        clubs={clubs}
+        header={header}
+        shortTitle={linkedPrint?.short_title ?? null}
+        printNumber={linkedPrint?.number ?? null}
+      />
       <RebelGrid rebels={rebels} term={header.term} />
       <FullRosterGrid
         seats={seats}

--- a/frontend/components/voting/ClubBreakdownTable.tsx
+++ b/frontend/components/voting/ClubBreakdownTable.tsx
@@ -257,15 +257,15 @@ function PngClubRow({ c, isLast }: { c: ClubBreakdownRow; isLast: boolean }) {
     <img
       src={`/club-logos/${logoEntry.file}`}
       alt={c.club_name}
-      width={32}
-      height={32}
+      width={40}
+      height={40}
       loading="eager"
       decoding="sync"
       style={{
-        width: 32,
-        height: 32,
+        width: 40,
+        height: 40,
         objectFit: "contain",
-        borderRadius: 4,
+        borderRadius: 5,
         background: "var(--background)",
         border: "1px solid var(--border)",
         flexShrink: 0,
@@ -278,12 +278,12 @@ function PngClubRow({ c, isLast }: { c: ClubBreakdownRow; isLast: boolean }) {
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "center",
-        width: 32,
-        height: 32,
-        borderRadius: 4,
+        width: 40,
+        height: 40,
+        borderRadius: 5,
         background: c.clubColor,
         color: "var(--background)",
-        fontSize: 13,
+        fontSize: 15,
         fontWeight: 700,
         flexShrink: 0,
       }}
@@ -298,19 +298,19 @@ function PngClubRow({ c, isLast }: { c: ClubBreakdownRow; isLast: boolean }) {
         flex: 1,
         minHeight: 0,
         display: "grid",
-        gridTemplateColumns: "170px 56px 1fr 170px",
-        gap: 18,
+        gridTemplateColumns: "180px 56px 1fr 220px",
+        gap: 20,
         alignItems: "center",
-        padding: "4px 0",
+        padding: "2px 0",
         borderBottom: isLast ? "none" : "1px solid var(--border)",
       }}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, minWidth: 0 }}>
         <span
           aria-hidden
           style={{
-            width: 4,
-            height: 32,
+            width: 5,
+            height: 40,
             background: c.clubColor,
             borderRadius: 2,
             flexShrink: 0,
@@ -319,7 +319,7 @@ function PngClubRow({ c, isLast }: { c: ClubBreakdownRow; isLast: boolean }) {
         {logo}
         <span
           style={{
-            fontSize: 14,
+            fontSize: 17,
             color: "var(--secondary-foreground)",
             overflow: "hidden",
             textOverflow: "ellipsis",
@@ -336,7 +336,7 @@ function PngClubRow({ c, isLast }: { c: ClubBreakdownRow; isLast: boolean }) {
         style={{
           fontFamily: "var(--font-mono, monospace)",
           fontVariantNumeric: "tabular-nums",
-          fontSize: 15,
+          fontSize: 18,
           color: "var(--secondary-foreground)",
           textAlign: "right",
         }}
@@ -347,7 +347,7 @@ function PngClubRow({ c, isLast }: { c: ClubBreakdownRow; isLast: boolean }) {
       <div
         style={{
           display: "flex",
-          height: 30,
+          height: 38,
           background: "var(--muted)",
           border: "1px solid var(--border)",
         }}
@@ -364,7 +364,7 @@ function PngClubRow({ c, isLast }: { c: ClubBreakdownRow; isLast: boolean }) {
                 justifyContent: "center",
                 width: `${pct * 100}%`,
                 background: s.color,
-                fontSize: 11,
+                fontSize: 14,
                 fontWeight: 700,
                 fontFamily: "var(--font-mono, monospace)",
                 color: s.textOnFaint ? "var(--secondary-foreground)" : "var(--background)",
@@ -378,15 +378,16 @@ function PngClubRow({ c, isLast }: { c: ClubBreakdownRow; isLast: boolean }) {
 
       <div
         style={{
-          fontSize: 13,
+          fontSize: 15,
           color: "var(--secondary-foreground)",
           textAlign: "right",
+          whiteSpace: "nowrap",
         }}
       >
         <span
           style={{
             fontFamily: "var(--font-mono, monospace)",
-            fontSize: 10,
+            fontSize: 11,
             color: "var(--muted-foreground)",
             letterSpacing: "0.1em",
             textTransform: "uppercase",
@@ -408,7 +409,7 @@ function PngClubRow({ c, isLast }: { c: ClubBreakdownRow; isLast: boolean }) {
               fontFamily: "var(--font-mono, monospace)",
               marginLeft: 8,
               color: "var(--destructive)",
-              fontSize: 10,
+              fontSize: 11,
               letterSpacing: "0.1em",
               textTransform: "uppercase",
             }}
@@ -441,12 +442,12 @@ export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: P
   const filteredClubs = excludeUnaffiliated(clubs, (c) => c.club_ref)
     .filter((c) => (c.total ?? 0) >= MIN_KLUB_AGGREGATE);
 
-  // PNG title block: print short_title (when available) as the headline, and
-  // the official voting question (header.title) as italic subtitle. The two
-  // are different things — the print is the document being voted on, the
-  // voting title is the procedural question read in the chamber.
-  const pngHeadline = clampForPng(shortTitle, 140);
-  const pngQuestion = clampForPng(header.title, 280);
+  // PNG title block: the voting title (header.title — the official question
+  // read in the chamber) is the primary display. The print's short_title
+  // (when present) sits below as italic context subtitle. Voting title wins
+  // because that's what was actually voted on — the print is incidental.
+  const pngQuestion = clampForPng(header.title, 220);
+  const pngSubtitle = clampForPng(shortTitle, 110);
 
   return (
     <section
@@ -563,55 +564,41 @@ export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: P
             {printNumber ? ` · druk ${printNumber}` : ""}
           </div>
 
-          {pngHeadline && (
-            <div
-              style={{
-                fontFamily: "var(--font-serif, serif)",
-                fontSize: 42,
-                fontWeight: 500,
-                lineHeight: 1.1,
-                letterSpacing: "-0.02em",
-                marginBottom: 16,
-                color: "var(--foreground)",
-              }}
-            >
-              {pngHeadline}
-            </div>
-          )}
+          <div
+            style={{
+              fontFamily: "var(--font-serif, serif)",
+              fontSize: 30,
+              fontWeight: 500,
+              lineHeight: 1.18,
+              letterSpacing: "-0.015em",
+              color: "var(--foreground)",
+              marginBottom: pngSubtitle ? 12 : 0,
+            }}
+          >
+            „{pngQuestion}”
+          </div>
 
-          <div>
-            <div
-              style={{
-                fontFamily: "var(--font-mono, monospace)",
-                textTransform: "uppercase",
-                fontSize: 10,
-                color: "var(--muted-foreground)",
-                letterSpacing: "0.12em",
-                marginBottom: 4,
-              }}
-            >
-              pytanie poddane pod głosowanie
-            </div>
+          {pngSubtitle && (
             <div
               style={{
                 fontFamily: "var(--font-serif, serif)",
                 fontStyle: "italic",
-                fontSize: pngHeadline ? 15 : 22,
-                lineHeight: 1.35,
+                fontSize: 18,
+                lineHeight: 1.3,
                 color: "var(--secondary-foreground)",
               }}
             >
-              „{pngQuestion}”
+              {pngSubtitle}
             </div>
-          </div>
+          )}
         </div>
 
         {/* Column headers */}
         <div
           style={{
             display: "grid",
-            gridTemplateColumns: "170px 56px 1fr 170px",
-            gap: 18,
+            gridTemplateColumns: "180px 56px 1fr 220px",
+            gap: 20,
             fontFamily: "var(--font-mono, monospace)",
             textTransform: "uppercase",
             fontSize: 10,
@@ -660,7 +647,7 @@ export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: P
           }}
         >
           <span>tygodnik sejmowy · jak głosowały kluby</span>
-          <span>sejmograf.vercel.app</span>
+          <span>tygodniksejmowy.pl</span>
         </div>
       </div>
     </section>

--- a/frontend/components/voting/ClubBreakdownTable.tsx
+++ b/frontend/components/voting/ClubBreakdownTable.tsx
@@ -3,6 +3,8 @@
 import { useRef } from "react";
 import type { ClubBreakdownRow, VotingHeader } from "@/lib/db/voting";
 import { ClubBadge } from "@/components/clubs/ClubBadge";
+import { CLUB_LOGOS } from "@/lib/atlas/club-logos";
+import { KLUB_LABELS } from "@/lib/atlas/constants";
 import { CopyAsPngButton } from "./CopyAsPngButton";
 import { excludeUnaffiliated, MIN_KLUB_AGGREGATE } from "@/lib/clubs/filter";
 
@@ -10,6 +12,7 @@ type Props = {
   clubs: ClubBreakdownRow[];
   header: VotingHeader;
   shortTitle: string | null;
+  printNumber: string | null;
 };
 
 type Segment = {
@@ -228,6 +231,194 @@ function ClubRow({ c }: { c: ClubBreakdownRow }) {
   );
 }
 
+// Compact, viewport-independent row used inside the PNG capture node only.
+// Plain <img> with loading="eager" so the off-screen capture target doesn't
+// trip Next/Image's lazy-load IntersectionObserver (which never fires for
+// elements positioned outside the viewport).
+function PngClubRow({ c }: { c: ClubBreakdownRow }) {
+  const segs: Segment[] = [
+    { n: c.yes, color: "var(--success)", label: "ZA", textOnFaint: false },
+    { n: c.no, color: "var(--destructive)", label: "PRZECIW", textOnFaint: false },
+    { n: c.abstain, color: "var(--warning)", label: "WSTRZ.", textOnFaint: false },
+    { n: c.not_voting, color: "var(--border)", label: "NIEOB.", textOnFaint: true },
+  ];
+  const total = c.total;
+  const showBroken =
+    c.brokenCount > 0 &&
+    (c.disciplineLabel === "ZA" ||
+      c.disciplineLabel === "PRZECIW" ||
+      c.disciplineLabel === "WSTRZ.");
+
+  const logoEntry = CLUB_LOGOS[c.club_ref];
+  const shortLabel = KLUB_LABELS[c.club_ref] ?? c.club_ref;
+
+  const logo = logoEntry ? (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={`/club-logos/${logoEntry.file}`}
+      alt={c.club_name}
+      width={24}
+      height={24}
+      loading="eager"
+      decoding="sync"
+      style={{
+        width: 24,
+        height: 24,
+        objectFit: "contain",
+        borderRadius: 3,
+        background: "var(--background)",
+        border: "1px solid var(--border)",
+        flexShrink: 0,
+      }}
+    />
+  ) : (
+    <span
+      aria-hidden
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 24,
+        height: 24,
+        borderRadius: 3,
+        background: c.clubColor,
+        color: "var(--background)",
+        fontSize: 10,
+        fontWeight: 700,
+        flexShrink: 0,
+      }}
+    >
+      {c.club_ref.slice(0, 2).toUpperCase()}
+    </span>
+  );
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "150px 44px 1fr 150px",
+        gap: 14,
+        alignItems: "center",
+        padding: "7px 0",
+        borderBottom: "1px solid var(--border)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+        <span
+          aria-hidden
+          style={{
+            width: 3,
+            height: 22,
+            background: c.clubColor,
+            borderRadius: 2,
+            flexShrink: 0,
+          }}
+        />
+        {logo}
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--secondary-foreground)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            fontFamily: "var(--font-mono, monospace)",
+            fontWeight: 600,
+          }}
+        >
+          {shortLabel}
+        </span>
+      </div>
+
+      <div
+        style={{
+          fontFamily: "var(--font-mono, monospace)",
+          fontVariantNumeric: "tabular-nums",
+          fontSize: 12,
+          color: "var(--secondary-foreground)",
+          textAlign: "right",
+        }}
+      >
+        {c.total}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          height: 20,
+          background: "var(--muted)",
+          border: "1px solid var(--border)",
+        }}
+      >
+        {segs.map((s, i) => {
+          const pct = total > 0 ? s.n / total : 0;
+          const showLabel = s.n > 0 && pct > 0.08;
+          return (
+            <div
+              key={i}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: `${pct * 100}%`,
+                background: s.color,
+                fontSize: 9,
+                fontWeight: 700,
+                fontFamily: "var(--font-mono, monospace)",
+                color: s.textOnFaint ? "var(--secondary-foreground)" : "var(--background)",
+              }}
+            >
+              {showLabel ? s.n : ""}
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        style={{
+          fontSize: 11,
+          color: "var(--secondary-foreground)",
+          textAlign: "right",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "var(--font-mono, monospace)",
+            fontSize: 9,
+            color: "var(--muted-foreground)",
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+          }}
+        >
+          za klubem{" "}
+        </span>
+        <span
+          style={{
+            color: c.disciplineLabel === "—" ? "var(--muted-foreground)" : "var(--foreground)",
+            fontWeight: 600,
+          }}
+        >
+          {c.disciplineLabel}
+        </span>
+        {showBroken && (
+          <span
+            style={{
+              fontFamily: "var(--font-mono, monospace)",
+              marginLeft: 6,
+              color: "var(--destructive)",
+              fontSize: 9,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+            }}
+          >
+            ↪ {c.brokenCount}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function formatDateShort(iso: string): string {
   const d = new Date(iso);
   const dd = String(d.getDate()).padStart(2, "0");
@@ -235,8 +426,25 @@ function formatDateShort(iso: string): string {
   return `${dd}.${mm}.${d.getFullYear()}`;
 }
 
-export function ClubBreakdownTable({ clubs, header, shortTitle }: Props) {
+function clampForPng(s: string | null | undefined, max: number): string | null {
+  if (!s) return null;
+  const trimmed = s.trim();
+  if (trimmed.length <= max) return trimmed;
+  return trimmed.slice(0, max - 1).trimEnd() + "…";
+}
+
+export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: Props) {
   const captureRef = useRef<HTMLDivElement | null>(null);
+
+  const filteredClubs = excludeUnaffiliated(clubs, (c) => c.club_ref)
+    .filter((c) => (c.total ?? 0) >= MIN_KLUB_AGGREGATE);
+
+  // PNG title block: print short_title (when available) as the headline, and
+  // the official voting question (header.title) as italic subtitle. The two
+  // are different things — the print is the document being voted on, the
+  // voting title is the procedural question read in the chamber.
+  const pngHeadline = clampForPng(shortTitle, 140);
+  const pngQuestion = clampForPng(header.title, 280);
 
   return (
     <section
@@ -277,89 +485,174 @@ export function ClubBreakdownTable({ clubs, header, shortTitle }: Props) {
           {shortTitle ?? header.title}
         </div>
 
+        {/* Live (responsive) rows. */}
         <div
-          ref={captureRef}
+          className="hidden sm:grid items-center font-mono uppercase"
           style={{
-            background: "var(--background)",
-            padding: 16,
-            border: "1px solid var(--border)",
+            gridTemplateColumns: "120px 80px 1fr 240px",
+            gap: 24,
+            fontSize: 10,
+            color: "var(--muted-foreground)",
+            letterSpacing: "0.14em",
+            borderBottom: "1px solid var(--rule)",
+            paddingBottom: 10,
+            marginBottom: 4,
           }}
         >
-          {/* Capture-only header — only visible in PNG export, not the live page */}
-          <div
-            className="png-only font-serif"
-            style={{
-              borderBottom: "1px solid var(--border)",
-              paddingBottom: 14,
-              marginBottom: 18,
-            }}
-          >
-            <div
-              className="font-mono uppercase"
-              style={{
-                fontSize: 10,
-                color: "var(--muted-foreground)",
-                letterSpacing: "0.16em",
-                marginBottom: 6,
-              }}
-            >
-              Sejm {header.term} · pos. {header.sitting} · głos. nr {header.voting_number} · {formatDateShort(header.date)}
-            </div>
-            <div style={{ fontSize: 22, fontWeight: 500, color: "var(--foreground)", lineHeight: 1.2 }}>
-              {shortTitle ?? header.title}
-            </div>
-          </div>
-
-          <div
-            className="hidden sm:grid items-center font-mono uppercase"
-            style={{
-              gridTemplateColumns: "120px 80px 1fr 240px",
-              gap: 24,
-              fontSize: 10,
-              color: "var(--muted-foreground)",
-              letterSpacing: "0.14em",
-              borderBottom: "1px solid var(--rule)",
-              paddingBottom: 10,
-              marginBottom: 4,
-            }}
-          >
-            <span>Klub</span>
-            <span className="text-right">Mandaty</span>
-            <span>Rozkład głosów</span>
-            <span className="text-right">Dyscyplina</span>
-          </div>
-
-          {/* Niezrzeszeni excluded — single-MP "klub" rolled-ups distort the
-              narrative. They still appear in the imienna roster below.
-              Also drop sub-MIN_KLUB_AGGREGATE klubs: discipline numbers from
-              <3-MP klubs are noise, not signal. */}
-          {excludeUnaffiliated(clubs, (c) => c.club_ref)
-            .filter((c) => (c.total ?? 0) >= MIN_KLUB_AGGREGATE)
-            .map((c) => (
-              <ClubRow key={c.club_ref} c={c} />
-            ))}
-
-          <div
-            className="png-only font-mono uppercase"
-            style={{
-              marginTop: 18,
-              paddingTop: 12,
-              borderTop: "1px solid var(--border)",
-              fontSize: 9,
-              color: "var(--muted-foreground)",
-              letterSpacing: "0.18em",
-              textAlign: "right",
-            }}
-          >
-            sejmograf.vercel.app
-          </div>
+          <span>Klub</span>
+          <span className="text-right">Mandaty</span>
+          <span>Rozkład głosów</span>
+          <span className="text-right">Dyscyplina</span>
         </div>
+
+        {/* Niezrzeszeni excluded — single-MP "klub" rolled-ups distort the
+            narrative. They still appear in the imienna roster below.
+            Also drop sub-MIN_KLUB_AGGREGATE klubs: discipline numbers from
+            <3-MP klubs are noise, not signal. */}
+        {filteredClubs.map((c) => (
+          <ClubRow key={c.club_ref} c={c} />
+        ))}
       </div>
 
-      <style>{`
-        .png-only { display: none; }
-        .capturing .png-only { display: block; }
-      `}</style>
+      {/* PNG-only capture target. Fixed 1080x1080 square, off-screen so the
+          live page is unaffected. Always in the DOM so logos load eagerly
+          (off-screen lazy <Image> would never trip the IntersectionObserver,
+          which is why this section uses plain <img loading="eager">). */}
+      <div
+        ref={captureRef}
+        aria-hidden
+        style={{
+          position: "fixed",
+          top: 0,
+          left: "-12000px",
+          width: 1080,
+          height: 1080,
+          background: "var(--background)",
+          padding: 56,
+          boxSizing: "border-box",
+          overflow: "hidden",
+          zIndex: -1,
+          pointerEvents: "none",
+          display: "flex",
+          flexDirection: "column",
+          fontFamily: "var(--font-serif, serif)",
+          color: "var(--foreground)",
+        }}
+      >
+        {/* Header block */}
+        <div
+          style={{
+            paddingBottom: 22,
+            borderBottom: "2px solid var(--rule)",
+            marginBottom: 22,
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "var(--font-mono, monospace)",
+              textTransform: "uppercase",
+              fontSize: 12,
+              color: "var(--muted-foreground)",
+              letterSpacing: "0.18em",
+              marginBottom: 14,
+            }}
+          >
+            Sejm {header.term} · pos. {header.sitting} · głos. nr {header.voting_number} · {formatDateShort(header.date)}
+            {printNumber ? ` · druk ${printNumber}` : ""}
+          </div>
+
+          {pngHeadline && (
+            <div
+              style={{
+                fontFamily: "var(--font-serif, serif)",
+                fontSize: 34,
+                fontWeight: 500,
+                lineHeight: 1.12,
+                letterSpacing: "-0.018em",
+                marginBottom: 14,
+                color: "var(--foreground)",
+              }}
+            >
+              {pngHeadline}
+            </div>
+          )}
+
+          <div>
+            <div
+              style={{
+                fontFamily: "var(--font-mono, monospace)",
+                textTransform: "uppercase",
+                fontSize: 10,
+                color: "var(--muted-foreground)",
+                letterSpacing: "0.12em",
+                marginBottom: 4,
+              }}
+            >
+              pytanie poddane pod głosowanie
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--font-serif, serif)",
+                fontStyle: "italic",
+                fontSize: pngHeadline ? 15 : 22,
+                lineHeight: 1.35,
+                color: "var(--secondary-foreground)",
+              }}
+            >
+              „{pngQuestion}”
+            </div>
+          </div>
+        </div>
+
+        {/* Column headers */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "150px 44px 1fr 150px",
+            gap: 14,
+            fontFamily: "var(--font-mono, monospace)",
+            textTransform: "uppercase",
+            fontSize: 9,
+            color: "var(--muted-foreground)",
+            letterSpacing: "0.14em",
+            borderBottom: "1px solid var(--rule)",
+            paddingBottom: 6,
+            marginBottom: 2,
+          }}
+        >
+          <span>Klub</span>
+          <span style={{ textAlign: "right" }}>Mand.</span>
+          <span>Rozkład głosów</span>
+          <span style={{ textAlign: "right" }}>Dyscyplina</span>
+        </div>
+
+        {/* Rows */}
+        <div style={{ flex: 1, minHeight: 0 }}>
+          {filteredClubs.map((c) => (
+            <PngClubRow key={c.club_ref} c={c} />
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            marginTop: 16,
+            paddingTop: 12,
+            borderTop: "1px solid var(--border)",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            fontFamily: "var(--font-mono, monospace)",
+            textTransform: "uppercase",
+            fontSize: 10,
+            color: "var(--muted-foreground)",
+            letterSpacing: "0.18em",
+          }}
+        >
+          <span>tygodnik sejmowy · jak głosowały kluby</span>
+          <span>sejmograf.vercel.app</span>
+        </div>
+      </div>
     </section>
   );
 }

--- a/frontend/components/voting/ClubBreakdownTable.tsx
+++ b/frontend/components/voting/ClubBreakdownTable.tsx
@@ -235,7 +235,7 @@ function ClubRow({ c }: { c: ClubBreakdownRow }) {
 // Plain <img> with loading="eager" so the off-screen capture target doesn't
 // trip Next/Image's lazy-load IntersectionObserver (which never fires for
 // elements positioned outside the viewport).
-function PngClubRow({ c }: { c: ClubBreakdownRow }) {
+function PngClubRow({ c, isLast }: { c: ClubBreakdownRow; isLast: boolean }) {
   const segs: Segment[] = [
     { n: c.yes, color: "var(--success)", label: "ZA", textOnFaint: false },
     { n: c.no, color: "var(--destructive)", label: "PRZECIW", textOnFaint: false },
@@ -257,15 +257,15 @@ function PngClubRow({ c }: { c: ClubBreakdownRow }) {
     <img
       src={`/club-logos/${logoEntry.file}`}
       alt={c.club_name}
-      width={24}
-      height={24}
+      width={32}
+      height={32}
       loading="eager"
       decoding="sync"
       style={{
-        width: 24,
-        height: 24,
+        width: 32,
+        height: 32,
         objectFit: "contain",
-        borderRadius: 3,
+        borderRadius: 4,
         background: "var(--background)",
         border: "1px solid var(--border)",
         flexShrink: 0,
@@ -278,12 +278,12 @@ function PngClubRow({ c }: { c: ClubBreakdownRow }) {
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "center",
-        width: 24,
-        height: 24,
-        borderRadius: 3,
+        width: 32,
+        height: 32,
+        borderRadius: 4,
         background: c.clubColor,
         color: "var(--background)",
-        fontSize: 10,
+        fontSize: 13,
         fontWeight: 700,
         flexShrink: 0,
       }}
@@ -295,20 +295,22 @@ function PngClubRow({ c }: { c: ClubBreakdownRow }) {
   return (
     <div
       style={{
+        flex: 1,
+        minHeight: 0,
         display: "grid",
-        gridTemplateColumns: "150px 44px 1fr 150px",
-        gap: 14,
+        gridTemplateColumns: "170px 56px 1fr 170px",
+        gap: 18,
         alignItems: "center",
-        padding: "7px 0",
-        borderBottom: "1px solid var(--border)",
+        padding: "4px 0",
+        borderBottom: isLast ? "none" : "1px solid var(--border)",
       }}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
         <span
           aria-hidden
           style={{
-            width: 3,
-            height: 22,
+            width: 4,
+            height: 32,
             background: c.clubColor,
             borderRadius: 2,
             flexShrink: 0,
@@ -317,7 +319,7 @@ function PngClubRow({ c }: { c: ClubBreakdownRow }) {
         {logo}
         <span
           style={{
-            fontSize: 11,
+            fontSize: 14,
             color: "var(--secondary-foreground)",
             overflow: "hidden",
             textOverflow: "ellipsis",
@@ -334,7 +336,7 @@ function PngClubRow({ c }: { c: ClubBreakdownRow }) {
         style={{
           fontFamily: "var(--font-mono, monospace)",
           fontVariantNumeric: "tabular-nums",
-          fontSize: 12,
+          fontSize: 15,
           color: "var(--secondary-foreground)",
           textAlign: "right",
         }}
@@ -345,7 +347,7 @@ function PngClubRow({ c }: { c: ClubBreakdownRow }) {
       <div
         style={{
           display: "flex",
-          height: 20,
+          height: 30,
           background: "var(--muted)",
           border: "1px solid var(--border)",
         }}
@@ -362,7 +364,7 @@ function PngClubRow({ c }: { c: ClubBreakdownRow }) {
                 justifyContent: "center",
                 width: `${pct * 100}%`,
                 background: s.color,
-                fontSize: 9,
+                fontSize: 11,
                 fontWeight: 700,
                 fontFamily: "var(--font-mono, monospace)",
                 color: s.textOnFaint ? "var(--secondary-foreground)" : "var(--background)",
@@ -376,7 +378,7 @@ function PngClubRow({ c }: { c: ClubBreakdownRow }) {
 
       <div
         style={{
-          fontSize: 11,
+          fontSize: 13,
           color: "var(--secondary-foreground)",
           textAlign: "right",
         }}
@@ -384,7 +386,7 @@ function PngClubRow({ c }: { c: ClubBreakdownRow }) {
         <span
           style={{
             fontFamily: "var(--font-mono, monospace)",
-            fontSize: 9,
+            fontSize: 10,
             color: "var(--muted-foreground)",
             letterSpacing: "0.1em",
             textTransform: "uppercase",
@@ -404,9 +406,9 @@ function PngClubRow({ c }: { c: ClubBreakdownRow }) {
           <span
             style={{
               fontFamily: "var(--font-mono, monospace)",
-              marginLeft: 6,
+              marginLeft: 8,
               color: "var(--destructive)",
-              fontSize: 9,
+              fontSize: 10,
               letterSpacing: "0.1em",
               textTransform: "uppercase",
             }}
@@ -565,11 +567,11 @@ export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: P
             <div
               style={{
                 fontFamily: "var(--font-serif, serif)",
-                fontSize: 34,
+                fontSize: 42,
                 fontWeight: 500,
-                lineHeight: 1.12,
-                letterSpacing: "-0.018em",
-                marginBottom: 14,
+                lineHeight: 1.1,
+                letterSpacing: "-0.02em",
+                marginBottom: 16,
                 color: "var(--foreground)",
               }}
             >
@@ -608,15 +610,15 @@ export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: P
         <div
           style={{
             display: "grid",
-            gridTemplateColumns: "150px 44px 1fr 150px",
-            gap: 14,
+            gridTemplateColumns: "170px 56px 1fr 170px",
+            gap: 18,
             fontFamily: "var(--font-mono, monospace)",
             textTransform: "uppercase",
-            fontSize: 9,
+            fontSize: 10,
             color: "var(--muted-foreground)",
             letterSpacing: "0.14em",
             borderBottom: "1px solid var(--rule)",
-            paddingBottom: 6,
+            paddingBottom: 8,
             marginBottom: 2,
           }}
         >
@@ -626,10 +628,18 @@ export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: P
           <span style={{ textAlign: "right" }}>Dyscyplina</span>
         </div>
 
-        {/* Rows */}
-        <div style={{ flex: 1, minHeight: 0 }}>
-          {filteredClubs.map((c) => (
-            <PngClubRow key={c.club_ref} c={c} />
+        {/* Rows — flex column with each row flex:1 so 4 klubs stretch to fill
+            the square as much as 12 do. No empty bottom space. */}
+        <div
+          style={{
+            flex: 1,
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          {filteredClubs.map((c, i) => (
+            <PngClubRow key={c.club_ref} c={c} isLast={i === filteredClubs.length - 1} />
           ))}
         </div>
 


### PR DESCRIPTION
The PNG export was rendering at whatever responsive width the viewport happened to be (so wildly different on phone vs desktop), and only showed one title (print short_title fell back to voting title — never both).

Capture now happens against a dedicated off-screen 1080×1080 node so the PNG is always square regardless of device. Header shows the print short title as the headline and the official voting question as italic subtitle, with the meta line also surfacing the druk number. Rows in the PNG are an own, viewport-independent compact layout (20px bar, 7px padding, tighter columns) so the chart fits 9 klubs cleanly inside the square on both phone and desktop captures.

Plain <img loading="eager"> for klub logos inside the off-screen node because Next/Image's IntersectionObserver-driven lazy-load would never fire for an element at left:-12000px.

https://claude.ai/code/session_017XiBnqzpoGoeX3b4CCk1E4