### PR TITLE
voting: square 1:1 PNG capture, both titles, compact rows

### DIFF
--- a/frontend/components/voting/ClubBreakdownTable.tsx
+++ b/frontend/components/voting/ClubBreakdownTable.tsx
@@ -517,31 +517,40 @@ export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: P
         ))}
       </div>
 
-      {/* PNG-only capture target. Fixed 1080x1080 square, off-screen so the
-          live page is unaffected. Always in the DOM so logos load eagerly
-          (off-screen lazy <Image> would never trip the IntersectionObserver,
-          which is why this section uses plain <img loading="eager">). */}
+      {/* PNG-only capture target. Wrapped in a 0×0 clipping container so the
+          inner 1080×1080 node renders with normal positioning — html-to-image
+          serializes the element into an SVG <foreignObject>, and any
+          position:fixed/absolute/negative-offset on the capture root gets
+          preserved in the clone and pushes content outside the SVG viewport
+          (= blank PNG). Static positioning on the capture root avoids that.
+          Always in the DOM so logos load eagerly. */}
       <div
-        ref={captureRef}
         aria-hidden
         style={{
-          position: "fixed",
+          position: "absolute",
           top: 0,
-          left: "-12000px",
-          width: 1080,
-          height: 1080,
-          background: "var(--background)",
-          padding: 56,
-          boxSizing: "border-box",
+          left: 0,
+          width: 0,
+          height: 0,
           overflow: "hidden",
-          zIndex: -1,
           pointerEvents: "none",
-          display: "flex",
-          flexDirection: "column",
-          fontFamily: "var(--font-serif, serif)",
-          color: "var(--foreground)",
         }}
       >
+        <div
+          ref={captureRef}
+          style={{
+            width: 1080,
+            height: 1080,
+            background: "var(--background)",
+            padding: 56,
+            boxSizing: "border-box",
+            overflow: "hidden",
+            display: "flex",
+            flexDirection: "column",
+            fontFamily: "var(--font-serif, serif)",
+            color: "var(--foreground)",
+          }}
+        >
         {/* Header block */}
         <div
           style={{
@@ -648,6 +657,7 @@ export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: P
         >
           <span>tygodnik sejmowy · jak głosowały kluby</span>
           <span>tygodniksejmowy.pl</span>
+        </div>
         </div>
       </div>
     </section>

--- a/frontend/components/voting/CopyAsPngButton.tsx
+++ b/frontend/components/voting/CopyAsPngButton.tsx
@@ -21,12 +21,25 @@ export function CopyAsPngButton({
     node.classList.add("capturing");
     try {
       const { toBlob } = await import("html-to-image");
+      // Wait for any in-flight web fonts to resolve so the capture doesn't fall
+      // back to system fonts mid-load (esp. on first visit to the page).
+      if (typeof document !== "undefined" && "fonts" in document) {
+        try { await document.fonts.ready; } catch { /* ignore */ }
+      }
       // Wait one frame so .capturing toggles render before capture.
       await new Promise<void>((r) => requestAnimationFrame(() => r()));
+      // Pin explicit dims so html-to-image doesn't have to infer them from
+      // an off-screen / clipped element's bounding rect (which can return 0).
+      const w = node.offsetWidth || node.scrollWidth;
+      const h = node.offsetHeight || node.scrollHeight;
       const blob = await toBlob(node, {
         backgroundColor: "#f4efe4",
         pixelRatio: 2,
         cacheBust: true,
+        width: w,
+        height: h,
+        canvasWidth: w,
+        canvasHeight: h,
       });
       if (!blob) throw new Error("no blob");
       try {
@@ -49,7 +62,10 @@ export function CopyAsPngButton({
       URL.revokeObjectURL(url);
       setState("done");
       setTimeout(() => setState("idle"), 1800);
-    } catch {
+    } catch (err) {
+      // Surface the underlying error in the console so a blank/failed capture
+      // is debuggable from the user's devtools.
+      console.error("[CopyAsPngButton] capture failed", err);
       setState("fail");
       setTimeout(() => setState("idle"), 2000);
     } finally {


### PR DESCRIPTION
## Summary

Rebuilds the "kopiuj jako PNG" output on `/glosowanie/[id]` so it's actually shareable on Twitter:

- **Always 1:1 (1080×1080).** Capture target is a dedicated, fixed-size, off-screen DOM node — output no longer depends on whether the user is on phone or desktop.
- **Voting title as the headline.** The official voting question (`header.title`) is the primary 30px serif display; the print's `short_title` (when present) sits below as italic context subtitle. Druk number lives only in the meta line.
- **Rows fill the square.** Each row is `flex: 1` so 4 klubs stretch the same as 12 — no more 40% empty bottom canvas.
- **Larger type, tighter padding.** 40px logos, 38px bars, 17–18px row text. Discipline column widened to 220px with `nowrap` so "↪ N" doesn't wrap when discipline is broken.
- **Footer URL → `tygodniksejmowy.pl`** (was `sejmograf.vercel.app`).

Final iteration also fixes a production bug where the downloaded PNG was a blank canvas: the original `position: fixed; left: -12000px` hide strategy preserved the offset on the cloned root inside html-to-image's SVG `<foreignObject>`, pushing content out of frame. Now uses a 0×0 clipping wrapper around a normally-positioned capture node, plus `await document.fonts.ready` and explicit `width/height` to `toBlob`.

## Test plan

- [ ] Open `/glosowanie/<id>` on desktop, click "kopiuj jako PNG" → verify clipboard / download produces a 2160×2160 square with voting title + print subtitle + filled rows
- [ ] Repeat on mobile (Safari + Chrome) — output should be visually identical
- [ ] Confirm footer reads `tygodniksejmowy.pl`
- [ ] Confirm no console errors; if capture fails, the error now logs via `console.error("[CopyAsPngButton] capture failed", err)`

https://claude.ai/code/session_017XiBnqzpoGoeX3b4CCk1E4

---
_Generated by [Claude Code](https://claude.ai/code/session_017XiBnqzpoGoeX3b4CCk1E4)_