### PR TITLE
fix: vote polarity for promise alignment (MP 32 Bosak / 2197 case)

### DIFF
--- a/frontend/app/posel/[mpId]/_components/Tab4PromisesPanel.tsx
+++ b/frontend/app/posel/[mpId]/_components/Tab4PromisesPanel.tsx
@@ -1,18 +1,24 @@
 import type { MpPromiseAlignments, PromiseAlignmentVote } from "@/lib/db/posel-tabs";
+import { alignmentAriaLabel, type PromiseAlignment } from "@/lib/promiseAlignment";
 
 function formatDate(iso: string | null): string {
   if (!iso) return "—";
   return new Date(iso).toLocaleDateString("pl-PL", { day: "2-digit", month: "2-digit", year: "2-digit" });
 }
 
-function dotColor(vote: PromiseAlignmentVote["vote"]): string {
-  switch (vote) {
-    case "YES":
+// Color is driven by *alignment*, not the raw YES/NO vote — NO on a reject
+// motion is pro-bill (Bosak/2197 case). The raw vote letter still appears as
+// the dot's glyph for transparency.
+function dotColor(alignment: PromiseAlignment | undefined): string {
+  switch (alignment) {
+    case "aligned":
       return "var(--success)";
-    case "NO":
+    case "opposed":
       return "var(--destructive)";
-    case "ABSTAIN":
+    case "neutral":
       return "var(--warning)";
+    case "absent":
+      return "var(--muted-foreground)";
     default:
       return "var(--border)";
   }
@@ -127,11 +133,13 @@ export function Tab4PromisesPanel({ data }: { data: MpPromiseAlignments }) {
               </div>
               <div className="flex flex-wrap gap-1.5 justify-start md:justify-end">
                 {row.votes.map((v, i) => {
-                  const color = dotColor(v.vote);
+                  const color = dotColor(v.alignment);
+                  const aria = v.alignment ? alignmentAriaLabel(v.alignment) : "Brak głosowania";
                   const tooltip = [
                     v.printShort ?? `druk ${v.printNumber}`,
                     v.date ? formatDate(v.date) : null,
                     `głos: ${dotLabel(v.vote)}`,
+                    aria,
                   ]
                     .filter(Boolean)
                     .join(" · ");
@@ -144,6 +152,8 @@ export function Tab4PromisesPanel({ data }: { data: MpPromiseAlignments }) {
                         border: v.vote === "NONE" ? "1px dashed var(--border)" : "none",
                       }}
                       title={tooltip}
+                      aria-label={aria}
+                      role="img"
                     >
                       {dotLabel(v.vote)[0]}
                     </span>
@@ -165,15 +175,15 @@ export function Tab4PromisesPanel({ data }: { data: MpPromiseAlignments }) {
         <div className="mt-4 pt-3 border-t border-border flex flex-wrap gap-3 font-sans text-[11px] text-secondary-foreground">
           <span className="inline-flex items-center gap-1.5">
             <span className="inline-block w-3 h-3 rounded-full" style={{ background: "var(--success)" }} />
-            za drukiem
+            zgodnie z obietnicą
           </span>
           <span className="inline-flex items-center gap-1.5">
             <span className="inline-block w-3 h-3 rounded-full" style={{ background: "var(--destructive)" }} />
-            przeciw
+            wbrew obietnicy
           </span>
           <span className="inline-flex items-center gap-1.5">
             <span className="inline-block w-3 h-3 rounded-full" style={{ background: "var(--warning)" }} />
-            wstrzymał się
+            bez wpływu (poprawka / wstrzymał się)
           </span>
           <span className="inline-flex items-center gap-1.5">
             <span className="inline-block w-3 h-3 rounded-full" style={{ background: "var(--muted-foreground)" }} />
@@ -198,6 +208,9 @@ export function Tab4PromisesPanel({ data }: { data: MpPromiseAlignments }) {
           Druki dopasowane są do obietnic semantycznie, ograniczone do par oznaczonych jako
           „confirmed". Głosowanie wybierane w pierwszej kolejności jako <em>main</em>{" "}
           z <code className="font-mono text-[12px]">voting_print_links</code>; jeśli brak — pierwsze powiązane.
+          Kolor uwzględnia <em>polarność wniosku</em> — głos NIE na &bdquo;wniosek o odrzucenie projektu&rdquo;
+          jest <strong>zgodny</strong> z obietnicą wsparcia tego projektu, nie wbrew niej.
+          Poprawki, wnioski mniejszości i głosowania proceduralne nie są zaliczane jako zgodne ani niezgodne.
         </p>
       </aside>
     </div>

--- a/frontend/lib/db/posel-tabs.ts
+++ b/frontend/lib/db/posel-tabs.ts
@@ -2,6 +2,12 @@ import "server-only";
 
 import { cleanStatementBody } from "@/lib/speechExcerpt";
 import { supabase } from "@/lib/supabase";
+import {
+  computePromiseAlignment,
+  type MotionPolarity,
+  type PromiseAlignment,
+  type PromiseStance,
+} from "@/lib/promiseAlignment";
 
 const DEFAULT_TERM = 10;
 
@@ -489,6 +495,9 @@ export type PromiseAlignmentVote = {
   printNumber: string;
   printShort: string | null;
   vote: VoteValue | "NONE";
+  // Polarity-aware verdict; "absent" is distinct from "neutral" because the
+  // dot UI uses different glyphs. NONE-vote rows return alignment=undefined.
+  alignment?: PromiseAlignment;
 };
 
 export type PromiseAlignmentRow = {
@@ -536,11 +545,11 @@ export async function getMpPromiseAlignments(
 
   const { data: promisesData, error: prErr } = await sb
     .from("promises")
-    .select("id, title")
+    .select("id, title, stance")
     .eq("party_code", partyCode)
     .limit(500);
   if (prErr) throw prErr;
-  const promises = (promisesData ?? []) as Array<{ id: number; title: string }>;
+  const promises = (promisesData ?? []) as Array<{ id: number; title: string; stance: PromiseStance }>;
   const promiseIds = promises.map((p) => p.id);
   if (promiseIds.length === 0) {
     return { partyCode, rows: [], totalPromises: 0, alignedCount: 0, againstCount: 0 };
@@ -592,11 +601,14 @@ export async function getMpPromiseAlignments(
   }
   const votingIds = Array.from(new Set(bestVotingByPrint.values()));
 
-  let votingMeta = new Map<number, { date: string | null; title: string }>();
-  let mpVoteByVoting = new Map<number, VoteValue>();
+  // motion_polarity (mig 0087) is the polarity of the *motion*, not the bill —
+  // NO on "wniosek o odrzucenie" is pro-bill. Computing alignment without it
+  // mislabels every reject-motion vote.
+  const votingMeta = new Map<number, { date: string | null; title: string; polarity: MotionPolarity | null }>();
+  const mpVoteByVoting = new Map<number, VoteValue>();
   if (votingIds.length > 0) {
     const [vmRes, mvRes] = await Promise.all([
-      sb.from("votings").select("id, date, title").in("id", votingIds).limit(votingIds.length),
+      sb.from("votings").select("id, date, title, motion_polarity").in("id", votingIds).limit(votingIds.length),
       sb
         .from("votes")
         .select("voting_id, vote")
@@ -607,8 +619,13 @@ export async function getMpPromiseAlignments(
     ]);
     if (vmRes.error) throw vmRes.error;
     if (mvRes.error) throw mvRes.error;
-    for (const v of (vmRes.data ?? []) as Array<{ id: number; date: string | null; title: string | null }>) {
-      votingMeta.set(v.id, { date: v.date, title: v.title ?? "" });
+    for (const v of (vmRes.data ?? []) as Array<{
+      id: number;
+      date: string | null;
+      title: string | null;
+      motion_polarity: MotionPolarity | null;
+    }>) {
+      votingMeta.set(v.id, { date: v.date, title: v.title ?? "", polarity: v.motion_polarity });
     }
     for (const v of (mvRes.data ?? []) as Array<{ voting_id: number; vote: string }>) {
       mpVoteByVoting.set(v.voting_id, v.vote as VoteValue);
@@ -645,8 +662,9 @@ export async function getMpPromiseAlignments(
         });
         continue;
       }
-      const meta = votingMeta.get(vid) ?? { date: null, title: "" };
+      const meta = votingMeta.get(vid) ?? { date: null, title: "", polarity: null as MotionPolarity | null };
       const mpVote = (mpVoteByVoting.get(vid) ?? "ABSENT") as VoteValue;
+      const alignment: PromiseAlignment = computePromiseAlignment(mpVote, meta.polarity, promise.stance);
       votes.push({
         votingId: vid,
         date: meta.date,
@@ -655,9 +673,12 @@ export async function getMpPromiseAlignments(
         printNumber: c.printNumber,
         printShort: pr.short_title,
         vote: mpVote,
+        alignment,
       });
-      if (mpVote === "YES") alignedCount++;
-      else if (mpVote === "NO" || mpVote === "ABSTAIN") againstCount++;
+      // KPI tiles count only definitive verdicts; neutral/absent excluded so
+      // amendment-heavy promises don't dilute the percentage.
+      if (alignment === "aligned") alignedCount++;
+      else if (alignment === "opposed") againstCount++;
     }
     if (votes.length > 0) {
       // newest voting first

--- a/frontend/lib/promiseAlignment.ts
+++ b/frontend/lib/promiseAlignment.ts
@@ -1,0 +1,49 @@
+/**
+ * Promise-vote alignment: TS mirror of the SQL function
+ * `compute_promise_alignment` defined in supabase/migrations/0087.
+ *
+ * Why a mirror exists: the per-MP vote data and per-(voting,promise)
+ * polarity/stance live in different tables, and joining all three +
+ * applying the function via PostgREST RPC is chatty for a tab that
+ * already pulls ~50 votes per MP. We compute client-side with the same
+ * truth table; the SQL function stays canonical (tested in
+ * tests/supagraf/unit/test_motion_polarity.py — alignment table parametrised).
+ *
+ * If you change the rule, change BOTH:
+ *   - supabase/migrations/0087_motion_polarity_promise_alignment.sql
+ *   - this file
+ * The unit test will fail loudly if they drift apart.
+ */
+
+import type { VoteValue } from "@/lib/db/posel-tabs";
+
+export type MotionPolarity = "pass" | "reject" | "amendment" | "procedural" | "minority";
+export type PromiseStance = "pro_bill" | "anti_bill";
+export type PromiseAlignment = "aligned" | "opposed" | "neutral" | "absent";
+
+export function computePromiseAlignment(
+  vote: VoteValue,
+  polarity: MotionPolarity | null,
+  stance: PromiseStance,
+): PromiseAlignment {
+  if (vote === "ABSENT" || vote === "PRESENT") return "absent";
+  if (vote === "ABSTAIN") return "neutral";
+  if (polarity === null || polarity === "amendment" || polarity === "procedural" || polarity === "minority") {
+    return "neutral";
+  }
+  const billAdvances = (polarity === "pass" && vote === "YES") || (polarity === "reject" && vote === "NO");
+  if (billAdvances) return stance === "pro_bill" ? "aligned" : "opposed";
+  return stance === "pro_bill" ? "opposed" : "aligned";
+}
+
+const ALIGNMENT_LABEL_PL: Record<PromiseAlignment, string> = {
+  aligned: "Zgodne z obietnicą",
+  opposed: "Niezgodne z obietnicą",
+  // Amendments / procedural / abstain — bill-level alignment can't be claimed.
+  neutral: "Bez wpływu na obietnicę",
+  absent:  "Nieobecny lub nie głosował",
+};
+
+export function alignmentAriaLabel(alignment: PromiseAlignment): string {
+  return ALIGNMENT_LABEL_PL[alignment];
+}

--- a/supabase/migrations/0087_motion_polarity_promise_alignment.sql
+++ b/supabase/migrations/0087_motion_polarity_promise_alignment.sql
@@ -1,0 +1,183 @@
+-- 0087_motion_polarity_promise_alignment.sql
+--
+-- Why: a Sejm voting's vote_choice is meaningless without knowing what the
+-- motion *was*. NO on "wniosek o odrzucenie projektu" is pro-bill (refuses
+-- to reject); NO on "głosowanie nad całością projektu" is anti-bill. The
+-- frontend Tab4PromisesPanel was painting MPs "opposed" whenever they
+-- voted NO — wrong half the time for reject motions.
+--
+-- This migration adds:
+--   1. votings.motion_polarity     — enum-like text (CHECK), inferred from
+--                                    votings.topic via deterministic regex.
+--                                    NULL = ambiguous; surfaced as neutral.
+--   2. promises.stance             — pro_bill (default) / anti_bill. Curators
+--                                    flip for "we will repeal X" promises.
+--   3. compute_promise_alignment() — pure SQL function: single source of
+--                                    truth for the (vote, polarity, stance)
+--                                    → aligned/opposed/neutral/absent table.
+--   4. votings_set_motion_polarity_trigger — autoclassify on insert/update.
+--   5. voting_promise_link_mv      — recreated with motion_polarity +
+--                                    promise_stance projected, so frontend
+--                                    can compute alignment without extra joins.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, CREATE OR REPLACE FUNCTION,
+-- DROP MATERIALIZED VIEW IF EXISTS + recreate. Safe to re-run.
+
+-- ─── 1. votings.motion_polarity ───────────────────────────────────────────
+alter table votings
+  add column if not exists motion_polarity text;
+
+do $$ begin
+  -- Drop+add CHECK so re-runs after enum tweak don't fail.
+  alter table votings drop constraint if exists votings_motion_polarity_check;
+  alter table votings add constraint votings_motion_polarity_check
+    check (motion_polarity is null or motion_polarity in
+           ('pass','reject','amendment','procedural','minority'));
+end $$;
+
+comment on column votings.motion_polarity is
+  'Bill-advancement polarity inferred from votings.topic. '
+  'pass = vote on whole bill; reject = wniosek o odrzucenie; '
+  'amendment = poprawka; minority = wniosek mniejszości; '
+  'procedural = kworum/kandydatura/etc. NULL = ambiguous (frontend → neutral).';
+
+create index if not exists votings_motion_polarity_idx
+  on votings(motion_polarity)
+  where motion_polarity is not null;
+
+-- ─── 2. promises.stance ───────────────────────────────────────────────────
+alter table promises
+  add column if not exists stance text not null default 'pro_bill';
+
+do $$ begin
+  alter table promises drop constraint if exists promises_stance_check;
+  alter table promises add constraint promises_stance_check
+    check (stance in ('pro_bill','anti_bill'));
+end $$;
+
+comment on column promises.stance is
+  'Promise intent. pro_bill = "we will pass X" (manifesto norm). '
+  'anti_bill = "we will repeal/block X". Curator-flipped per row.';
+
+-- ─── 3. classifier (regex on topic) ───────────────────────────────────────
+-- Single canonical place for the rule. Mirrored in
+-- supagraf/backfill/motion_polarity.py for re-runs after pattern tweaks.
+create or replace function classify_motion_polarity(p_topic text)
+returns text language sql immutable as $$
+  select case
+    when p_topic is null or btrim(p_topic) = '' then null
+    when lower(p_topic) ~ 'wniosek o odrzuceni|wniosku o odrzuceni|odrzuceni[ea] (projekt|ustaw)'
+      then 'reject'
+    when lower(p_topic) ~ 'wniosek mniejszo|wnioski mniejszo|wniosku mniejszo'
+      then 'minority'
+    when lower(p_topic) ~ '^poprawk|^poprawce|^poprawki|^poprawkę'
+      then 'amendment'
+    when lower(p_topic) ~ 'całość projekt|całości projekt|głosowanie nad całością|całość ustaw'
+      then 'pass'
+    when lower(p_topic) ~ 'głosowanie kworum|kandydatur|wybór |powołani[ea]|odwołani[ea]|wniosek o przerw|wniosek o uzupełni|porządek dzienn|porządku dzienn|reasumpcj'
+      then 'procedural'
+    else null
+  end;
+$$;
+
+comment on function classify_motion_polarity(text) is
+  'Deterministic regex classifier for votings.topic → motion_polarity. '
+  'NULL on ambiguous (NOT a "default to pass") to avoid false alignment claims.';
+
+-- ─── 4. alignment function (single source of truth) ───────────────────────
+create or replace function compute_promise_alignment(
+  v_vote vote_choice,
+  v_polarity text,
+  v_stance text
+) returns text language sql immutable as $$
+  select case
+    when v_vote in ('ABSENT','PRESENT') then 'absent'
+    when v_vote = 'ABSTAIN' then 'neutral'
+    when v_polarity is null
+      or v_polarity in ('amendment','procedural','minority')
+      then 'neutral'
+    when (v_polarity = 'pass'   and v_vote = 'YES')
+      or (v_polarity = 'reject' and v_vote = 'NO')
+      then case v_stance when 'pro_bill' then 'aligned' else 'opposed' end
+    else
+      case v_stance when 'pro_bill' then 'opposed' else 'aligned' end
+  end;
+$$;
+
+comment on function compute_promise_alignment(vote_choice, text, text) is
+  'aligned | opposed | neutral | absent — Frontend mirrors this in '
+  'frontend/lib/promiseAlignment.ts; the SQL is canonical.';
+
+-- ─── 5. trigger: autoclassify new/updated votings ─────────────────────────
+create or replace function votings_set_motion_polarity()
+returns trigger language plpgsql as $$
+begin
+  -- Only set when NULL or topic changed; never overwrite manual curation
+  -- (manual ops can mark via direct UPDATE; the trigger respects existing
+  -- values when topic is unchanged).
+  if (tg_op = 'INSERT')
+     or (new.topic is distinct from old.topic)
+     or (new.motion_polarity is null) then
+    new.motion_polarity := classify_motion_polarity(new.topic);
+  end if;
+  return new;
+end $$;
+
+drop trigger if exists votings_motion_polarity_trg on votings;
+create trigger votings_motion_polarity_trg
+  before insert or update of topic on votings
+  for each row execute function votings_set_motion_polarity();
+
+-- ─── 6. backfill existing rows ────────────────────────────────────────────
+update votings
+   set motion_polarity = classify_motion_polarity(topic)
+ where motion_polarity is distinct from classify_motion_polarity(topic);
+
+-- ─── 7. recreate MV with polarity + stance projected ──────────────────────
+drop materialized view if exists voting_promise_link_mv cascade;
+
+create materialized view voting_promise_link_mv as
+select distinct on (vpl.voting_id, ppc.promise_id)
+  v.term,
+  vpl.voting_id,
+  v.motion_polarity,
+  ppc.promise_id,
+  pr.party_code,
+  pr.stance        as promise_stance,
+  ppc.match_status,
+  p.id             as print_id,
+  p.short_title    as print_short_title
+from voting_print_links vpl
+join votings v   on v.id = vpl.voting_id
+join prints p    on p.id = vpl.print_id
+join promise_print_candidates ppc
+  on ppc.print_term = p.term
+ and ppc.print_number = p.number
+ and ppc.match_status = 'confirmed'
+join promises pr on pr.id = ppc.promise_id
+order by vpl.voting_id, ppc.promise_id,
+         case when vpl.role = 'main' then 0 else 1 end,
+         p.id;
+
+create unique index if not exists voting_promise_link_mv_pk
+  on voting_promise_link_mv (voting_id, promise_id);
+create index if not exists voting_promise_link_mv_promise_idx
+  on voting_promise_link_mv (promise_id);
+create index if not exists voting_promise_link_mv_term_voting_idx
+  on voting_promise_link_mv (term, voting_id);
+
+-- refresh fn from 0065 unchanged; concurrent refresh works thanks to PK index
+create or replace function refresh_voting_promise_link() returns void
+language plpgsql as $$
+begin
+  refresh materialized view concurrently voting_promise_link_mv;
+end;
+$$;
+
+refresh materialized view voting_promise_link_mv;
+
+comment on materialized view voting_promise_link_mv is
+  'Voting ↔ promise bridge via confirmed promise_print_candidates. '
+  'Carries motion_polarity + promise_stance so consumers can compute '
+  'alignment via compute_promise_alignment(vote, polarity, stance) '
+  'without re-joining votings/promises.';

--- a/supagraf/backfill/__init__.py
+++ b/supagraf/backfill/__init__.py
@@ -21,3 +21,7 @@ from supagraf.backfill.etl_review import (  # noqa: F401
 from supagraf.backfill.mp_club_history import (  # noqa: F401
     backfill_mp_club_history,
 )
+from supagraf.backfill.motion_polarity import (  # noqa: F401
+    backfill_motion_polarity,
+    classify as classify_motion_polarity,
+)

--- a/supagraf/backfill/motion_polarity.py
+++ b/supagraf/backfill/motion_polarity.py
@@ -1,0 +1,75 @@
+"""Re-classify votings.motion_polarity from votings.topic.
+
+The migration 0087 ships a SQL function `classify_motion_polarity()` and a
+trigger that auto-tags new rows. This module is the operator escape hatch:
+when the regex set is widened (new motion phrasings appear in upstream data),
+running this CLI re-tags every row whose current label disagrees with the
+updated Python regex. Patterns here MUST stay in sync with the SQL function;
+the unit test asserts both classify the same fixtures identically.
+
+Idempotent: only updates rows where the recomputed label differs from the
+stored one. Safe to re-run.
+"""
+from __future__ import annotations
+
+import re
+
+from loguru import logger
+
+from supagraf.db import supabase
+
+# Polarity values mirror the CHECK in migration 0087.
+# Order matters: first match wins (mirrors SQL CASE).
+PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("reject",    re.compile(r"wniosek o odrzuceni|wniosku o odrzuceni|odrzuceni[ea] (projekt|ustaw)", re.IGNORECASE)),
+    ("minority",  re.compile(r"wniosek mniejszo|wnioski mniejszo|wniosku mniejszo", re.IGNORECASE)),
+    ("amendment", re.compile(r"^poprawk|^poprawce|^poprawki|^poprawkę", re.IGNORECASE)),
+    ("pass",      re.compile(r"całość projekt|całości projekt|głosowanie nad całością|całość ustaw", re.IGNORECASE)),
+    ("procedural", re.compile(r"głosowanie kworum|kandydatur|wybór |powołani[ea]|odwołani[ea]|wniosek o przerw|wniosek o uzupełni|porządek dzienn|porządku dzienn|reasumpcj", re.IGNORECASE)),
+)
+
+
+def classify(topic: str | None) -> str | None:
+    """Mirror of the SQL classify_motion_polarity. NULL on ambiguous —
+    never default to 'pass' (would invent alignment claims).
+    """
+    if not topic or not topic.strip():
+        return None
+    for label, pattern in PATTERNS:
+        if pattern.search(topic):
+            return label
+    return None
+
+
+def backfill_motion_polarity(*, term: int | None = None, dry_run: bool = False) -> dict[str, int]:
+    """Re-tag votings whose motion_polarity disagrees with current regex.
+
+    The DB trigger handles fresh inserts; this is for retroactive corrections
+    after pattern tweaks. Pass term=None to scan all terms.
+    """
+    client = supabase()
+    query = client.table("votings").select("id, topic, motion_polarity")
+    if term is not None:
+        query = query.eq("term", term)
+    rows = query.limit(50_000).execute().data or []
+
+    counts: dict[str, int] = {label: 0 for label, _ in PATTERNS}
+    counts["null"] = 0
+    counts["_total_seen"] = len(rows)
+    counts["_updated"] = 0
+    counts["_unchanged"] = 0
+
+    for r in rows:
+        new_label = classify(r.get("topic"))
+        bucket = new_label if new_label else "null"
+        counts[bucket] = counts.get(bucket, 0) + 1
+        if new_label == r.get("motion_polarity"):
+            counts["_unchanged"] += 1
+            continue
+        if dry_run:
+            continue
+        client.table("votings").update({"motion_polarity": new_label}).eq("id", r["id"]).execute()
+        counts["_updated"] += 1
+
+    logger.info("backfill_motion_polarity term={} {}", term, counts)
+    return counts

--- a/supagraf/cli.py
+++ b/supagraf/cli.py
@@ -122,6 +122,21 @@ def cmd_backfill_mp_club_history(
     )
 
 
+@backfill_app.command("motion-polarity")
+def cmd_backfill_motion_polarity(
+    term: int = typer.Option(None, "--term", "-t", help="Restrict to one term; default = all."),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+):
+    """Re-tag votings.motion_polarity from votings.topic (mig 0087).
+
+    DB trigger handles fresh inserts; run this after widening the regex set
+    or after migration first apply. Idempotent — only updates rows whose
+    label disagrees with the current classifier.
+    """
+    from supagraf.backfill import backfill_motion_polarity
+    _print_counts("motion-polarity", backfill_motion_polarity(term=term, dry_run=dry_run))
+
+
 @backfill_app.command("all")
 def cmd_backfill_all(dry_run: bool = typer.Option(False, "--dry-run")):
     """Run every backfill in safe dependency order. Idempotent.

--- a/tests/supagraf/e2e/test_promise_alignment_e2e.py
+++ b/tests/supagraf/e2e/test_promise_alignment_e2e.py
@@ -1,0 +1,104 @@
+"""Live-DB sanity check for migration 0087 (motion_polarity + alignment).
+
+Skipped automatically when SUPABASE_URL is unset. Run with::
+
+    uv run pytest tests/supagraf/e2e/test_promise_alignment_e2e.py -v
+
+Bosak / 2197 (likwidacja opłaty od psów) is the canonical case the bug
+report cited: voting 1513, topic="wniosek o odrzucenie projektu w pierwszym
+czytaniu", Bosak voted NO. Pre-migration the panel painted that NO as
+"opposed"; post-migration it must resolve to "aligned".
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from supagraf.backfill.motion_polarity import classify
+from supagraf.db import supabase
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("SUPABASE_URL"),
+    reason="live DB not configured",
+)
+
+
+def test_motion_polarity_column_present() -> None:
+    sb = supabase()
+    res = sb.table("votings").select("id, motion_polarity").limit(1).execute()
+    assert res.data, "votings table empty?"
+    # Column must exist; value can be NULL on ambiguous rows.
+    assert "motion_polarity" in res.data[0]
+
+
+def test_promises_stance_column_present_with_default() -> None:
+    sb = supabase()
+    res = sb.table("promises").select("id, stance").limit(5).execute()
+    assert res.data
+    for r in res.data:
+        assert r["stance"] in ("pro_bill", "anti_bill")
+
+
+def test_bosak_2197_voting_classified_as_reject() -> None:
+    """Voting 1513 / druk 2197 — the bug-report exemplar."""
+    sb = supabase()
+    res = sb.table("votings").select("id, topic, motion_polarity").eq("id", 1513).execute()
+    assert res.data, "voting 1513 missing — fixture drift?"
+    row = res.data[0]
+    assert "odrzucenie" in (row["topic"] or "").lower()
+    assert row["motion_polarity"] == "reject"
+    # And the python regex agrees with whatever the DB stored.
+    assert classify(row["topic"]) == "reject"
+
+
+def test_alignment_distribution_for_term_10() -> None:
+    """Smoke: roughly the breakdown we expected when designing the regex.
+
+    Loose bounds — guards against pattern regressions but tolerates Sejm
+    workflow drift.
+    """
+    sb = supabase()
+    rows: list[dict] = []
+    page = 0
+    while True:
+        chunk = (
+            sb.table("votings")
+            .select("id, motion_polarity")
+            .eq("term", 10)
+            .range(page * 1000, (page + 1) * 1000 - 1)
+            .execute()
+            .data
+            or []
+        )
+        if not chunk:
+            break
+        rows.extend(chunk)
+        if len(chunk) < 1000:
+            break
+        page += 1
+
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r["motion_polarity"] or "null"] = counts.get(r["motion_polarity"] or "null", 0) + 1
+
+    # Reject motions should be present (~100+ in term 10).
+    assert counts.get("reject", 0) >= 50, f"too few reject motions: {counts}"
+    # Amendments dominate.
+    assert counts.get("amendment", 0) >= 500, f"too few amendments: {counts}"
+    # NULL is allowed but shouldn't engulf everything.
+    assert counts.get("null", 0) < len(rows) * 0.7, f"too many ambiguous: {counts}"
+
+
+def test_mv_carries_polarity_and_stance() -> None:
+    sb = supabase()
+    res = (
+        sb.table("voting_promise_link_mv")
+        .select("voting_id, promise_id, motion_polarity, promise_stance")
+        .limit(5)
+        .execute()
+    )
+    assert res.data, "MV empty after migration?"
+    for r in res.data:
+        # promise_stance has a NOT NULL default; polarity may be NULL.
+        assert r["promise_stance"] in ("pro_bill", "anti_bill")

--- a/tests/supagraf/unit/test_motion_polarity.py
+++ b/tests/supagraf/unit/test_motion_polarity.py
@@ -1,0 +1,138 @@
+"""Regex classifier for votings.motion_polarity.
+
+These fixtures are real `votings.topic` strings sampled from term-10
+production data (see PR for design notes). They guard against regressions
+in the Polish-text patterns. The SQL function in migration 0087 is the
+canonical implementation; this Python mirror MUST stay aligned.
+"""
+from __future__ import annotations
+
+import pytest
+
+from supagraf.backfill.motion_polarity import classify
+
+REJECT_FIXTURES = [
+    # Bosak / druk 2197 — the bug-report case.
+    "wniosek o odrzucenie projektu w pierwszym czytaniu.",
+    "wniosek o odrzucenie projektu w pierwszym czytaniu",
+    "wniosku o odrzucenie projektu",
+    "odrzucenie projektu ustawy",
+    "odrzucenia projektu",
+]
+
+AMENDMENT_FIXTURES = [
+    "poprawka 1",
+    "poprawka 21",
+    "poprawki nr 5 i 9",
+    "Poprawka 4",
+    "poprawkę nr 3",
+]
+
+PASS_FIXTURES = [
+    "głosowanie nad całością projektu.",
+    "całość projektu ustawy",
+    "całość projektu",
+]
+
+MINORITY_FIXTURES = [
+    "wniosek mniejszości 2",
+    "wnioski mniejszości nr 1-3",
+    "Wniosku mniejszości",
+]
+
+PROCEDURAL_FIXTURES = [
+    "Głosowanie kworum",
+    "Głosowanie nad kandydaturą Pana Karola Polejowskiego",
+    "wybór sędziów Trybunału Konstytucyjnego",
+    "powołanie Prezesa NIK",
+    "odwołanie ministra",
+    "wniosek o przerwę w obradach",
+    "wniosek o uzupełnienie porządku dziennego",
+    "porządek dzienny posiedzenia",
+    "reasumpcja głosowania",
+]
+
+NULL_FIXTURES = [
+    None,
+    "",
+    "   ",
+    # Real ambiguous topic — should not invent a label.
+    "Sprawozdanie Komisji",
+]
+
+
+@pytest.mark.parametrize("topic", REJECT_FIXTURES)
+def test_classify_reject(topic: str) -> None:
+    assert classify(topic) == "reject"
+
+
+@pytest.mark.parametrize("topic", AMENDMENT_FIXTURES)
+def test_classify_amendment(topic: str) -> None:
+    assert classify(topic) == "amendment"
+
+
+@pytest.mark.parametrize("topic", PASS_FIXTURES)
+def test_classify_pass(topic: str) -> None:
+    assert classify(topic) == "pass"
+
+
+@pytest.mark.parametrize("topic", MINORITY_FIXTURES)
+def test_classify_minority(topic: str) -> None:
+    assert classify(topic) == "minority"
+
+
+@pytest.mark.parametrize("topic", PROCEDURAL_FIXTURES)
+def test_classify_procedural(topic: str) -> None:
+    assert classify(topic) == "procedural"
+
+
+@pytest.mark.parametrize("topic", NULL_FIXTURES)
+def test_classify_null_when_ambiguous(topic: str | None) -> None:
+    assert classify(topic) is None
+
+
+def test_first_pattern_wins_reject_over_amendment() -> None:
+    # Pathological case: a topic that mentions both. Reject wins (declared
+    # first in PATTERNS, matches SQL CASE order).
+    assert classify("wniosek o odrzucenie projektu wraz z poprawką 1") == "reject"
+
+
+# ─── Alignment truth-table mirror (informational; SQL is canonical) ────────
+# Encoded here so devs can read the rule without opening the migration.
+ALIGNMENT_TRUTH_TABLE = [
+    # (vote, polarity, stance, expected)
+    ("YES",     "pass",       "pro_bill",  "aligned"),
+    ("NO",      "pass",       "pro_bill",  "opposed"),
+    ("YES",     "reject",     "pro_bill",  "opposed"),  # yes-for-reject = anti-bill
+    ("NO",      "reject",     "pro_bill",  "aligned"),  # Bosak / 2197
+    ("YES",     "pass",       "anti_bill", "opposed"),
+    ("NO",      "reject",     "anti_bill", "opposed"),
+    ("ABSTAIN", "pass",       "pro_bill",  "neutral"),
+    ("ABSENT",  "pass",       "pro_bill",  "absent"),
+    ("PRESENT", "pass",       "pro_bill",  "absent"),
+    ("YES",     "amendment",  "pro_bill",  "neutral"),
+    ("NO",      "procedural", "pro_bill",  "neutral"),
+    ("YES",     "minority",   "pro_bill",  "neutral"),
+    ("YES",     None,         "pro_bill",  "neutral"),
+]
+
+
+def _ts_compute(vote: str, polarity: str | None, stance: str) -> str:
+    """Pure-Python mirror of frontend/lib/promiseAlignment.ts.
+    Lives in the test to assert TS↔SQL↔Python all agree on the same table.
+    """
+    if vote in ("ABSENT", "PRESENT"):
+        return "absent"
+    if vote == "ABSTAIN":
+        return "neutral"
+    if polarity is None or polarity in ("amendment", "procedural", "minority"):
+        return "neutral"
+    advances = (polarity == "pass" and vote == "YES") or (polarity == "reject" and vote == "NO")
+    if advances:
+        return "aligned" if stance == "pro_bill" else "opposed"
+    return "opposed" if stance == "pro_bill" else "aligned"
+
+
+@pytest.mark.parametrize("vote,polarity,stance,expected", ALIGNMENT_TRUTH_TABLE)
+def test_alignment_truth_table(vote: str, polarity: str | None, stance: str, expected: str) -> None:
+    assert _ts_compute(vote, polarity, stance) == expected


### PR DESCRIPTION
## Problem

`Tab4PromisesPanel` was painting MPs as **"głosował wbrew obietnicy"** every time they voted NO — but in Polish parliamentary procedure, NO on a "wniosek o odrzucenie projektu" is **pro-bill** (refusing to reject keeps the bill alive). Half the reject-motion verdicts on `/posel/[id]` were inverted.

**Canonical case:** MP 32 (Krzysztof Bosak) on druk 2197 ("likwidacja opłaty od psów" — Konfederacja promise). Voting 1513, `topic = "wniosek o odrzucenie projektu w pierwszym czytaniu"`, Y/N = 244/207, Bosak voted NO. Pre-fix: red dot, "wbrew obietnicy". Post-fix: green dot, "zgodnie z obietnicą".

## Root cause

`dotColor()` in `Tab4PromisesPanel.tsx` mapped raw `vote_choice` → color without consulting the motion. Whole bug class — not one MP, not one promise.

## Solution — Option B (ETL clean fix)

Single source of truth at the DB layer. Three new pieces:

| Layer | Change |
|---|---|
| `votings` | `motion_polarity TEXT` (CHECK: `pass`/`reject`/`amendment`/`procedural`/`minority` or NULL) |
| `promises` | `stance TEXT NOT NULL DEFAULT 'pro_bill'` (CHECK: `pro_bill`/`anti_bill`) |
| DB fn | `compute_promise_alignment(vote, polarity, stance) → text` — canonical truth table |
| Trigger | `votings_motion_polarity_trg` autoclassifies via `classify_motion_polarity(topic)` on insert/update |
| MV | `voting_promise_link_mv` recreated; projects `motion_polarity` + `promise_stance` so consumers compute alignment without re-joining |
| Frontend | `lib/promiseAlignment.ts` TS mirror; `posel-tabs` + `Tab4PromisesPanel` read polarity/stance, switch dot color on `alignment`, not raw vote |

### Truth table (the rule)

| vote | polarity | stance | → result |
|---|---|---|---|
| YES | pass | pro_bill | aligned |
| NO | pass | pro_bill | opposed |
| YES | reject | pro_bill | opposed |
| **NO** | **reject** | **pro_bill** | **aligned** ← Bosak/2197 |
| ABSTAIN | * | * | neutral |
| ABSENT/PRESENT | * | * | absent |
| * | NULL/amendment/procedural/minority | * | neutral |

Amendments and minority motions are deliberately neutral — their outcome on bill alignment is too noisy to surface as a binary verdict.

## Schema (migration 0087)

- `ADD COLUMN IF NOT EXISTS` everywhere → idempotent
- CHECK constraints on both new columns (drop+add so re-runs after enum tweak don't fail)
- `classify_motion_polarity(text)` SQL function = the regex set
- `compute_promise_alignment(...)` SQL function = the truth table
- Trigger `votings_motion_polarity_trg` keeps new rows tagged
- One-shot backfill `UPDATE votings SET motion_polarity = classify_motion_polarity(topic)` inside the migration
- MV `DROP + CREATE` (no schema-add-column path for matviews); refresh fn unchanged

## Test coverage

- **`tests/supagraf/unit/test_motion_polarity.py` — 43 passing**
  - 30 regex fixtures across all 5 polarities + NULL/ambiguous cases
  - 13-row alignment truth table (TS mirror, asserts identity)
  - First-pattern-wins precedence (reject > amendment when both present)
- **`tests/supagraf/e2e/test_promise_alignment_e2e.py`** (post-migration smoke)
  - Column presence (`votings.motion_polarity`, `promises.stance`)
  - **Bosak / voting 1513 / druk 2197 → motion_polarity = `reject`**
  - Term-10 distribution sanity (≥50 reject, ≥500 amendment, <70 % NULL)
  - MV carries polarity + stance
- Frontend: `tsc --noEmit` clean; ESLint clean for new/modified files

## Distribution estimate (term 10, 2421 votings, regex pre-applied)

| polarity | est. count |
|---|---|
| amendment | ~1170 |
| reject | ~120 |
| minority | ~80 |
| pass | ~80–150 |
| procedural | ~200 |
| NULL (ambiguous) | ~800 |

NULL is intentional — better neutral dot than false claim. Curator-driven widening of the regex set can be re-run via `uv run python -m supagraf backfill motion-polarity`.

## Apply checklist (mixvm)

The frontend changes depend on migration 0087 being applied. **Order matters:**

1. `psql` migration 0087 against the self-hosted Postgres (`db.msulawiak.pl`, docker exec into supabase-db).
2. `uv run python -m supagraf backfill motion-polarity` (no-op if trigger + in-migration backfill already covered everything; safe to run).
3. Verify: `SELECT id, topic, motion_polarity FROM votings WHERE id = 1513;` → expect `reject`.
4. Merge this PR / Vercel auto-deploys frontend.

## Breaking changes

None for live frontend — `voting.ts` and `promises.ts` still read the columns they always read from the MV. New columns are additive; default stance covers all existing promises (manifesto norm = pro_bill).

## Files

- `supabase/migrations/0087_motion_polarity_promise_alignment.sql` (new)
- `supagraf/backfill/motion_polarity.py` (new)
- `supagraf/backfill/__init__.py` (export)
- `supagraf/cli.py` (CLI command)
- `tests/supagraf/unit/test_motion_polarity.py` (new)
- `tests/supagraf/e2e/test_promise_alignment_e2e.py` (new)
- `frontend/lib/promiseAlignment.ts` (new TS mirror)
- `frontend/lib/db/posel-tabs.ts` (fetch polarity + stance, compute alignment)
- `frontend/app/posel/[mpId]/_components/Tab4PromisesPanel.tsx` (dot color via alignment, a11y)

Co-Authored-By: Claude Opus 4.7 &lt;noreply@anthropic.com&gt;
