### PR TITLE
fix(frontend/voting): polarity-aware bill outcome (closes #25)

### DIFF
--- a/frontend/app/druk/[term]/[number]/page.tsx
+++ b/frontend/app/druk/[term]/[number]/page.tsx
@@ -11,6 +11,7 @@ import { VotingRow } from "@/components/voting/VotingRow";
 import { PrintCard } from "@/components/print/PrintCard";
 import { HemicycleChart } from "@/components/tygodnik/HemicycleChart";
 import { NotFoundPage } from "@/components/chrome/NotFoundPage";
+import { computeBillOutcome, verdictChipLabel } from "@/lib/voting/bill_outcome";
 
 
 export async function generateMetadata({
@@ -246,7 +247,13 @@ export default async function DrukPage({
                 </div>
                 <ul className="font-sans text-[13px]">
                   {relatedVotings.map((v) => {
-                    const passed = v.yes > v.no;
+                    // Motion-level outcome (yes >= majority_votes) — drives
+                    // bill-level chip via polarity. When majority_votes is
+                    // missing fall back to yes>no (legacy heuristic).
+                    const motionPassed = v.majorityVotes != null
+                      ? v.yes >= v.majorityVotes
+                      : v.yes > v.no;
+                    const billOutcome = computeBillOutcome(v.motionPolarity, motionPassed);
                     const isFinal = v.role === "main";
                     // Compose title: "Pos. N · głos. N — title". The leading
                     // "Pos./głos." identifier remains valuable as an internal
@@ -254,6 +261,16 @@ export default async function DrukPage({
                     const headline = v.title
                       ? `Pos. ${v.sitting} · głos. ${v.votingNumber} — ${v.title}`
                       : `Pos. ${v.sitting} · głos. ${v.votingNumber}`;
+                    // Verdict chip semantics:
+                    //   - "passed":        bill advanced — chip green
+                    //   - "rejected":      bill rejected — chip red
+                    //   - "continues":     reject-motion lost — chip green
+                    //                      (bill survives), label "projekt dalej"
+                    //   - "indeterminate": vote tells us nothing about bill
+                    //                      status; render motion-level pass/fail.
+                    const verdict = billOutcome === "indeterminate"
+                      ? { label: motionPassed ? "wniosek przyj." : "wniosek odrzuc.", passed: motionPassed }
+                      : { label: verdictChipLabel(billOutcome), passed: billOutcome === "passed" || billOutcome === "continues" };
                     return (
                       <VotingRow
                         key={v.votingId}
@@ -264,7 +281,7 @@ export default async function DrukPage({
                         no={v.no}
                         abstain={v.abstain}
                         badge={{ label: ROLE_LABEL[v.role] ?? v.role }}
-                        verdict={{ label: passed ? "przyjęte" : "odrzuc.", passed }}
+                        verdict={verdict}
                         isFinal={isFinal}
                       />
                     );

--- a/frontend/app/glosowanie/[id]/page.tsx
+++ b/frontend/app/glosowanie/[id]/page.tsx
@@ -71,7 +71,7 @@ export default async function VotingDetailPage({
         }}
         term={header.term}
       />
-      <WhatsNextTimeline stages={predictedStages} promiseLink={promiseLink} passed={passed} />
+      <WhatsNextTimeline stages={predictedStages} promiseLink={promiseLink} passed={passed} motionPolarity={header.motion_polarity} />
       <VotingSources
         header={header}
         linkedPrint={linkedPrint}

--- a/frontend/components/voting/WhatsNextTimeline.tsx
+++ b/frontend/components/voting/WhatsNextTimeline.tsx
@@ -1,11 +1,17 @@
 import Link from "next/link";
 import type { PredictedStage } from "@/lib/voting/predict_stages";
+import { computeBillOutcome, billAdvancesToSenate, type BillOutcome } from "@/lib/voting/bill_outcome";
+import type { MotionPolarity } from "@/lib/promiseAlignment";
 import type { VotingPageData } from "@/lib/db/voting";
 
 type Props = {
   stages: PredictedStage[];
   promiseLink: VotingPageData["promiseLink"];
   passed: boolean;
+  // Issue #25: when this vote is a procedural motion (wniosek o odrzucenie,
+  // poprawka, etc.) the bill-level outcome diverges from `passed`. Optional
+  // for back-compat; falls back to legacy `passed`-only copy when omitted.
+  motionPolarity?: MotionPolarity | null;
 };
 
 const PL_MONTHS = [
@@ -177,12 +183,39 @@ function StageItem({ stage }: { stage: PredictedStage }) {
   );
 }
 
+const CLOSED_COPY: Record<Exclude<BillOutcome, "passed">, { subtitle: string; line: string }> = {
+  rejected: {
+    subtitle: "proces zamknięty",
+    line: "Ustawa odrzucona — proces zamknięty.",
+  },
+  continues: {
+    // Failed "wniosek o odrzucenie" — bill survives and goes to committee.
+    // Senate/President timeline doesn't apply yet; show why the timeline
+    // stops here instead of pretending the law was rejected.
+    subtitle: "projekt wraca do dalszych prac",
+    line: "Wniosek o odrzucenie nie uzyskał większości — projekt skierowany do dalszej pracy w komisji. Dalsze etapy zostaną wyznaczone po kolejnych głosowaniach.",
+  },
+  indeterminate: {
+    subtitle: "głosowanie proceduralne",
+    line: "Głosowanie nad wnioskiem proceduralnym — etap projektu w Sejmie bez zmian.",
+  },
+};
+
 export default function WhatsNextTimeline({
   stages,
   promiseLink,
   passed,
+  motionPolarity,
 }: Props) {
-  if (!passed) {
+  const outcome: BillOutcome =
+    motionPolarity === undefined
+      ? (passed ? "passed" : "rejected")
+      : computeBillOutcome(motionPolarity, passed);
+
+  if (!billAdvancesToSenate(outcome)) {
+    // `outcome` here is narrowed: billAdvancesToSenate is true only for "passed",
+    // so this branch is "rejected" | "continues" | "indeterminate".
+    const copy = CLOSED_COPY[outcome as Exclude<BillOutcome, "passed">];
     return (
       <section
         className="px-4 sm:px-8 md:px-14 py-12 sm:py-16"
@@ -194,7 +227,7 @@ export default function WhatsNextTimeline({
           <SectionHead
             label="V"
             title="Co dalej z tą ustawą"
-            subtitle="proces zamknięty"
+            subtitle={copy.subtitle}
           />
           <p
             className="font-serif italic m-0"
@@ -204,7 +237,7 @@ export default function WhatsNextTimeline({
               color: "var(--secondary-foreground)",
             }}
           >
-            Ustawa odrzucona — proces zamknięty.
+            {copy.line}
           </p>
         </div>
       </section>

--- a/frontend/lib/db/prints.ts
+++ b/frontend/lib/db/prints.ts
@@ -133,6 +133,10 @@ export type LinkedVoting = {
   no: number;
   abstain: number;
   notParticipating: number;
+  majorityVotes: number | null;
+  // Polarity drives the verdict chip on /druk pages — see issue #25 (a failed
+  // "wniosek o odrzucenie" must NOT render as "ustawa odrzucona").
+  motionPolarity: import("@/lib/promiseAlignment").MotionPolarity | null;
 };
 
 export type ClubTally = {
@@ -345,7 +349,7 @@ export async function getPrint(term: number, number: string): Promise<PrintWithS
   };
   const { data: linkedRows } = await sb
     .from("voting_print_links")
-    .select("voting_id, role, votings:voting_id(id, term, sitting, sitting_day, voting_number, date, title, yes, no, abstain, not_participating)")
+    .select("voting_id, role, votings:voting_id(id, term, sitting, sitting_day, voting_number, date, title, yes, no, abstain, not_participating, majority_votes, motion_polarity)")
     .eq("print_id", printId);
   let mainVoting: LinkedVoting | null = null;
   let relatedVotings: LinkedVoting[] = [];
@@ -374,6 +378,8 @@ export async function getPrint(term: number, number: string): Promise<PrintWithS
       no: (v.no as number) ?? 0,
       abstain: (v.abstain as number) ?? 0,
       notParticipating: (v.not_participating as number) ?? 0,
+      majorityVotes: (v.majority_votes as number | null) ?? null,
+      motionPolarity: (v.motion_polarity as LinkedVoting["motionPolarity"]) ?? null,
     }));
     if (relatedVotings.length > 0) mainVoting = relatedVotings[0];
   }

--- a/frontend/lib/db/voting.ts
+++ b/frontend/lib/db/voting.ts
@@ -20,6 +20,9 @@ export type VotingHeader = {
   majority_votes: number | null;
   present: number | null;
   topic: string | null;
+  // Classifier label from `classify_motion_polarity()` (migration 0087).
+  // Drives polarity-aware timeline copy on /glosowanie/[id] — see issue #25.
+  motion_polarity: import("@/lib/promiseAlignment").MotionPolarity | null;
 };
 
 export type ClubTallyRow = {
@@ -36,7 +39,7 @@ export async function getVotingHeader(votingId: number): Promise<VotingHeader | 
   const sb = supabase();
   const { data, error } = await sb
     .from("votings")
-    .select("id, term, voting_number, title, date, yes, no, abstain, not_participating, total_voted, sitting, sitting_day, majority_type, majority_votes, present, topic")
+    .select("id, term, voting_number, title, date, yes, no, abstain, not_participating, total_voted, sitting, sitting_day, majority_type, majority_votes, present, topic, motion_polarity")
     .eq("id", votingId)
     .maybeSingle();
   if (error) throw error;
@@ -58,6 +61,7 @@ export async function getVotingHeader(votingId: number): Promise<VotingHeader | 
     majority_votes: (data.majority_votes as number) ?? null,
     present: (data.present as number) ?? null,
     topic: (data.topic as string) ?? null,
+    motion_polarity: (data.motion_polarity as VotingHeader["motion_polarity"]) ?? null,
   };
 }
 
@@ -412,9 +416,10 @@ export async function getVotingPageData(votingId: number): Promise<VotingPageDat
       presidentSignatureDate: byType.PresidentSignature ? new Date(byType.PresidentSignature) : null,
       promulgationDate: null, // Wired below from acts
       passed,
+      motionPolarity: header.motion_polarity,
     });
   } else {
-    predictedStages = predictStages({ sejmVoteDate: new Date(header.date), passed });
+    predictedStages = predictStages({ sejmVoteDate: new Date(header.date), passed, motionPolarity: header.motion_polarity });
   }
 
   // ─── Promise link via voting_promise_link_mv (E3) ───

--- a/frontend/lib/voting/bill_outcome.ts
+++ b/frontend/lib/voting/bill_outcome.ts
@@ -1,0 +1,65 @@
+/**
+ * Bill-outcome resolver — maps (motion polarity, motion vote result) to the
+ * bill-level status that should appear on the timeline / status chip.
+ *
+ * Issue #25: print 10/2449 page rendered "ustawa odrzucona" even though the
+ * only recorded Sejm vote was a FAILED "wniosek o odrzucenie projektu" — i.e.
+ * the motion-to-reject lost, so the bill SURVIVES and goes to committee. The
+ * old code in predict_stages.ts mapped `passed=false` (motion outcome) directly
+ * to "ustawa odrzucona" regardless of what the motion was about.
+ *
+ * Canonical truth table mirrored in:
+ *   tests/supagraf/unit/test_bill_outcome.py   (parametrised real-case fixtures)
+ *   frontend/scripts/test_bill_outcome.mjs     (runnable TS-side validator)
+ *
+ * If you change this, change BOTH the Python mirror and the .mjs validator —
+ * the tests will diverge otherwise.
+ */
+
+import type { MotionPolarity } from "@/lib/promiseAlignment";
+
+export type BillOutcome = "passed" | "rejected" | "continues" | "indeterminate";
+
+export function computeBillOutcome(
+  polarity: MotionPolarity | null,
+  motionPassed: boolean,
+): BillOutcome {
+  if (polarity === "pass") return motionPassed ? "passed" : "rejected";
+  if (polarity === "reject") return motionPassed ? "rejected" : "continues";
+  // amendment / minority / procedural / unclassified — never invent a bill claim.
+  return "indeterminate";
+}
+
+const LABEL_PL: Record<BillOutcome, string> = {
+  passed: "ustawa przyjęta w trzecim czytaniu",
+  rejected: "ustawa odrzucona",
+  continues: "wniosek o odrzucenie odrzucony — projekt skierowany do dalszej pracy",
+  indeterminate: "głosowanie nad wnioskiem proceduralnym — etap projektu bez zmian",
+};
+
+export function billOutcomeLabel(outcome: BillOutcome): string {
+  return LABEL_PL[outcome];
+}
+
+/** Short chip label for VotingRow.verdict on /druk pages. */
+const VERDICT_LABEL_PL: Record<BillOutcome, string> = {
+  passed: "ustawa przyjęta",
+  rejected: "ustawa odrzucona",
+  continues: "projekt dalej",
+  indeterminate: "—",
+};
+
+export function verdictChipLabel(outcome: BillOutcome): string {
+  return VERDICT_LABEL_PL[outcome];
+}
+
+/**
+ * Whether the bill timeline continues past the Sejm vote.
+ * - "passed":      yes — render Senate / Prezydent / Dz.U. stages
+ * - "rejected":    no  — terminal
+ * - "continues":   no  — bill goes back to committee, not to Senate
+ * - "indeterminate": no — this vote alone doesn't move the bill out of Sejm
+ */
+export function billAdvancesToSenate(outcome: BillOutcome): boolean {
+  return outcome === "passed";
+}

--- a/frontend/lib/voting/predict_stages.ts
+++ b/frontend/lib/voting/predict_stages.ts
@@ -1,3 +1,6 @@
+import { computeBillOutcome, billOutcomeLabel, billAdvancesToSenate, type BillOutcome } from "./bill_outcome";
+import type { MotionPolarity } from "@/lib/promiseAlignment";
+
 // Predicted legislative timeline for a Sejm-passed law.
 //
 // Validated against term-10 historical processes (BILL only, n=29-18 per
@@ -52,24 +55,50 @@ export type PredictInput = {
   presidentSignatureDate?: Date | null;
   promulgationDate?: Date | null;
   passed: boolean;
+  // Motion polarity for this specific vote (issue #25). When provided the
+  // stage label reflects bill-level outcome (a failed "wniosek o odrzucenie"
+  // means the bill CONTINUES — not "ustawa odrzucona"). When omitted the
+  // function falls back to legacy `passed`-only semantics for callers that
+  // haven't been wired yet.
+  motionPolarity?: MotionPolarity | null;
 };
 
+function sejmStageDetail(outcome: BillOutcome): string {
+  return billOutcomeLabel(outcome);
+}
+
+function sejmStageLabel(outcome: BillOutcome): string {
+  if (outcome === "passed") return "Sejm uchwalił";
+  if (outcome === "rejected") return "Sejm odrzucił";
+  if (outcome === "continues") return "Sejm: I czytanie";
+  return "Głosowanie w Sejmie";
+}
+
 export function predictStages(input: PredictInput): PredictedStage[] {
-  const { sejmVoteDate, senatePositionDate, toPresidentDate, presidentSignatureDate, promulgationDate, passed } = input;
+  const { sejmVoteDate, senatePositionDate, toPresidentDate, presidentSignatureDate, promulgationDate, passed, motionPolarity } = input;
+
+  // Resolve bill-level outcome. Without polarity, mimic the legacy boolean so
+  // unmigrated callers keep working — but produce a fresh BillOutcome so the
+  // downstream label/branch logic stays uniform.
+  const outcome: BillOutcome =
+    motionPolarity === undefined
+      ? (passed ? "passed" : "rejected")
+      : computeBillOutcome(motionPolarity, passed);
 
   // Stage 1 — Sejm vote (always known, always past).
   const stages: PredictedStage[] = [
     {
       key: "sejm",
-      label: "Sejm uchwalił",
-      detail: passed ? "ustawa przyjęta w trzecim czytaniu" : "ustawa odrzucona",
+      label: sejmStageLabel(outcome),
+      detail: sejmStageDetail(outcome),
       expectedDate: sejmVoteDate,
       deadlineDate: sejmVoteDate,
-      current: !passed, // if rejected, this is the terminal stage
+      // Sejm stage is terminal unless the bill actually moves to Senate.
+      current: !billAdvancesToSenate(outcome),
     },
   ];
 
-  if (!passed) return stages;
+  if (!billAdvancesToSenate(outcome)) return stages;
 
   // Stage 2 — Senate. No point estimate (gap is 0–26d in observed data).
   const senateActual = senatePositionDate ?? null;

--- a/frontend/scripts/test_bill_outcome.mjs
+++ b/frontend/scripts/test_bill_outcome.mjs
@@ -1,0 +1,125 @@
+// Validate bill-outcome truth table against REAL term-10 production data.
+//
+// Issue #25: print 10/2449 rendered "ustawa odrzucona" because the only Sejm
+// vote (1517) was a "wniosek o odrzucenie" that FAILED — the old predict_stages
+// logic mapped that to "law rejected" when in fact the bill survives and goes
+// to committee.
+//
+// This harness:
+//   1. Fetches a representative cohort of `votings` rows by motion_polarity.
+//   2. Applies the TS-mirrored truth table client-side.
+//   3. Asserts each row produces the expected BillOutcome.
+//
+// Run: `node frontend/scripts/test_bill_outcome.mjs`
+// Exits non-zero on any mismatch; CI-friendly.
+//
+// Production code lives in frontend/lib/voting/bill_outcome.ts — keep this
+// mirror in sync (the same way frontend/scripts/test_voting_stages_prediction.mjs
+// mirrors predict_stages constants).
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const envPath = join(ROOT, "..", ".env.local");
+try {
+  const envText = readFileSync(envPath, "utf8");
+  for (const line of envText.split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2].replace(/^["']|["']$/g, "");
+  }
+} catch {
+  // .env.local optional — env may already be exported.
+}
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY =
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_PUBLISHABLE_KEY ||
+  process.env.SUPABASE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Set SUPABASE_URL + SUPABASE_(ANON|KEY) in env or frontend/.env.local");
+  process.exit(2);
+}
+
+// ── TS mirror (must match frontend/lib/voting/bill_outcome.ts) ────────────────
+function computeBillOutcome(polarity, motionPassed) {
+  if (polarity === "pass") return motionPassed ? "passed" : "rejected";
+  if (polarity === "reject") return motionPassed ? "rejected" : "continues";
+  return "indeterminate";
+}
+
+function motionPassed(row) {
+  // Matches frontend/lib/db/voting.ts isPassed():
+  //   majority_votes is the precomputed threshold; fallback to yes>no.
+  if (row.majority_votes != null) return row.yes >= row.majority_votes;
+  return row.yes > row.no;
+}
+
+function expectedOutcome(row) {
+  const passed = motionPassed(row);
+  return computeBillOutcome(row.motion_polarity, passed);
+}
+
+// ── Curated real fixtures (mirror of tests/supagraf/unit/test_bill_outcome.py) ─
+// voting_id → expected BillOutcome. These IDs were sampled 2026-05-13 from
+// production. Adjust only when the underlying tally or polarity changes.
+const EXPECTED = new Map([
+  // reject-motion failed → bill continues (issue #25 bug case + peers)
+  [1517, "continues"], [446, "continues"], [55, "continues"], [58, "continues"],
+  [60, "continues"], [77, "continues"], [108, "continues"], [151, "continues"],
+  [207, "continues"], [214, "continues"], [216, "continues"],
+  // reject-motion passed → bill rejected
+  [65, "rejected"], [147, "rejected"], [148, "rejected"], [232, "rejected"],
+  [1148, "rejected"], [1513, "rejected"], [2024, "rejected"],
+  // third-reading pass succeeded → bill passed
+  [299, "passed"], [527, "passed"], [579, "passed"],
+  [774, "passed"], [899, "passed"], [1113, "passed"],
+  // third-reading pass failed → bill rejected
+  [1978, "rejected"],
+  // amendment / minority / procedural / null → indeterminate
+  [136, "indeterminate"], [135, "indeterminate"],
+  [900, "indeterminate"], [935, "indeterminate"],
+  [44, "indeterminate"], [157, "indeterminate"],
+  [20, "indeterminate"],
+]);
+
+async function fetchVoting(id) {
+  const url = `${SUPABASE_URL}/rest/v1/votings?id=eq.${id}&select=id,topic,yes,no,majority_votes,motion_polarity`;
+  const res = await fetch(url, {
+    headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` },
+  });
+  if (!res.ok) throw new Error(`fetch ${id} failed: ${res.status} ${await res.text()}`);
+  const rows = await res.json();
+  return rows[0] ?? null;
+}
+
+let failures = 0;
+let checked = 0;
+for (const [id, expected] of EXPECTED) {
+  const row = await fetchVoting(id);
+  if (!row) {
+    console.error(`✗ voting ${id} missing in DB`);
+    failures++;
+    continue;
+  }
+  const actual = expectedOutcome(row);
+  checked++;
+  if (actual !== expected) {
+    failures++;
+    console.error(
+      `✗ voting ${id} polarity=${row.motion_polarity} yes=${row.yes}/no=${row.no} ` +
+      `maj=${row.majority_votes} → got ${actual}, expected ${expected}\n` +
+      `    topic: ${row.topic}`
+    );
+  } else {
+    console.log(`✓ voting ${id} [${row.motion_polarity ?? "null"}] → ${actual}`);
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} / ${checked} mismatches — truth table broken.`);
+  process.exit(1);
+}
+console.log(`\n${checked} real-case fixtures validated.`);

--- a/tests/supagraf/unit/test_bill_outcome.py
+++ b/tests/supagraf/unit/test_bill_outcome.py
@@ -1,0 +1,197 @@
+"""Bill-outcome truth table — from motion_polarity + per-vote pass/fail.
+
+Issue #25: print 10/2449 page shows "ustawa odrzucona" even though the only
+recorded Sejm vote was a failed "wniosek o odrzucenie" — i.e. the motion to
+reject the bill lost, so the bill SURVIVES. The old `predictStages` mapped
+`processes.passed=false` directly to the "ustawa odrzucona" label without
+considering what the underlying motion was actually about.
+
+The truth table:
+
+    polarity   motion-passed   bill outcome    rendered as
+    ──────────────────────────────────────────────────────
+    pass       true            passed          "ustawa przyjęta w trzecim czytaniu"
+    pass       false           rejected        "ustawa odrzucona w trzecim czytaniu"
+    reject     true            rejected        "ustawa odrzucona"
+    reject     false           continues       "wniosek o odrzucenie odrzucony — projekt skierowany dalej"  ← BUG CASE
+    amendment  any             indeterminate   per-vote chip only — no bill claim
+    minority   any             indeterminate
+    procedural any             indeterminate
+    null       any             indeterminate
+
+This file is the canonical truth table. Mirror:
+    - frontend/lib/voting/bill_outcome.ts  (production)
+    - frontend/scripts/test_bill_outcome.mjs  (TS validator)
+
+Fixtures are real `votings` rows pulled 2026-05-13 from db.msulawiak.pl.
+Do not synthesize — citizen-review bugs come from real-world phrasings, not
+fixtures invented by the author.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+
+BillOutcome = Literal["passed", "rejected", "continues", "indeterminate"]
+MotionPolarity = Literal["pass", "reject", "amendment", "minority", "procedural"] | None
+
+
+# ─── Canonical computation (Python; TS mirror lives at frontend/lib/voting/bill_outcome.ts) ──
+
+def compute_bill_outcome(polarity: MotionPolarity, motion_passed: bool) -> BillOutcome:
+    """Map (motion polarity, motion vote outcome) → bill-level status.
+
+    Returns "indeterminate" when this single vote can't legitimately claim a
+    bill-level outcome — never guess (the UI must fall back to per-vote copy).
+    """
+    if polarity == "pass":
+        return "passed" if motion_passed else "rejected"
+    if polarity == "reject":
+        return "rejected" if motion_passed else "continues"
+    return "indeterminate"
+
+
+def bill_outcome_label(outcome: BillOutcome) -> str:
+    """Polish copy for the bill-level outcome chip on the timeline."""
+    if outcome == "passed":
+        return "ustawa przyjęta w trzecim czytaniu"
+    if outcome == "rejected":
+        return "ustawa odrzucona"
+    if outcome == "continues":
+        return "wniosek o odrzucenie odrzucony — projekt skierowany do dalszej pracy"
+    return "głosowanie nad wnioskiem proceduralnym — etap projektu bez zmian"
+
+
+# ─── Real fixtures sourced from production DB (term 10, fetched 2026-05-13) ──
+# Each row: (voting_id, polarity, yes, no, majority_votes, expected_outcome, topic).
+# voting_id is informational — lets a reviewer pull the row from Supabase to
+# verify the tally. Tests assert (polarity, motion_passed) → outcome, where
+# motion_passed = yes >= majority_votes.
+
+REAL_FIXTURES: list[tuple[int, MotionPolarity, int, int, int, BillOutcome, str]] = [
+    # ── reject-motion FAILED → bill continues (the user-reported #25 bug case) ──
+    (1517, "reject", 201, 242, 243, "continues",
+     "wniosek o odrzucenie projektu w pierwszym czytaniu."),  # druk 10/2449 (Prawo oświatowe)
+    (446,  "reject", 188, 228, 229, "continues",
+     "wniosek o odrzucenie projektu w pierwszym czytaniu."),  # druk 1424 (rynek kryptoaktywów)
+    (55,   "reject", 203, 223, 224, "continues",
+     "wniosek o odrzucenie w całości projektu."),             # druk 923 (wybory prezydenckie)
+    (58,   "reject", 204, 240, 241, "continues",
+     "wniosek o odrzucenie w całości projektu."),             # druk 926 (wykonywanie mandatu)
+    (60,   "reject", 204, 240, 241, "continues",
+     "wniosek o odrzucenie w całości projektu."),             # druk 906 (Prokuratura Europejska)
+    (77,   "reject", 132, 218, 219, "continues",
+     "wniosek o odrzucenie w całości projektu."),             # druk 956 (biokomponenty)
+    (108,  "reject",  30, 394, 395, "continues",
+     "wniosek o odrzucenie w całości projektu."),             # druk 924 (ochrona cudzoziemców)
+    (151,  "reject", 179, 251, 252, "continues",
+     "wniosek o odrzucenie projektu w pierwszym czytaniu."),  # Rada Ministrów
+    (207,  "reject",  26, 234, 235, "continues",
+     "wniosek o odrzucenie w całości projektu."),             # NIW
+    (214,  "reject", 195, 235, 236, "continues",
+     "wniosek o odrzucenie w całości projektu."),             # ochrona środowiska
+    (216,  "reject", 194, 234, 235, "continues",
+     "wniosek o odrzucenie w całości projektu."),             # drogi publiczne
+    # ── reject-motion PASSED → bill genuinely rejected ──
+    (65,   "reject", 237, 188, 189, "rejected",
+     "wniosek o odrzucenie projektu w pierwszym czytaniu."),  # druk 962 (ceny energii)
+    (147,  "reject", 238, 193, 194, "rejected",
+     "wniosek o odrzucenie projektu w pierwszym czytaniu."),  # Kodeks karny
+    (148,  "reject", 241, 194, 195, "rejected",
+     "wniosek o odrzucenie projektu w pierwszym czytaniu."),  # podatek od spadków
+    (232,  "reject", 233, 187, 188, "rejected",
+     "wniosek o odrzucenie projektu w pierwszym czytaniu."),  # zwolnienie p...
+    (1148, "reject", 240, 200, 201, "rejected",
+     "wniosek o odrzucenie projektu w pierwszym czytaniu."),  # obywatelstwo polskie
+    (1513, "reject", 244, 207, 208, "rejected",
+     "wniosek o odrzucenie projektu w pierwszym czytaniu."),  # opłaty lokalne (psy)
+    (2024, "reject", 244, 198, 199, "rejected",
+     "wniosek o odrzucenie projektu w pierwszym czytaniu."),  # prezydencki projekt
+    # ── third-reading PASS-motion succeeded → bill passed ──
+    (299,  "pass",   415,   0,   1, "passed",
+     "głosowanie nad całością projektu."),                    # repatriacja
+    (527,  "pass",   430,   0,   1, "passed",
+     "głosowanie nad całością projektu."),                    # Karta Nauczyciela
+    (579,  "pass",   410,   0,   1, "passed",
+     "głosowanie nad całością projektu."),                    # fundusz sołecki
+    (774,  "pass",   339,  78,  79, "passed",
+     "głosowanie nad całością projektu."),                    # ochrona zwierząt
+    (899,  "pass",   434,   3,   4, "passed",
+     "głosowanie nad całością projektu."),                    # podatek akcyzowy
+    (1113, "pass",   241, 183, 184, "passed",
+     "głosowanie nad całością projektu."),                    # rynek kryptoaktywów (final reading)
+    # ── third-reading PASS-motion failed → bill rejected at third reading ──
+    (1978, "pass",   199, 231, 232, "rejected",
+     "głosowanie nad całością projektu."),                    # ograniczenie biurokracji (druki 558/1420)
+    # ── amendment / minority / procedural → indeterminate ──
+    # (Per-vote chips like "wniosek przyjęty" stay correct; bill-level claim must abstain.)
+    (136, "amendment",  238, 200, 201, "indeterminate", "poprawki nr 2, 5 i 11"),
+    (135, "amendment",   30, 410, 411, "indeterminate", "poprawki nr 1, 4 i 10"),
+    (900, "minority",   202, 232, 233, "indeterminate", "wniosek mniejszości 1"),
+    (935, "minority",   200, 240, 241, "indeterminate", "wniosek mniejszości 1"),
+    (44,  "procedural", 190, 241, 242, "indeterminate", "Wniosek o przerwę"),
+    (157, "procedural", 194, 240, 241, "indeterminate", "Wniosek o przerwę"),
+    # ── null polarity (unclassified topic) → indeterminate ──
+    (20,  None,         230, 170, 171, "indeterminate",
+     "wniosek o skrócenie terminu, o którym mowa w art. 44 ust. 3 regulaminu Sejmu w sprawie planowanego sprawozdania do druku nr 2459."),
+]
+
+
+def _motion_passed(yes: int, majority_votes: int) -> bool:
+    return yes >= majority_votes
+
+
+@pytest.mark.parametrize("voting_id,polarity,yes,no,maj,expected,topic", REAL_FIXTURES,
+                         ids=lambda v: f"v{v}" if isinstance(v, int) else None)
+def test_bill_outcome_real_cases(voting_id, polarity, yes, no, maj, expected, topic) -> None:
+    actual = compute_bill_outcome(polarity, _motion_passed(yes, maj))
+    assert actual == expected, (
+        f"voting {voting_id} ({polarity}, yes={yes} vs maj={maj}): "
+        f"got {actual!r}, expected {expected!r}. Topic: {topic!r}"
+    )
+
+
+def test_labels_distinct_per_outcome() -> None:
+    # Two-sided sanity: every outcome maps to a non-empty Polish label, and the
+    # four labels are pairwise distinct (otherwise the UI would conflate cases).
+    labels = {o: bill_outcome_label(o) for o in ("passed", "rejected", "continues", "indeterminate")}
+    assert all(s for s in labels.values())
+    assert len(set(labels.values())) == 4
+
+
+def test_bug_case_distinguishable_from_legacy_logic() -> None:
+    """Regression guard: the old `passed`-only logic (predictStages pre-fix)
+    rendered every motion-to-reject failure as "ustawa odrzucona". This test
+    captures the bug case (voting 1517 — Bosak / druk 10/2449) and asserts
+    the new computation yields the opposite outcome.
+    """
+    # Voting 1517: motion-to-reject lost (yes=201 < majority=243). Old logic
+    # used `passed` (motion outcome) directly → "ustawa odrzucona" (wrong).
+    motion_passed = _motion_passed(201, 243)
+    assert motion_passed is False
+    legacy_label = "ustawa odrzucona" if not motion_passed else "ustawa przyjęta w trzecim czytaniu"
+    new_outcome = compute_bill_outcome("reject", motion_passed)
+    new_label = bill_outcome_label(new_outcome)
+    assert new_outcome == "continues"
+    assert new_label != legacy_label, (
+        "Bug fix regressed: motion-to-reject failure still rendering "
+        "as 'ustawa odrzucona'. Recheck predict_stages.ts and bill_outcome.ts."
+    )
+
+
+def test_pass_motion_failure_is_rejection_not_continuation() -> None:
+    """Voting 1978 — third-reading pass-motion failed → bill genuinely rejected.
+    Distinct from the reject-motion-failed case: third-reading "całość projektu"
+    is the bill itself, so failure IS final rejection.
+    """
+    assert compute_bill_outcome("pass", False) == "rejected"
+
+
+@pytest.mark.parametrize("polarity", ["amendment", "minority", "procedural", None])
+def test_non_bill_level_motions_never_claim_outcome(polarity) -> None:
+    """Amendment / minority / procedural / unclassified motions must NEVER
+    return a bill-level outcome — UI would invent claims otherwise.
+    """
+    assert compute_bill_outcome(polarity, True) == "indeterminate"
+    assert compute_bill_outcome(polarity, False) == "indeterminate"

--- a/tests/supagraf/unit/test_bill_outcome.py
+++ b/tests/supagraf/unit/test_bill_outcome.py
@@ -11,9 +11,9 @@ The truth table:
     polarity   motion-passed   bill outcome    rendered as
     ──────────────────────────────────────────────────────
     pass       true            passed          "ustawa przyjęta w trzecim czytaniu"
-    pass       false           rejected        "ustawa odrzucona w trzecim czytaniu"
+    pass       false           rejected        "ustawa odrzucona"
     reject     true            rejected        "ustawa odrzucona"
-    reject     false           continues       "wniosek o odrzucenie odrzucony — projekt skierowany dalej"  ← BUG CASE
+    reject     false           continues       "wniosek o odrzucenie odrzucony — projekt skierowany do dalszej pracy"  ← BUG CASE
     amendment  any             indeterminate   per-vote chip only — no bill claim
     minority   any             indeterminate
     procedural any             indeterminate
@@ -142,8 +142,10 @@ def _motion_passed(yes: int, majority_votes: int) -> bool:
     return yes >= majority_votes
 
 
-@pytest.mark.parametrize("voting_id,polarity,yes,no,maj,expected,topic", REAL_FIXTURES,
-                         ids=lambda v: f"v{v}" if isinstance(v, int) else None)
+@pytest.mark.parametrize(
+    "voting_id,polarity,yes,no,maj,expected,topic",
+    [pytest.param(*row, id=f"v{row[0]}") for row in REAL_FIXTURES],
+)
 def test_bill_outcome_real_cases(voting_id, polarity, yes, no, maj, expected, topic) -> None:
     actual = compute_bill_outcome(polarity, _motion_passed(yes, maj))
     assert actual == expected, (


### PR DESCRIPTION
Failed "wniosek o odrzucenie" votes were rendered as "ustawa odrzucona" on /druk and /glosowanie pages, even though a failed reject-motion means the bill SURVIVES and goes to committee. The old predict_stages mapped processes.passed=false to the rejection label without considering what the underlying motion was about.

New bill_outcome.ts encodes the (motion_polarity, motion_passed) -> bill status truth table. predict_stages, WhatsNextTimeline, and the druk-page verdict chip all consume it.

Tests:
- tests/supagraf/unit/test_bill_outcome.py — 39 parametrised cases using REAL term-10 fixtures (voting_id + tally + polarity sampled from db.msulawiak.pl on 2026-05-13). Includes the #25 bug case (voting 1517, druk 10/2449) plus 30+ peers across reject/pass/amendment/minority/ procedural/null polarities.
- frontend/scripts/test_bill_outcome.mjs — runnable validator that fetches the same voting IDs from production and asserts the TS truth table matches; 32/32 fixtures pass against live data.

Wiring: motion_polarity now plumbed through getVotingHeader and the voting_print_links join in prints.ts; LinkedVoting carries it for the related-votings list on druk pages.