### PR TITLE
fix(voting): polarity-aware verdict stamp on /glosowanie/[id] (#25 follow-up)

### DIFF
--- a/frontend/components/voting/VerdictStamp.tsx
+++ b/frontend/components/voting/VerdictStamp.tsx
@@ -1,10 +1,13 @@
 import type { VotingHeader } from "@/lib/db/voting";
+import { verdictStampWords } from "@/lib/voting/bill_outcome";
 
 export function VerdictStamp({
   header,
   passed,
 }: {
   header: VotingHeader;
+  // `passed` here is the MOTION result (yes >= majority). The bill-level
+  // consequence is derived inside via header.motion_polarity — see issue #25.
   passed: boolean;
 }) {
   const margin = Math.abs(header.yes - header.no);
@@ -15,22 +18,51 @@ export function VerdictStamp({
       ? Math.round(((header.yes + header.no + header.abstain) / turnoutDenom) * 1000) / 10
       : 0;
 
+  const { subject, verb, sublabel } = verdictStampWords(header.motion_polarity, passed);
+
   return (
     <div className="flex items-center flex-wrap gap-4 sm:gap-6 mb-7">
       <div
-        className="font-serif"
-        style={{
-          fontStyle: "italic",
-          // clamp keeps "ODRZUCONA" inside a 320px viewport without breaking the
-          // 92px headline scale on desktop. ~10ch wide at 1cqi sizing.
-          fontSize: "clamp(54px, 14vw, 92px)",
-          lineHeight: 0.9,
-          fontWeight: 500,
-          color: passed ? "var(--success)" : "var(--destructive)",
-          letterSpacing: "-0.04em",
-        }}
+        className="font-serif flex flex-col"
+        style={{ lineHeight: 0.9 }}
       >
-        {passed ? "PRZYJĘTA" : "ODRZUCONA"}
+        <div
+          className="font-mono uppercase"
+          style={{
+            fontSize: 11,
+            letterSpacing: "0.18em",
+            color: "var(--muted-foreground)",
+            marginBottom: 6,
+          }}
+        >
+          {subject}
+        </div>
+        <div
+          style={{
+            fontStyle: "italic",
+            // clamp keeps the verb inside a 320px viewport without breaking the
+            // 92px headline scale on desktop. ~10ch wide at 1cqi sizing.
+            fontSize: "clamp(54px, 14vw, 92px)",
+            fontWeight: 500,
+            color: passed ? "var(--success)" : "var(--destructive)",
+            letterSpacing: "-0.04em",
+          }}
+        >
+          {verb}
+        </div>
+        {sublabel && (
+          <div
+            className="font-sans"
+            style={{
+              fontSize: 12,
+              color: "var(--muted-foreground)",
+              marginTop: 6,
+              fontStyle: "italic",
+            }}
+          >
+            {sublabel}
+          </div>
+        )}
       </div>
       <div
         className="font-sans sm:border-l sm:border-border sm:pl-[18px]"

--- a/frontend/lib/voting/bill_outcome.ts
+++ b/frontend/lib/voting/bill_outcome.ts
@@ -41,6 +41,65 @@ export function billOutcomeLabel(outcome: BillOutcome): string {
   return LABEL_PL[outcome];
 }
 
+/**
+ * Verdict-stamp words for the giant headline on /glosowanie/[id].
+ *
+ * Pre-fix the stamp always read "PRZYJĘTA" / "ODRZUCONA" — feminine, matching
+ * "ustawa". That's misleading when the vote is a "wniosek o odrzucenie": the
+ * MOTION was rejected but the BILL survives. Issue #25 follow-up: vary the
+ * subject by polarity so the stamp says "WNIOSEK ODRZUCONY" (masculine) for
+ * motion votes, avoiding the "ustawa odrzucona" misread entirely.
+ *
+ * Verb agrees grammatically with the subject:
+ *   USTAWA / POPRAWKA (feminine)         → PRZYJĘTA / ODRZUCONA
+ *   WNIOSEK / WNIOSEK MNIEJSZOŚCI (masc) → PRZYJĘTY / ODRZUCONY
+ *   GŁOSOWANIE (neuter)                  → PRZYJĘTE / ODRZUCONE
+ *
+ * Sublabel describes the bill-level consequence ("projekt skierowany do
+ * dalszych prac", "ustawa odrzucona w trzecim czytaniu", etc.) so the reader
+ * gets both the motion result and what it means for the bill.
+ */
+export type VerdictStampWords = {
+  subject: string;
+  verb: string;
+  /** Bill-level consequence, one short line. Empty string when no claim. */
+  sublabel: string;
+};
+
+import type { MotionPolarity as _MP } from "@/lib/promiseAlignment";
+
+function subjectFor(polarity: _MP | null): { subject: string; gender: "f" | "m" | "n" } {
+  if (polarity === "pass") return { subject: "USTAWA", gender: "f" };
+  if (polarity === "reject") return { subject: "WNIOSEK", gender: "m" };
+  if (polarity === "amendment") return { subject: "POPRAWKA", gender: "f" };
+  if (polarity === "minority") return { subject: "WNIOSEK MNIEJSZOŚCI", gender: "m" };
+  if (polarity === "procedural") return { subject: "WNIOSEK", gender: "m" };
+  return { subject: "GŁOSOWANIE", gender: "n" };
+}
+
+function verbFor(motionPassed: boolean, gender: "f" | "m" | "n"): string {
+  if (gender === "f") return motionPassed ? "PRZYJĘTA" : "ODRZUCONA";
+  if (gender === "m") return motionPassed ? "PRZYJĘTY" : "ODRZUCONY";
+  return motionPassed ? "PRZYJĘTE" : "ODRZUCONE";
+}
+
+function sublabelFor(outcome: BillOutcome): string {
+  if (outcome === "passed") return "ustawa przyjęta w trzecim czytaniu";
+  if (outcome === "rejected") return "projekt zamknięty";
+  if (outcome === "continues") return "projekt skierowany do dalszych prac";
+  return "";
+}
+
+export function verdictStampWords(
+  polarity: _MP | null,
+  motionPassed: boolean,
+): VerdictStampWords {
+  const { subject, gender } = subjectFor(polarity);
+  const verb = verbFor(motionPassed, gender);
+  const sublabel = sublabelFor(computeBillOutcome(polarity, motionPassed));
+  return { subject, verb, sublabel };
+}
+
 /** Short chip label for VotingRow.verdict on /druk pages. */
 const VERDICT_LABEL_PL: Record<BillOutcome, string> = {
   passed: "ustawa przyjęta",

--- a/tests/supagraf/unit/test_bill_outcome.py
+++ b/tests/supagraf/unit/test_bill_outcome.py
@@ -197,3 +197,96 @@ def test_non_bill_level_motions_never_claim_outcome(polarity) -> None:
     """
     assert compute_bill_outcome(polarity, True) == "indeterminate"
     assert compute_bill_outcome(polarity, False) == "indeterminate"
+
+
+# ─── Verdict-stamp truth table (mirror of bill_outcome.ts verdictStampWords) ──
+# The giant headline on /glosowanie/[id]. Pre-fix it always read "PRZYJĘTA" /
+# "ODRZUCONA" (feminine, matching "ustawa") — feels like "ustawa odrzucona"
+# even when the vote was a procedural motion. Subject + grammatical gender
+# now derive from polarity.
+
+def _stamp_words(polarity: MotionPolarity, motion_passed: bool) -> tuple[str, str, str]:
+    """Python mirror of frontend/lib/voting/bill_outcome.ts verdictStampWords.
+    Returns (subject, verb, sublabel).
+    """
+    if polarity == "pass":
+        subject, gender = "USTAWA", "f"
+    elif polarity == "reject":
+        subject, gender = "WNIOSEK", "m"
+    elif polarity == "amendment":
+        subject, gender = "POPRAWKA", "f"
+    elif polarity == "minority":
+        subject, gender = "WNIOSEK MNIEJSZOŚCI", "m"
+    elif polarity == "procedural":
+        subject, gender = "WNIOSEK", "m"
+    else:
+        subject, gender = "GŁOSOWANIE", "n"
+
+    if gender == "f":
+        verb = "PRZYJĘTA" if motion_passed else "ODRZUCONA"
+    elif gender == "m":
+        verb = "PRZYJĘTY" if motion_passed else "ODRZUCONY"
+    else:
+        verb = "PRZYJĘTE" if motion_passed else "ODRZUCONE"
+
+    outcome = compute_bill_outcome(polarity, motion_passed)
+    if outcome == "passed":
+        sublabel = "ustawa przyjęta w trzecim czytaniu"
+    elif outcome == "rejected":
+        sublabel = "projekt zamknięty"
+    elif outcome == "continues":
+        sublabel = "projekt skierowany do dalszych prac"
+    else:
+        sublabel = ""
+    return subject, verb, sublabel
+
+
+# Each tuple: (voting_id, polarity, yes, maj, expected_subject, expected_verb, expected_sublabel)
+STAMP_FIXTURES: list[tuple[int, MotionPolarity, int, int, str, str, str]] = [
+    # Bug case: reject motion failed → "WNIOSEK ODRZUCONY" (NOT "USTAWA ODRZUCONA")
+    (1517, "reject", 201, 243, "WNIOSEK", "ODRZUCONY", "projekt skierowany do dalszych prac"),
+    (446,  "reject", 188, 229, "WNIOSEK", "ODRZUCONY", "projekt skierowany do dalszych prac"),
+    (55,   "reject", 203, 224, "WNIOSEK", "ODRZUCONY", "projekt skierowany do dalszych prac"),
+    # Reject motion passed → "WNIOSEK PRZYJĘTY" + sublabel "projekt zamknięty"
+    (65,   "reject", 237, 189, "WNIOSEK", "PRZYJĘTY", "projekt zamknięty"),
+    (1513, "reject", 244, 208, "WNIOSEK", "PRZYJĘTY", "projekt zamknięty"),
+    # Third-reading pass succeeded → "USTAWA PRZYJĘTA"
+    (299,  "pass",   415,   1, "USTAWA",  "PRZYJĘTA", "ustawa przyjęta w trzecim czytaniu"),
+    (1113, "pass",   241, 184, "USTAWA",  "PRZYJĘTA", "ustawa przyjęta w trzecim czytaniu"),
+    # Third-reading pass failed → "USTAWA ODRZUCONA" + sublabel "projekt zamknięty"
+    (1978, "pass",   199, 232, "USTAWA",  "ODRZUCONA", "projekt zamknięty"),
+    # Amendment passed/failed — feminine, no bill-level claim
+    (136, "amendment", 238, 201, "POPRAWKA", "PRZYJĘTA", ""),
+    (135, "amendment",  30, 411, "POPRAWKA", "ODRZUCONA", ""),
+    # Minority motions — masculine
+    (900, "minority", 202, 233, "WNIOSEK MNIEJSZOŚCI", "ODRZUCONY", ""),
+    # Procedural — masculine
+    (44,  "procedural", 190, 242, "WNIOSEK", "ODRZUCONY", ""),
+    # Null polarity — neuter fallback
+    (20,  None, 230, 171, "GŁOSOWANIE", "PRZYJĘTE", ""),
+]
+
+
+@pytest.mark.parametrize(
+    "voting_id,polarity,yes,maj,expected_subject,expected_verb,expected_sublabel",
+    [pytest.param(*row, id=f"v{row[0]}") for row in STAMP_FIXTURES],
+)
+def test_verdict_stamp_words_real_cases(
+    voting_id, polarity, yes, maj, expected_subject, expected_verb, expected_sublabel,
+) -> None:
+    subject, verb, sublabel = _stamp_words(polarity, _motion_passed(yes, maj))
+    assert subject == expected_subject, f"voting {voting_id}: subject"
+    assert verb == expected_verb, f"voting {voting_id}: verb"
+    assert sublabel == expected_sublabel, f"voting {voting_id}: sublabel"
+
+
+def test_stamp_avoids_ustawa_odrzucona_misread_for_reject_motions() -> None:
+    """Regression guard for issue #25: a failed 'wniosek o odrzucenie' MUST
+    NOT render as feminine 'ODRZUCONA' (which reads as 'ustawa odrzucona').
+    Subject should be 'WNIOSEK' (masculine), verb 'ODRZUCONY'.
+    """
+    subject, verb, _ = _stamp_words("reject", motion_passed=False)
+    assert subject == "WNIOSEK"
+    assert verb == "ODRZUCONY"
+    # The two words combined never form "USTAWA ODRZUCONA":
+    assert f"{subject} {verb}" != "USTAWA ODRZUCONA"


### PR DESCRIPTION
Follow-up to #28 — that PR fixed the timeline copy and the /druk verdict chip but missed `VerdictStamp.tsx`, the giant headline on `/glosowanie/[id]`. For voting 1517 (the bug case, druk 10/2449) the stamp still rendered a feminine "ODRZUCONA" driven only by `passed`, which reads as "ustawa odrzucona" — exactly the misread issue #25 aims to prevent.

## What changes

`VerdictStamp.tsx` now derives subject + grammatical gender from `motion_polarity`:

| polarity   | subject              | gender | verb (passed / failed)  |
| ---------- | -------------------- | ------ | ----------------------- |
| pass       | USTAWA               | f      | PRZYJĘTA / ODRZUCONA    |
| reject     | WNIOSEK              | m      | PRZYJĘTY / ODRZUCONY    |
| amendment  | POPRAWKA             | f      | PRZYJĘTA / ODRZUCONA    |
| minority   | WNIOSEK MNIEJSZOŚCI  | m      | PRZYJĘTY / ODRZUCONY    |
| procedural | WNIOSEK              | m      | PRZYJĘTY / ODRZUCONY    |
| null       | GŁOSOWANIE           | n      | PRZYJĘTE / ODRZUCONE    |

Color stays motion-outcome based (green = motion passed, red = motion failed). The bill-level consequence moves to a small italic sublabel below the headline:

- `passed`    → "ustawa przyjęta w trzecim czytaniu"
- `rejected`  → "projekt zamknięty"
- `continues` → "projekt skierowany do dalszych prac"
- `indeterminate` → empty

For voting 1517 the stamp now reads **WNIOSEK / ODRZUCONY / projekt skierowany do dalszych prac** instead of just **ODRZUCONA** — no longer parseable as "ustawa odrzucona".

## Tests

`tests/supagraf/unit/test_bill_outcome.py` extended with:
- 13 new real-case stamp fixtures across all polarities (voting IDs 1517, 446, 55, 65, 1513, 299, 1113, 1978, 136, 135, 900, 44, 20).
- `test_stamp_avoids_ustawa_odrzucona_misread_for_reject_motions` — pinned regression guard asserting `(reject, motion-failed)` can never produce "USTAWA ODRZUCONA".

53/53 Python tests pass; `tsc --noEmit` clean; `node scripts/test_bill_outcome.mjs` revalidates 32/32 live truth-table cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sEATcg5AoCV8andKXZesD)_