### PR TITLE
fix(voting): show real motion topic + polarity-aware "final" labels (#25 follow-up²)

### DIFF
--- a/frontend/app/druk/[term]/[number]/page.tsx
+++ b/frontend/app/druk/[term]/[number]/page.tsx
@@ -54,14 +54,29 @@ function formatDate(iso: string | null): string {
 }
 
 // Compact Polish labels for voting roles in the related-votings list.
+// "main" intentionally has NO entry — the upstream voting_print_links ETL
+// tags procedural reject-motions with role="main" too (issue #25 follow-up:
+// voting 1517 is role="main" on druk 10/2449 despite being a "wniosek o
+// odrzucenie"). The chip label is derived per-row from motion_polarity so
+// it can't claim "całość" for a procedural motion.
 const ROLE_LABEL: Record<string, string> = {
-  main: "całość",
   sprawozdanie: "sprawozd.",
   autopoprawka: "autopoprawka",
   poprawka: "poprawka",
   joint: "łączne",
   other: "inne",
 };
+
+// Polarity-aware chip label for the `role="main"` row (replaces the blanket
+// "całość" that conflated final third-reading votes with procedural motions).
+function mainRoleLabel(polarity: import("@/lib/promiseAlignment").MotionPolarity | null): string {
+  if (polarity === "pass") return "całość";
+  if (polarity === "reject") return "wniosek o odrzucenie";
+  if (polarity === "amendment") return "poprawki";
+  if (polarity === "minority") return "wniosek mniejsz.";
+  if (polarity === "procedural") return "wniosek proc.";
+  return "główne";
+}
 
 function StageRow({ s, isLast }: { s: ProcessStage; isLast: boolean }) {
   const label = stageLabel(s.stageType, s.stageName);
@@ -280,7 +295,7 @@ export default async function DrukPage({
                         yes={v.yes}
                         no={v.no}
                         abstain={v.abstain}
-                        badge={{ label: ROLE_LABEL[v.role] ?? v.role }}
+                        badge={{ label: v.role === "main" ? mainRoleLabel(v.motionPolarity) : (ROLE_LABEL[v.role] ?? v.role) }}
                         verdict={verdict}
                         isFinal={isFinal}
                       />
@@ -438,7 +453,18 @@ export default async function DrukPage({
             {mainVoting && (
               <>
                 <div className="mt-7 text-[10px] tracking-[0.16em] uppercase text-destructive mb-3.5">
-                  ✶ {mainVoting.role === "main" ? "Głosowanie końcowe" : `Głosowanie · ${mainVoting.role}`}
+                  ✶ {
+                    // Issue #25 follow-up: role="main" is set by ETL on any
+                    // voting linked to the print (incl. procedural reject-
+                    // motions). Only label "Głosowanie końcowe" when the
+                    // motion was actually the third-reading bill vote
+                    // (polarity="pass"); otherwise describe what was voted on.
+                    mainVoting.role === "main"
+                      ? (mainVoting.motionPolarity === "pass"
+                          ? "Głosowanie końcowe"
+                          : `Głosowanie · ${mainRoleLabel(mainVoting.motionPolarity)}`)
+                      : `Głosowanie · ${mainVoting.role}`
+                  }
                 </div>
                 <div
                   className="font-serif font-medium leading-none tracking-[-0.02em]"

--- a/frontend/app/tygodnik/_components/BriefList.tsx
+++ b/frontend/app/tygodnik/_components/BriefList.tsx
@@ -719,6 +719,7 @@ export function BriefList({
                   voting_id: ev.payload.voting_id,
                   voting_number: ev.payload.voting_number,
                   title: ev.payload.title,
+                  topic: ev.payload.topic,
                   date: ev.payload.date,
                   yes: ev.payload.yes,
                   no: ev.payload.no,

--- a/frontend/components/tygodnik/VotingHemicycleCard.tsx
+++ b/frontend/components/tygodnik/VotingHemicycleCard.tsx
@@ -20,6 +20,11 @@ export type VotingHemicycleData = {
   voting_id: number;
   voting_number: number;
   title: string;
+  // Question actually voted on ("wniosek o odrzucenie projektu...", "głosowanie
+  // nad całością projektu", etc.). Distinct from `title`, which is the agenda
+  // kicker. Surfacing both prevents the procedural-motion-vs-bill-vote
+  // confusion (issue #25 follow-up).
+  topic?: string | null;
   date: string;
   yes: number;
   no: number;
@@ -91,6 +96,33 @@ export function VotingHemicycleCard({
       }>
         {primaryTitle}
       </CardTitle>
+
+      {voting.topic?.trim() && (
+        <div
+          className="font-serif italic"
+          style={{
+            fontSize: 13,
+            lineHeight: 1.45,
+            color: "var(--secondary-foreground)",
+            marginBottom: 12,
+          }}
+        >
+          <span
+            className="font-mono"
+            style={{
+              fontSize: 10,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "var(--muted-foreground)",
+              marginRight: 8,
+              fontStyle: "normal",
+            }}
+          >
+            pytanie:
+          </span>
+          „{voting.topic.trim()}".
+        </div>
+      )}
 
       {linkedPrint?.impact_punch && (
         <DotyczyCallout>“{linkedPrint.impact_punch}”</DotyczyCallout>

--- a/frontend/components/voting/ClubBreakdownTable.tsx
+++ b/frontend/components/voting/ClubBreakdownTable.tsx
@@ -442,11 +442,13 @@ export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: P
   const filteredClubs = excludeUnaffiliated(clubs, (c) => c.club_ref)
     .filter((c) => (c.total ?? 0) >= MIN_KLUB_AGGREGATE);
 
-  // PNG title block: the voting title (header.title — the official question
-  // read in the chamber) is the primary display. The print's short_title
-  // (when present) sits below as italic context subtitle. Voting title wins
-  // because that's what was actually voted on — the print is incidental.
-  const pngQuestion = clampForPng(header.title, 220);
+  // PNG title block: the question actually voted on is `header.topic`
+  // ("wniosek o odrzucenie projektu w pierwszym czytaniu" etc.) — NOT
+  // `header.title`, which is the agenda kicker ("Pkt. 5 ..."). The print's
+  // short_title (when present) sits below as italic context subtitle.
+  // Issue #25 follow-up: rendering the agenda kicker as the "question" made
+  // reject-motion votes read as votes on the bill itself.
+  const pngQuestion = clampForPng(header.topic?.trim() || header.title, 220);
   const pngSubtitle = clampForPng(shortTitle, 110);
 
   return (
@@ -485,7 +487,7 @@ export function ClubBreakdownTable({ clubs, header, shortTitle, printNumber }: P
             marginBottom: 24,
           }}
         >
-          {shortTitle ?? header.title}
+          {shortTitle ?? header.topic?.trim() ?? header.title}
         </div>
 
         {/* Live (responsive) rows. */}

--- a/frontend/components/voting/VotingHero.tsx
+++ b/frontend/components/voting/VotingHero.tsx
@@ -26,6 +26,18 @@ export function VotingHero({ data }: { data: VotingPageData }) {
     linkedPrint?.short_title ??
     header.title.replace(/^Pkt\.?\s*\d+\s*/, "");
 
+  // Issue #25 follow-up: header.title is the AGENDA kicker ("Pkt. 5 Pierwsze
+  // czytanie..."), NOT the question that was actually voted on. The real
+  // question lives in header.topic ("wniosek o odrzucenie projektu w
+  // pierwszym czytaniu" for voting 1517). Render topic for the "pytanie
+  // poddane pod głosowanie" line; fall back to title only when topic is
+  // missing/blank (rare — null for ~0.5% of term-10 rows).
+  const motionQuestion = header.topic?.trim() || header.title;
+  // Show the agenda kicker as a small subcaption so the reader still sees
+  // the procedural context (which czytanie / which print) without it
+  // masquerading as the question.
+  const agendaCaption = header.topic?.trim() ? header.title : null;
+
   const dateLong = formatDateLong(header.date);
   const timeStr = formatTime(header.date);
 
@@ -68,31 +80,46 @@ export function VotingHero({ data }: { data: VotingPageData }) {
             {cleanedTitle}.
           </h1>
 
-          <p
-            className="font-serif text-[17px] sm:text-[19px] md:text-[21px]"
-            style={{
-              lineHeight: 1.5,
-              color: "var(--secondary-foreground)",
-              margin: "0 0 36px",
-              textWrap: "pretty",
-              maxWidth: 560,
-              fontStyle: "italic",
-            }}
-          >
-            <span
-              className="block font-mono uppercase"
+          <div style={{ margin: "0 0 36px", maxWidth: 560 }}>
+            <p
+              className="font-serif text-[17px] sm:text-[19px] md:text-[21px]"
               style={{
-                fontSize: 11,
-                color: "var(--muted-foreground)",
-                letterSpacing: "0.1em",
-                marginBottom: 4,
-                fontStyle: "normal",
+                lineHeight: 1.5,
+                color: "var(--secondary-foreground)",
+                margin: 0,
+                textWrap: "pretty",
+                fontStyle: "italic",
               }}
             >
-              pytanie poddane pod głosowanie
-            </span>
-            „{header.title}".
-          </p>
+              <span
+                className="block font-mono uppercase"
+                style={{
+                  fontSize: 11,
+                  color: "var(--muted-foreground)",
+                  letterSpacing: "0.1em",
+                  marginBottom: 4,
+                  fontStyle: "normal",
+                }}
+              >
+                pytanie poddane pod głosowanie
+              </span>
+              „{motionQuestion}".
+            </p>
+            {agendaCaption && (
+              <p
+                className="font-mono"
+                style={{
+                  fontSize: 11,
+                  color: "var(--muted-foreground)",
+                  marginTop: 8,
+                  letterSpacing: "0.04em",
+                  lineHeight: 1.45,
+                }}
+              >
+                kontekst: {agendaCaption}
+              </p>
+            )}
+          </div>
 
           <VerdictStamp header={header} passed={passed} />
 


### PR DESCRIPTION
Follow-up to #28 / #29. The voting page (`/glosowanie/1517`) and the druk sidebar still misrepresented procedural reject-motions in three additional places, all keying off `header.title` (the agenda kicker "Pkt. 5 Pierwsze czytanie…") or the `voting_print_links.role="main"` flag without consulting `motion_polarity`.

## What changes

**1. `VotingHero.tsx` — "PYTANIE PODDANE POD GŁOSOWANIE" was quoting the agenda kicker.**

The label "pytanie poddane pod głosowanie" sat above `header.title` ("Pkt. 5 Pierwsze czytanie rządowego projektu ustawy…"), so readers thought the question was the bill itself. Now renders `header.topic` ("wniosek o odrzucenie projektu w pierwszym czytaniu"). The agenda kicker stays as a small `kontekst:` subcaption — context preserved, no longer masquerading as the question.

**2. `ClubBreakdownTable.tsx` — same swap (topic, not title) for the chart "question" line and the PNG export header.**

The old comment explicitly claimed the agenda kicker was "the official question read in the chamber". It is not — `topic` is.

**3. `/druk/[term]/[number]/page.tsx` — "Głosowanie końcowe" + "całość" chip on procedural motions.**

ETL writes `voting_print_links.role="main"` on ANY voting linked to a print, including procedural reject-motions. New `mainRoleLabel(motionPolarity)` per-row:

| polarity   | chip                  |
| ---------- | --------------------- |
| pass       | całość                |
| reject     | wniosek o odrzucenie  |
| amendment  | poprawki              |
| minority   | wniosek mniejsz.      |
| procedural | wniosek proc.         |
| null       | główne                |

Sidebar header now reads `Głosowanie końcowe` only when `polarity === "pass"`; otherwise it describes what was actually voted on (`Głosowanie · wniosek o odrzucenie`).

**4. `VotingHemicycleCard.tsx` (tygodnik feed) — surface `voting.topic`.**

The `vote_events_v` payload already includes `topic` (migration 0062), it was just unused. Cards now render a small italic `pytanie: „…"` line under the title so the reader sees what was voted on without inferring it from the bill title.

## Effect on voting 1517 / druk 10/2449

| surface | before | after |
| --- | --- | --- |
| /glosowanie hero question | „Pkt. 5 Pierwsze czytanie rządowego projektu…" | „wniosek o odrzucenie projektu w pierwszym czytaniu." |
| /druk sidebar header | ✶ Głosowanie końcowe | ✶ Głosowanie · wniosek o odrzucenie |
| /druk related-votings chip | całość | wniosek o odrzucenie |
| /tygodnik feed card | (no question shown) | pytanie: „wniosek o odrzucenie…" |

## Out of scope

`voting_print_links.role` is still "main" on procedural motions — fixing that requires an ETL backfill (rename role or split `main_third_reading` vs `main_other`). The UI now compensates via `motion_polarity` so this isn't user-visible, but it's the proper long-term fix.

## Tests

No new tests; the existing `bill_outcome` truth table (53 Python parametrised cases + 32-fixture live `.mjs` validator) still covers the polarity logic. `tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sEATcg5AoCV8andKXZesD)_