### PR TITLE
fix(atlas): show real dissent count in party discipline

### DIFF
--- a/frontend/app/atlas/_components/DyscyplinaPartyjna.tsx
+++ b/frontend/app/atlas/_components/DyscyplinaPartyjna.tsx
@@ -30,7 +30,7 @@ export function DyscyplinaPartyjna({ data }: { data: DisciplineRow[] }) {
           {data.map((d) => {
             const pct = d.loyalty * 100;
             const color = KLUB_COLORS[d.klub] ?? "var(--muted-foreground)";
-            const dissents = Math.round(d.votings * (1 - d.loyalty));
+            const dissents = d.dissents;
             const klubLabel = KLUB_LABELS[d.klub] ?? d.klub;
             return (
               <HoverCard key={d.klub} openDelay={120} closeDelay={80}>
@@ -73,8 +73,8 @@ export function DyscyplinaPartyjna({ data }: { data: DisciplineRow[] }) {
                   <div className="grid grid-cols-2 gap-y-1.5 font-mono text-[11px]">
                     <span className="text-muted-foreground">lojalność średnia</span>
                     <span className="text-right text-foreground font-semibold">{pct.toFixed(1)}%</span>
-                    <span className="text-muted-foreground">odstępstw (~)</span>
-                    <span className="text-right text-foreground">{dissents}</span>
+                    <span className="text-muted-foreground">odstępstw</span>
+                    <span className="text-right text-foreground">{dissents.toLocaleString("pl-PL")}</span>
                     <span className="text-muted-foreground">głosowań w próbie</span>
                     <span className="text-right text-foreground">{d.votings.toLocaleString("pl-PL")}</span>
                     <span className="text-muted-foreground">średnia obecność</span>
@@ -95,11 +95,11 @@ export function DyscyplinaPartyjna({ data }: { data: DisciplineRow[] }) {
         >
           <p className="m-0 mb-3.5">
             <strong className="text-foreground">{KLUB_LABELS[top.klub] ?? top.klub} najbardziej zdyscyplinowany</strong>
-            {" "}— {(top.loyalty * 100).toFixed(1)}% głosów zgodnych. Tylko {Math.round(top.votings * (1 - top.loyalty))} odstępstw w {top.votings.toLocaleString("pl-PL")} głosowaniach.
+            {" "}— {(top.loyalty * 100).toFixed(1)}% głosów zgodnych. Tylko {top.dissents.toLocaleString("pl-PL")} odstępstw w {top.votings.toLocaleString("pl-PL")} głosowaniach.
           </p>
           <p className="m-0 mb-3.5">
             <strong className="text-foreground">{KLUB_LABELS[bottom.klub] ?? bottom.klub} się sypie.</strong>
-            {" "}{(bottom.loyalty * 100).toFixed(1)}% lojalności — {Math.round(bottom.votings * (1 - bottom.loyalty))} głosów wbrew klubowi.
+            {" "}{(bottom.loyalty * 100).toFixed(1)}% lojalności — {bottom.dissents.toLocaleString("pl-PL")} głosów wbrew klubowi.
             {bottom.klub === "Polska2050" && (
               <> Konsekwencja odpływu posłów do Centrum (zob. wykres&nbsp;03).</>
             )}

--- a/frontend/lib/db/atlas.ts
+++ b/frontend/lib/db/atlas.ts
@@ -99,6 +99,7 @@ export type DisciplineRow = {
   loyalty: number;       // 0..1, mean of per-voting loyalty
   votings: number;       // n votings counted (>=5 voting members)
   totalMembersAvg: number; // avg total members per voting (rough klub size)
+  dissents: number;      // total member-votes against the klub line across votings
 };
 
 export async function getPartyDiscipline(term = 10): Promise<DisciplineRow[]> {
@@ -110,7 +111,7 @@ export async function getPartyDiscipline(term = 10): Promise<DisciplineRow[]> {
     .in("club_short", [...MAIN_KLUBS]);
   if (error) throw error;
 
-  type Acc = { sumLoyalty: number; n: number; sumTotal: number };
+  type Acc = { sumLoyalty: number; n: number; sumTotal: number; dissents: number };
   const acc = new Map<string, Acc>();
 
   for (const r of (data ?? []) as Array<{
@@ -123,10 +124,11 @@ export async function getPartyDiscipline(term = 10): Promise<DisciplineRow[]> {
     if (voting < 5) continue; // too thin to define a "klub line"
     const winner = Math.max(yes, no, abstain);
     const loyalty = winner / voting;
-    const a = acc.get(r.club_short) ?? { sumLoyalty: 0, n: 0, sumTotal: 0 };
+    const a = acc.get(r.club_short) ?? { sumLoyalty: 0, n: 0, sumTotal: 0, dissents: 0 };
     a.sumLoyalty += loyalty;
     a.n += 1;
     a.sumTotal += r.total ?? 0;
+    a.dissents += voting - winner;
     acc.set(r.club_short, a);
   }
 
@@ -139,6 +141,7 @@ export async function getPartyDiscipline(term = 10): Promise<DisciplineRow[]> {
       loyalty: a.sumLoyalty / a.n,
       votings: a.n,
       totalMembersAvg: a.sumTotal / a.n,
+      dissents: a.dissents,
     });
   }
   rows.sort((x, y) => y.loyalty - x.loyalty);


### PR DESCRIPTION
Previous code derived "odstępstw" as round(votings * (1 - meanLoyalty)), mixing a count (votings) with a mean-of-ratios. With high discipline (e.g. P2050 99.8%) this rounded to 0, contradicting the loyalty bar. Sum dissenting member-votes directly from voting_by_club instead.