### PR TITLE
fix(voting): bill-outcome-first verdict stamp + Polish role labels (druk 2197)

### DIFF
--- a/frontend/app/druk/[term]/[number]/page.tsx
+++ b/frontend/app/druk/[term]/[number]/page.tsx
@@ -53,13 +53,11 @@ function formatDate(iso: string | null): string {
   return new Date(iso).toLocaleDateString("pl-PL", { day: "numeric", month: "long", year: "numeric" });
 }
 
-// Compact Polish labels for voting roles in the related-votings list.
-// "main" intentionally has NO entry — the upstream voting_print_links ETL
-// tags procedural reject-motions with role="main" too (issue #25 follow-up:
-// voting 1517 is role="main" on druk 10/2449 despite being a "wniosek o
-// odrzucenie"). The chip label is derived per-row from motion_polarity so
-// it can't claim "całość" for a procedural motion.
-const ROLE_LABEL: Record<string, string> = {
+// Compact Polish labels per voting_print_links.role for cases where
+// motion_polarity is null/unknown. When polarity is known, votingChip()
+// below derives a polarity-based label first — the role is only a fallback.
+const ROLE_LABEL_PL: Record<string, string> = {
+  main: "główne",
   sprawozdanie: "sprawozd.",
   autopoprawka: "autopoprawka",
   poprawka: "poprawka",
@@ -67,15 +65,25 @@ const ROLE_LABEL: Record<string, string> = {
   other: "inne",
 };
 
-// Polarity-aware chip label for the `role="main"` row (replaces the blanket
-// "całość" that conflated final third-reading votes with procedural motions).
-function mainRoleLabel(polarity: import("@/lib/promiseAlignment").MotionPolarity | null): string {
-  if (polarity === "pass") return "całość";
+// Polarity drives the chip first (the actual semantics of the voting); role
+// is the fallback when polarity is null. Citizen review (druk 10/2197):
+// voting 1513 ended up role='other' after ETL reclassification (PR #31) but
+// the sidebar still rendered "Głosowanie · other" because the previous fix
+// only handled role==='main'. This handles every role with a Polish label.
+function votingChip(polarity: import("@/lib/promiseAlignment").MotionPolarity | null, role: string): string {
+  if (polarity === "pass") return "całość projektu";
   if (polarity === "reject") return "wniosek o odrzucenie";
   if (polarity === "amendment") return "poprawki";
-  if (polarity === "minority") return "wniosek mniejsz.";
-  if (polarity === "procedural") return "wniosek proc.";
-  return "główne";
+  if (polarity === "minority") return "wniosek mniejszości";
+  if (polarity === "procedural") return "wniosek proceduralny";
+  return ROLE_LABEL_PL[role] ?? "głosowanie";
+}
+
+// Sidebar header — "Głosowanie końcowe" only when the voting really IS the
+// third-reading completion vote. Otherwise describe what was voted on.
+function sidebarHeaderLabel(polarity: import("@/lib/promiseAlignment").MotionPolarity | null, role: string): string {
+  if (polarity === "pass" && role === "main") return "Głosowanie końcowe";
+  return `Głosowanie · ${votingChip(polarity, role)}`;
 }
 
 function StageRow({ s, isLast }: { s: ProcessStage; isLast: boolean }) {
@@ -295,7 +303,7 @@ export default async function DrukPage({
                         yes={v.yes}
                         no={v.no}
                         abstain={v.abstain}
-                        badge={{ label: v.role === "main" ? mainRoleLabel(v.motionPolarity) : (ROLE_LABEL[v.role] ?? v.role) }}
+                        badge={{ label: votingChip(v.motionPolarity, v.role) }}
                         verdict={verdict}
                         isFinal={isFinal}
                       />
@@ -453,18 +461,7 @@ export default async function DrukPage({
             {mainVoting && (
               <>
                 <div className="mt-7 text-[10px] tracking-[0.16em] uppercase text-destructive mb-3.5">
-                  ✶ {
-                    // Issue #25 follow-up: role="main" is set by ETL on any
-                    // voting linked to the print (incl. procedural reject-
-                    // motions). Only label "Głosowanie końcowe" when the
-                    // motion was actually the third-reading bill vote
-                    // (polarity="pass"); otherwise describe what was voted on.
-                    mainVoting.role === "main"
-                      ? (mainVoting.motionPolarity === "pass"
-                          ? "Głosowanie końcowe"
-                          : `Głosowanie · ${mainRoleLabel(mainVoting.motionPolarity)}`)
-                      : `Głosowanie · ${mainVoting.role}`
-                  }
+                  ✶ {sidebarHeaderLabel(mainVoting.motionPolarity, mainVoting.role)}
                 </div>
                 <div
                   className="font-serif font-medium leading-none tracking-[-0.02em]"

--- a/frontend/components/voting/VerdictStamp.tsx
+++ b/frontend/components/voting/VerdictStamp.tsx
@@ -18,7 +18,14 @@ export function VerdictStamp({
       ? Math.round(((header.yes + header.no + header.abstain) / turnoutDenom) * 1000) / 10
       : 0;
 
-  const { subject, verb, sublabel } = verdictStampWords(header.motion_polarity, passed);
+  const { headline, tone, motionDescription } = verdictStampWords(header.motion_polarity, passed);
+  // Headline color comes from BILL outcome (not motion outcome) so a citizen
+  // sees green/red that matches what happened to the project, not what
+  // happened to a procedural motion. neutral = amendment/minority/procedural.
+  const headlineColor =
+    tone === "success" ? "var(--success)" :
+    tone === "destructive" ? "var(--destructive)" :
+    "var(--foreground)";
 
   return (
     <div className="flex items-center flex-wrap gap-4 sm:gap-6 mb-7">
@@ -27,40 +34,31 @@ export function VerdictStamp({
         style={{ lineHeight: 0.9 }}
       >
         <div
-          className="font-mono uppercase"
-          style={{
-            fontSize: 11,
-            letterSpacing: "0.18em",
-            color: "var(--muted-foreground)",
-            marginBottom: 6,
-          }}
-        >
-          {subject}
-        </div>
-        <div
           style={{
             fontStyle: "italic",
-            // clamp keeps the verb inside a 320px viewport without breaking the
-            // 92px headline scale on desktop. ~10ch wide at 1cqi sizing.
-            fontSize: "clamp(54px, 14vw, 92px)",
+            // clamp keeps the headline inside a 320px viewport without breaking
+            // the 80px headline scale on desktop. Some bill-outcome strings
+            // ("PROJEKT IDZIE DALEJ") are two words — slightly smaller cap
+            // than the old single-word stamp so it wraps cleanly.
+            fontSize: "clamp(44px, 11.5vw, 80px)",
             fontWeight: 500,
-            color: passed ? "var(--success)" : "var(--destructive)",
+            color: headlineColor,
             letterSpacing: "-0.04em",
           }}
         >
-          {verb}
+          {headline}
         </div>
-        {sublabel && (
+        {motionDescription && (
           <div
             className="font-sans"
             style={{
-              fontSize: 12,
+              fontSize: 13,
               color: "var(--muted-foreground)",
-              marginTop: 6,
+              marginTop: 10,
               fontStyle: "italic",
             }}
           >
-            {sublabel}
+            {motionDescription}
           </div>
         )}
       </div>

--- a/frontend/lib/voting/bill_outcome.ts
+++ b/frontend/lib/voting/bill_outcome.ts
@@ -44,60 +44,92 @@ export function billOutcomeLabel(outcome: BillOutcome): string {
 /**
  * Verdict-stamp words for the giant headline on /glosowanie/[id].
  *
- * Pre-fix the stamp always read "PRZYJĘTA" / "ODRZUCONA" — feminine, matching
- * "ustawa". That's misleading when the vote is a "wniosek o odrzucenie": the
- * MOTION was rejected but the BILL survives. Issue #25 follow-up: vary the
- * subject by polarity so the stamp says "WNIOSEK ODRZUCONY" (masculine) for
- * motion votes, avoiding the "ustawa odrzucona" misread entirely.
+ * Pre-fix: stamp showed huge motion-level verb (PRZYJĘTY/ODRZUCONY) coloured
+ * by motion outcome, with bill consequence ("projekt zamknięty" etc.) demoted
+ * to a tiny gray sublabel. Citizen review (druk 2197 / voting 1513): reading
+ * giant green "PRZYJĘTY" — even with "WNIOSEK" above — gets parsed as "bill
+ * passed" when in fact a successful reject-motion KILLED the bill.
  *
- * Verb agrees grammatically with the subject:
- *   USTAWA / POPRAWKA (feminine)         → PRZYJĘTA / ODRZUCONA
- *   WNIOSEK / WNIOSEK MNIEJSZOŚCI (masc) → PRZYJĘTY / ODRZUCONY
- *   GŁOSOWANIE (neuter)                  → PRZYJĘTE / ODRZUCONE
+ * New design inverts the hierarchy: the BIG label is the bill-level outcome
+ * (the thing a citizen actually cares about), coloured green/red by bill
+ * fate, and the motion-level description goes underneath in muted italic.
  *
- * Sublabel describes the bill-level consequence ("projekt skierowany do
- * dalszych prac", "ustawa odrzucona w trzecim czytaniu", etc.) so the reader
- * gets both the motion result and what it means for the bill.
+ *   bill outcome      headline             color    motion description below
+ *   ───────────────────────────────────────────────────────────────────────
+ *   passed            USTAWA PRZYJĘTA      success  „głosowanie nad całością — przyjęte"
+ *   rejected (pass)   USTAWA ODRZUCONA     red      „głosowanie nad całością — odrzucone"
+ *   rejected (reject) USTAWA ODRZUCONA     red      „wniosek o odrzucenie przyjęty"
+ *   continues         PROJEKT IDZIE DALEJ  success  „wniosek o odrzucenie odrzucony"
+ *   indeterminate     <motion-subject + verb, neutral>  ""
+ *
+ * Headline subject/verb agreement (Polish gender):
+ *   USTAWA / POPRAWKA  (f) → PRZYJĘTA / ODRZUCONA
+ *   WNIOSEK / PROJEKT  (m) → PRZYJĘTY / ODRZUCONY / IDZIE DALEJ
+ *   GŁOSOWANIE         (n) → PRZYJĘTE / ODRZUCONE
  */
 export type VerdictStampWords = {
-  subject: string;
-  verb: string;
-  /** Bill-level consequence, one short line. Empty string when no claim. */
-  sublabel: string;
+  /** Big italic headline — what happened to the project (or motion if indeterminate). */
+  headline: string;
+  /** Color token name used by the stamp. */
+  tone: "success" | "destructive" | "neutral";
+  /** Smaller line below describing the motion. Empty when no motion-level context to add. */
+  motionDescription: string;
 };
 
-import type { MotionPolarity as _MP } from "@/lib/promiseAlignment";
-
-function subjectFor(polarity: _MP | null): { subject: string; gender: "f" | "m" | "n" } {
-  if (polarity === "pass") return { subject: "USTAWA", gender: "f" };
-  if (polarity === "reject") return { subject: "WNIOSEK", gender: "m" };
-  if (polarity === "amendment") return { subject: "POPRAWKA", gender: "f" };
-  if (polarity === "minority") return { subject: "WNIOSEK MNIEJSZOŚCI", gender: "m" };
-  if (polarity === "procedural") return { subject: "WNIOSEK", gender: "m" };
-  return { subject: "GŁOSOWANIE", gender: "n" };
-}
-
-function verbFor(motionPassed: boolean, gender: "f" | "m" | "n"): string {
-  if (gender === "f") return motionPassed ? "PRZYJĘTA" : "ODRZUCONA";
-  if (gender === "m") return motionPassed ? "PRZYJĘTY" : "ODRZUCONY";
-  return motionPassed ? "PRZYJĘTE" : "ODRZUCONE";
-}
-
-function sublabelFor(outcome: BillOutcome): string {
-  if (outcome === "passed") return "ustawa przyjęta w trzecim czytaniu";
-  if (outcome === "rejected") return "projekt zamknięty";
-  if (outcome === "continues") return "projekt skierowany do dalszych prac";
+function motionDescriptionFor(polarity: MotionPolarity | null, motionPassed: boolean): string {
+  if (polarity === "pass") {
+    return motionPassed
+      ? "głosowanie nad całością projektu"
+      : "głosowanie nad całością projektu odrzucone";
+  }
+  if (polarity === "reject") {
+    return motionPassed
+      ? "wniosek o odrzucenie przyjęty"
+      : "wniosek o odrzucenie odrzucony";
+  }
   return "";
 }
 
+function indeterminateHeadline(polarity: MotionPolarity | null, motionPassed: boolean): { headline: string; tone: "neutral" } {
+  // Subjects + Polish gender for non-bill-claim polarities.
+  const subj = polarity === "amendment"
+    ? { word: "POPRAWKA", gender: "f" as const }
+    : polarity === "minority"
+      ? { word: "WNIOSEK MNIEJSZOŚCI", gender: "m" as const }
+      : polarity === "procedural"
+        ? { word: "WNIOSEK", gender: "m" as const }
+        : { word: "GŁOSOWANIE", gender: "n" as const };
+  const verb = subj.gender === "f"
+    ? (motionPassed ? "PRZYJĘTA" : "ODRZUCONA")
+    : subj.gender === "m"
+      ? (motionPassed ? "PRZYJĘTY" : "ODRZUCONY")
+      : (motionPassed ? "PRZYJĘTE" : "ODRZUCONE");
+  return { headline: `${subj.word} ${verb}`, tone: "neutral" };
+}
+
 export function verdictStampWords(
-  polarity: _MP | null,
+  polarity: MotionPolarity | null,
   motionPassed: boolean,
 ): VerdictStampWords {
-  const { subject, gender } = subjectFor(polarity);
-  const verb = verbFor(motionPassed, gender);
-  const sublabel = sublabelFor(computeBillOutcome(polarity, motionPassed));
-  return { subject, verb, sublabel };
+  const outcome = computeBillOutcome(polarity, motionPassed);
+  if (outcome === "indeterminate") {
+    const { headline, tone } = indeterminateHeadline(polarity, motionPassed);
+    return { headline, tone, motionDescription: "" };
+  }
+  let headline: string;
+  let tone: "success" | "destructive";
+  if (outcome === "passed") {
+    headline = "USTAWA PRZYJĘTA";
+    tone = "success";
+  } else if (outcome === "rejected") {
+    headline = "USTAWA ODRZUCONA";
+    tone = "destructive";
+  } else {
+    // continues — failed reject-motion; bill goes back to committee.
+    headline = "PROJEKT IDZIE DALEJ";
+    tone = "success";
+  }
+  return { headline, tone, motionDescription: motionDescriptionFor(polarity, motionPassed) };
 }
 
 /** Short chip label for VotingRow.verdict on /druk pages. */

--- a/tests/supagraf/unit/test_bill_outcome.py
+++ b/tests/supagraf/unit/test_bill_outcome.py
@@ -200,20 +200,34 @@ def test_non_bill_level_motions_never_claim_outcome(polarity) -> None:
 
 
 # ─── Verdict-stamp truth table (mirror of bill_outcome.ts verdictStampWords) ──
-# The giant headline on /glosowanie/[id]. Pre-fix it always read "PRZYJĘTA" /
-# "ODRZUCONA" (feminine, matching "ustawa") — feels like "ustawa odrzucona"
-# even when the vote was a procedural motion. Subject + grammatical gender
-# now derive from polarity.
+# Inverted hierarchy (citizen review on druk 2197 / voting 1513): the BIG label
+# is now the BILL outcome ("USTAWA PRZYJĘTA" / "USTAWA ODRZUCONA" / "PROJEKT
+# IDZIE DALEJ"), coloured green/red by what happened to the project — not what
+# happened to the procedural motion. The motion description ("wniosek o
+# odrzucenie przyjęty", "głosowanie nad całością") moves to a smaller italic
+# line below.
 
 def _stamp_words(polarity: MotionPolarity, motion_passed: bool) -> tuple[str, str, str]:
     """Python mirror of frontend/lib/voting/bill_outcome.ts verdictStampWords.
-    Returns (subject, verb, sublabel).
+    Returns (headline, tone, motion_description).
+    tone ∈ {"success", "destructive", "neutral"}.
     """
-    if polarity == "pass":
-        subject, gender = "USTAWA", "f"
-    elif polarity == "reject":
-        subject, gender = "WNIOSEK", "m"
-    elif polarity == "amendment":
+    outcome = compute_bill_outcome(polarity, motion_passed)
+    if outcome == "passed":
+        return "USTAWA PRZYJĘTA", "success", (
+            "głosowanie nad całością projektu" if motion_passed else "głosowanie nad całością projektu odrzucone"
+        )
+    if outcome == "rejected":
+        # Either polarity='pass' + failed, or polarity='reject' + passed.
+        motion = (
+            "głosowanie nad całością projektu odrzucone" if polarity == "pass"
+            else "wniosek o odrzucenie przyjęty"
+        )
+        return "USTAWA ODRZUCONA", "destructive", motion
+    if outcome == "continues":
+        return "PROJEKT IDZIE DALEJ", "success", "wniosek o odrzucenie odrzucony"
+    # indeterminate — fall back to motion subject + verb.
+    if polarity == "amendment":
         subject, gender = "POPRAWKA", "f"
     elif polarity == "minority":
         subject, gender = "WNIOSEK MNIEJSZOŚCI", "m"
@@ -221,72 +235,71 @@ def _stamp_words(polarity: MotionPolarity, motion_passed: bool) -> tuple[str, st
         subject, gender = "WNIOSEK", "m"
     else:
         subject, gender = "GŁOSOWANIE", "n"
-
     if gender == "f":
         verb = "PRZYJĘTA" if motion_passed else "ODRZUCONA"
     elif gender == "m":
         verb = "PRZYJĘTY" if motion_passed else "ODRZUCONY"
     else:
         verb = "PRZYJĘTE" if motion_passed else "ODRZUCONE"
-
-    outcome = compute_bill_outcome(polarity, motion_passed)
-    if outcome == "passed":
-        sublabel = "ustawa przyjęta w trzecim czytaniu"
-    elif outcome == "rejected":
-        sublabel = "projekt zamknięty"
-    elif outcome == "continues":
-        sublabel = "projekt skierowany do dalszych prac"
-    else:
-        sublabel = ""
-    return subject, verb, sublabel
+    return f"{subject} {verb}", "neutral", ""
 
 
-# Each tuple: (voting_id, polarity, yes, maj, expected_subject, expected_verb, expected_sublabel)
+# Each tuple: (voting_id, polarity, yes, maj, expected_headline, expected_tone, expected_motion)
 STAMP_FIXTURES: list[tuple[int, MotionPolarity, int, int, str, str, str]] = [
-    # Bug case: reject motion failed → "WNIOSEK ODRZUCONY" (NOT "USTAWA ODRZUCONA")
-    (1517, "reject", 201, 243, "WNIOSEK", "ODRZUCONY", "projekt skierowany do dalszych prac"),
-    (446,  "reject", 188, 229, "WNIOSEK", "ODRZUCONY", "projekt skierowany do dalszych prac"),
-    (55,   "reject", 203, 224, "WNIOSEK", "ODRZUCONY", "projekt skierowany do dalszych prac"),
-    # Reject motion passed → "WNIOSEK PRZYJĘTY" + sublabel "projekt zamknięty"
-    (65,   "reject", 237, 189, "WNIOSEK", "PRZYJĘTY", "projekt zamknięty"),
-    (1513, "reject", 244, 208, "WNIOSEK", "PRZYJĘTY", "projekt zamknięty"),
-    # Third-reading pass succeeded → "USTAWA PRZYJĘTA"
-    (299,  "pass",   415,   1, "USTAWA",  "PRZYJĘTA", "ustawa przyjęta w trzecim czytaniu"),
-    (1113, "pass",   241, 184, "USTAWA",  "PRZYJĘTA", "ustawa przyjęta w trzecim czytaniu"),
-    # Third-reading pass failed → "USTAWA ODRZUCONA" + sublabel "projekt zamknięty"
-    (1978, "pass",   199, 232, "USTAWA",  "ODRZUCONA", "projekt zamknięty"),
-    # Amendment passed/failed — feminine, no bill-level claim
-    (136, "amendment", 238, 201, "POPRAWKA", "PRZYJĘTA", ""),
-    (135, "amendment",  30, 411, "POPRAWKA", "ODRZUCONA", ""),
-    # Minority motions — masculine
-    (900, "minority", 202, 233, "WNIOSEK MNIEJSZOŚCI", "ODRZUCONY", ""),
-    # Procedural — masculine
-    (44,  "procedural", 190, 242, "WNIOSEK", "ODRZUCONY", ""),
-    # Null polarity — neuter fallback
-    (20,  None, 230, 171, "GŁOSOWANIE", "PRZYJĘTE", ""),
+    # The original #25 bug — reject motion failed → bill survives.
+    # Headline must NOT contain "ODRZUCONA" (would read as bill rejected).
+    (1517, "reject", 201, 243, "PROJEKT IDZIE DALEJ", "success", "wniosek o odrzucenie odrzucony"),
+    (446,  "reject", 188, 229, "PROJEKT IDZIE DALEJ", "success", "wniosek o odrzucenie odrzucony"),
+    (55,   "reject", 203, 224, "PROJEKT IDZIE DALEJ", "success", "wniosek o odrzucenie odrzucony"),
+    # The /druk/10/2197 case — reject motion passed → bill killed. The OLD
+    # stamp showed huge green "PRZYJĘTY" here; new stamp shows huge red
+    # "USTAWA ODRZUCONA" with motion description below.
+    (1513, "reject", 244, 208, "USTAWA ODRZUCONA", "destructive", "wniosek o odrzucenie przyjęty"),
+    (65,   "reject", 237, 189, "USTAWA ODRZUCONA", "destructive", "wniosek o odrzucenie przyjęty"),
+    # Third-reading pass succeeded.
+    (299,  "pass",   415,   1, "USTAWA PRZYJĘTA", "success", "głosowanie nad całością projektu"),
+    (1113, "pass",   241, 184, "USTAWA PRZYJĘTA", "success", "głosowanie nad całością projektu"),
+    # Third-reading pass failed → bill genuinely rejected at 3rd reading.
+    (1978, "pass",   199, 232, "USTAWA ODRZUCONA", "destructive", "głosowanie nad całością projektu odrzucone"),
+    # Amendments / minority / procedural / null — indeterminate, neutral tone.
+    (136, "amendment", 238, 201, "POPRAWKA PRZYJĘTA", "neutral", ""),
+    (135, "amendment",  30, 411, "POPRAWKA ODRZUCONA", "neutral", ""),
+    (900, "minority", 202, 233, "WNIOSEK MNIEJSZOŚCI ODRZUCONY", "neutral", ""),
+    (44,  "procedural", 190, 242, "WNIOSEK ODRZUCONY", "neutral", ""),
+    (20,  None, 230, 171, "GŁOSOWANIE PRZYJĘTE", "neutral", ""),
 ]
 
 
 @pytest.mark.parametrize(
-    "voting_id,polarity,yes,maj,expected_subject,expected_verb,expected_sublabel",
+    "voting_id,polarity,yes,maj,expected_headline,expected_tone,expected_motion",
     [pytest.param(*row, id=f"v{row[0]}") for row in STAMP_FIXTURES],
 )
 def test_verdict_stamp_words_real_cases(
-    voting_id, polarity, yes, maj, expected_subject, expected_verb, expected_sublabel,
+    voting_id, polarity, yes, maj, expected_headline, expected_tone, expected_motion,
 ) -> None:
-    subject, verb, sublabel = _stamp_words(polarity, _motion_passed(yes, maj))
-    assert subject == expected_subject, f"voting {voting_id}: subject"
-    assert verb == expected_verb, f"voting {voting_id}: verb"
-    assert sublabel == expected_sublabel, f"voting {voting_id}: sublabel"
+    headline, tone, motion_description = _stamp_words(polarity, _motion_passed(yes, maj))
+    assert headline == expected_headline, f"voting {voting_id}: headline"
+    assert tone == expected_tone, f"voting {voting_id}: tone"
+    assert motion_description == expected_motion, f"voting {voting_id}: motion description"
 
 
-def test_stamp_avoids_ustawa_odrzucona_misread_for_reject_motions() -> None:
-    """Regression guard for issue #25: a failed 'wniosek o odrzucenie' MUST
-    NOT render as feminine 'ODRZUCONA' (which reads as 'ustawa odrzucona').
-    Subject should be 'WNIOSEK' (masculine), verb 'ODRZUCONY'.
+def test_stamp_priorities_bill_outcome_for_reject_passed() -> None:
+    """Citizen review on druk 10/2197 / voting 1513: a reject-motion that PASSED
+    killed the bill. The big stamp must read "USTAWA ODRZUCONA" (red), not
+    a giant green "WNIOSEK PRZYJĘTY" with the kill demoted to a tiny sublabel.
     """
-    subject, verb, _ = _stamp_words("reject", motion_passed=False)
-    assert subject == "WNIOSEK"
-    assert verb == "ODRZUCONY"
-    # The two words combined never form "USTAWA ODRZUCONA":
-    assert f"{subject} {verb}" != "USTAWA ODRZUCONA"
+    headline, tone, motion = _stamp_words("reject", motion_passed=True)
+    assert headline == "USTAWA ODRZUCONA"
+    assert tone == "destructive"
+    assert "przyjęty" in motion  # motion description still accurate
+
+
+def test_stamp_priorities_bill_outcome_for_reject_failed() -> None:
+    """Mirror of the original #25 bug: a reject-motion that FAILED means the
+    bill SURVIVES. The big stamp must convey "project continues" (success
+    color), not "WNIOSEK ODRZUCONY" red-coloured.
+    """
+    headline, tone, motion = _stamp_words("reject", motion_passed=False)
+    assert headline == "PROJEKT IDZIE DALEJ"
+    assert tone == "success"
+    assert "odrzucony" in motion


### PR DESCRIPTION
Two citizen-review bugs from /druk/10/2197 (voting 1513 — reject motion that **passed**, killing the bill):

## 1. "Głosowanie · other" — English role leaked into Polish UI

PR #30's sidebar header / chip helpers only handled `role === "main"`. After the ETL reclassification in PR #31, votings that had been mis-tagged became `role='other'` — and the sidebar fell through to a raw `Głosowanie · ${role}` template, rendering literally `Głosowanie · other`. Same path produced English on the related-votings chip.

**Fix:** new `votingChip(polarity, role)` + `sidebarHeaderLabel(polarity, role)` helpers. Polarity drives the label when known:

| polarity   | label                  |
| ---------- | ---------------------- |
| pass       | całość projektu        |
| reject     | wniosek o odrzucenie   |
| amendment  | poprawki               |
| minority   | wniosek mniejszości    |
| procedural | wniosek proceduralny   |

When polarity is null, falls back to `ROLE_LABEL_PL` (main/sprawozd./autopoprawka/poprawka/joint/inne — all Polish, no English leak).

## 2. Tragic UI hierarchy on the verdict stamp

Old stamp for voting 1513 (reject motion **passed** → bill killed):

```
WNIOSEK
PRZYJĘTY     ← huge italic green
projekt zamknięty   ← tiny gray
```

Reader parses "WNIOSEK PRZYJĘTY" as "all good" before noticing the kill in the subtitle. Same shape inverted: a reject-motion that **fails** (saving the bill) reads "WNIOSEK ODRZUCONY" in red — also wrong-vibe.

**Fix:** invert the hierarchy. The BIG headline is now the **bill outcome**, coloured by what happened to the project. Motion description moves to a smaller italic line below:

| bill outcome     | headline             | color | motion description below                       |
| ---------------- | -------------------- | ----- | ---------------------------------------------- |
| passed           | USTAWA PRZYJĘTA      | green | głosowanie nad całością projektu               |
| rejected (pass)  | USTAWA ODRZUCONA     | red   | głosowanie nad całością projektu odrzucone     |
| rejected (reject)| USTAWA ODRZUCONA     | red   | wniosek o odrzucenie przyjęty                  |
| continues        | PROJEKT IDZIE DALEJ  | green | wniosek o odrzucenie odrzucony                 |
| indeterminate    | <motion subj + verb> | neutral | —                                            |

### Effect on real votings

| voting | before                      | after                                                  |
| ------ | --------------------------- | ------------------------------------------------------ |
| 1513 (druk 2197, reject passed) | huge green WNIOSEK PRZYJĘTY | huge red **USTAWA ODRZUCONA** · *wniosek o odrzucenie przyjęty* |
| 1517 (druk 2449, reject failed) | huge red WNIOSEK ODRZUCONY  | huge green **PROJEKT IDZIE DALEJ** · *wniosek o odrzucenie odrzucony* |
| 299 (pass passed)              | USTAWA PRZYJĘTA             | USTAWA PRZYJĘTA *(unchanged)*                          |
| 1978 (pass failed)             | USTAWA ODRZUCONA            | USTAWA ODRZUCONA *(unchanged)*                         |

## Tests

`_stamp_words` mirror rewritten for the new `(headline, tone, motion_description)` shape; same 13 real fixtures plus two new regression tests pinning both UX directions:

- `test_stamp_priorities_bill_outcome_for_reject_passed` — guards against future revert to green "WNIOSEK PRZYJĘTY" when the bill was actually killed.
- `test_stamp_priorities_bill_outcome_for_reject_failed` — guards against red "WNIOSEK ODRZUCONY" when the bill actually survived.

54/54 Python tests pass; `tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sEATcg5AoCV8andKXZesD)_