### PR TITLE
fix(frontend): real data update timestamp instead of misleading today label

### DIFF
--- a/frontend/app/atlas/page.tsx
+++ b/frontend/app/atlas/page.tsx
@@ -12,6 +12,7 @@ import {
   getTopicTrends,
   TOPICS_ENUM,
 } from "@/lib/db/atlas";
+import { getLastDataUpdate, formatDataUpdate } from "@/lib/db/freshness";
 import { MapaOkregow } from "./_components/MapaOkregow";
 import { HeatmapaKoalicji } from "./_components/HeatmapaKoalicji";
 import { SankeyKluby } from "./_components/SankeyKluby";
@@ -22,15 +23,6 @@ import { OCzymMowiSejm } from "./_components/OCzymMowiSejm";
 // Atlas is data-driven (Supabase) and we want it to recompute on each request
 // rather than freeze at build time.
 
-async function formatToday(): Promise<string> {
-  return new Date().toLocaleDateString("pl-PL", {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
-}
-
 // Vercel SSR can hit Supabase's PostgREST 8s ceiling on the voting_by_club
 // view (~250k votes re-aggregated per request). Don't 500 the page if one
 // module fails — render the rest and let the caller retry.
@@ -39,13 +31,14 @@ async function safe<T>(p: Promise<T>, fallback: T): Promise<T> {
 }
 
 export default async function AtlasPage() {
-  const [heatmap, discipline, topics, mapData, sankey, ministers] = await Promise.all([
+  const [heatmap, discipline, topics, mapData, sankey, ministers, lastUpdate] = await Promise.all([
     safe(getKlubHeatmap(), { klubs: [], cells: [], totalVotings: 0 }),
     safe(getPartyDiscipline(), []),
     safe(getTopicTrends(), { buckets: [], topics: TOPICS_ENUM, shares: [], totalsPerBucket: [] }),
     safe(getDistrictMap(), getMapPlaceholder()),
     safe(getKlubFlow(), getSankeyPlaceholder()),
     safe(getSlowMinisters(), getSlowMinistersPlaceholder()),
+    safe(getLastDataUpdate(), null),
   ]);
 
   return (
@@ -53,7 +46,7 @@ export default async function AtlasPage() {
       <div className="max-w-[1280px] mx-auto min-w-0 w-full">
         <PageBreadcrumb
           items={[{ label: "Atlas" }]}
-          subtitle={`Aktualizacja: ${await formatToday()} · n = ${heatmap.totalVotings.toLocaleString("pl-PL")} głosowań · Źródło: ETL sejmograf + API Sejmu RP`}
+          subtitle={`Aktualizacja: ${formatDataUpdate(lastUpdate)} · n = ${heatmap.totalVotings.toLocaleString("pl-PL")} głosowań · Źródło: ETL sejmograf + API Sejmu RP`}
         />
 
         <div className="grid gap-12 sm:gap-16 md:gap-20 min-w-0 [&>*]:min-w-0">

--- a/frontend/app/sondaze/_components/SondazeHero.tsx
+++ b/frontend/app/sondaze/_components/SondazeHero.tsx
@@ -7,10 +7,6 @@ function fmtPct(n: number): string {
   return n.toLocaleString("pl-PL", { minimumFractionDigits: 1, maximumFractionDigits: 1 });
 }
 
-function formatToday(): string {
-  return new Date().toLocaleDateString("pl-PL", { day: "numeric", month: "long" });
-}
-
 function daysAgo(iso: string): string {
   const d = new Date(iso + "T00:00:00Z");
   const now = new Date();
@@ -21,7 +17,7 @@ function daysAgo(iso: string): string {
   return `${Math.floor(diff / 7)} tyg. temu`;
 }
 
-export function SondazeHero({ rows }: { rows: PollAverageRow[] }) {
+export function SondazeHero({ rows, lastUpdateLabel }: { rows: PollAverageRow[]; lastUpdateLabel: string }) {
   const main = rows.filter((r) => !RESIDUAL_CODES.has(r.party_code));
   const latestPoll = main.reduce<string | null>((acc, r) => {
     if (!r.last_conducted_at) return acc;
@@ -93,7 +89,7 @@ export function SondazeHero({ rows }: { rows: PollAverageRow[] }) {
         </div>
 
         <div className="flex flex-wrap gap-x-3 gap-y-1.5 sm:gap-x-5 mt-6 sm:mt-7 font-mono text-[10px] sm:text-[11px] uppercase text-muted-foreground tracking-wide sm:tracking-wider">
-          <span>Aktualizacja: {formatToday()}</span>
+          <span>Aktualizacja: {lastUpdateLabel}</span>
           {latestPoll && (
             <>
               <span aria-hidden>·</span>

--- a/frontend/app/sondaze/page.tsx
+++ b/frontend/app/sondaze/page.tsx
@@ -6,6 +6,7 @@ import {
   TREND_DEFAULT_PARTIES,
 } from "@/lib/db/polls";
 import { getKlubPairAgreement, DEFAULT_TERM as COHESION_TERM } from "@/lib/db/coalition_agreement";
+import { getLastDataUpdate, formatDataUpdate } from "@/lib/db/freshness";
 import { RESIDUAL_CODES } from "./_components/partyMeta";
 import { Average30dGrid } from "./_components/Average30dGrid";
 import { QuarterlyTrendChart } from "./_components/QuarterlyTrendChart";
@@ -43,11 +44,12 @@ export default async function SondazePage() {
     return eligible.length > 0 ? eligible : [...TREND_DEFAULT_PARTIES];
   })();
 
-  const [trend, recent, pollsters, agreement] = await Promise.all([
+  const [trend, recent, pollsters, agreement, lastUpdate] = await Promise.all([
     safe(getPollTrendQuarterly(trendParties), []),
     safe(getRecentPolls(20), []),
     safe(getPollsterSummary(), []),
     safe(getKlubPairAgreement(COHESION_TERM), { byPair: new Map() }),
+    safe(getLastDataUpdate(), null),
   ]);
 
   const mainCount = averages.filter((r) => !RESIDUAL_CODES.has(r.party_code)).length;
@@ -64,7 +66,7 @@ export default async function SondazePage() {
     <main className="bg-background text-foreground font-serif px-3 sm:px-8 md:px-14 pt-8 sm:pt-12 pb-12 sm:pb-16 min-w-0">
       <div className="max-w-[1280px] mx-auto min-w-0">
         <PageBreadcrumb items={[{ label: "Sondaże" }]} />
-        <SondazeHero rows={averages} />
+        <SondazeHero rows={averages} lastUpdateLabel={formatDataUpdate(lastUpdate)} />
 
         <div className="mt-8 sm:mt-12">
           <SondazeTabsClient

--- a/frontend/lib/db/freshness.ts
+++ b/frontend/lib/db/freshness.ts
@@ -20,6 +20,21 @@ const PROBES: Array<{ table: string; termFilter: boolean }> = [
 
 const DEFAULT_TERM = 10;
 
+// Shared formatter so /atlas, /sondaze, SiteFooter all render the same string
+// instead of each cooking up its own "today" pseudo-timestamp.
+const PL_DATETIME = new Intl.DateTimeFormat("pl-PL", {
+  day: "numeric",
+  month: "long",
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZone: "Europe/Warsaw",
+});
+
+export function formatDataUpdate(d: Date | null): string {
+  if (!d) return "brak danych";
+  return PL_DATETIME.format(d);
+}
+
 export async function getLastDataUpdate(term = DEFAULT_TERM): Promise<Date | null> {
   const sb = supabase();
   const results = await Promise.all(


### PR DESCRIPTION
## Problem

Pages `/sondaze` and `/atlas` displayed `Aktualizacja: środa, 14 maja 2026` using `formatToday()` — returns CURRENT date regardless of actual data freshness. Misleading: user sees "today" even if ETL last ran 3+ hours ago or failed.

## Root cause

`formatToday()` returned `new Date()` formatted as Polish dotted-date string. No connection to real data timestamps.

## Solution

- Added shared `formatDataUpdate(Date | null)` formatter in `frontend/lib/db/freshness.ts`
- `/atlas` + `/sondaze` now fetch `getLastDataUpdate()` (max of `prints.loaded_at` etc.) alongside their data
- Display: `Aktualizacja: 14 maja, 04:04` (real timestamp, Warsaw TZ)
- Cold DB fallback: `Aktualizacja: brak danych`

## Changes

- `frontend/lib/db/freshness.ts` — added `formatDataUpdate()` shared formatter
- `frontend/app/atlas/page.tsx` — dropped `formatToday()`, added `getLastDataUpdate()` to Promise.all
- `frontend/app/sondaze/page.tsx` — added `getLastDataUpdate()` fetch, pass label as prop
- `frontend/app/sondaze/_components/SondazeHero.tsx` — takes `lastUpdateLabel: string` prop

## NOT touched

SiteFooter keeps `relativeLabel()` ("3 godz. temu") intentionally — chrome band wants relative, header wants absolute.

## Verify

- `pnpm build` green, TS strict clean, 23 routes generated
- /atlas + /sondaze show real timestamp instead of today
- Cold DB simulated → `brak danych`