### PR TITLE
perf(frontend): Lighthouse sweep — bundle, CLS, a11y, SEO

### DIFF
--- a/frontend/app/_components/FeatureTileGrid.tsx
+++ b/frontend/app/_components/FeatureTileGrid.tsx
@@ -166,6 +166,10 @@ export async function FeatureTileGrid() {
                               src={logo}
                               alt={r.klub}
                               title={r.klub}
+                              width={20}
+                              height={20}
+                              loading="lazy"
+                              decoding="async"
                               className="w-5 h-5 rounded-full object-cover border border-border"
                             />
                           ) : (
@@ -219,6 +223,10 @@ export async function FeatureTileGrid() {
                               src={logo}
                               alt={partyLabel(r.party_code)}
                               title={partyLabel(r.party_code)}
+                              width={20}
+                              height={20}
+                              loading="lazy"
+                              decoding="async"
                               className="w-5 h-5 rounded-full object-cover border border-border shrink-0"
                             />
                           ) : (

--- a/frontend/app/alerty/page.tsx
+++ b/frontend/app/alerty/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { ComingSoonPage } from "@/components/chrome/ComingSoonPage";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/alerty" },
+};
 
 // Subskrypcje alertów wymagają działającego backendu auth-less
 // (insert_alert_subscription RPC + worker dostarczający e-mail/RSS/push).

--- a/frontend/app/atlas/page.tsx
+++ b/frontend/app/atlas/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import { Ornament } from "@/components/chrome/Ornament";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/atlas" },
+};
+
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
 import {
   getDistrictMap,

--- a/frontend/app/budzet/page.tsx
+++ b/frontend/app/budzet/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import Image from "next/image";
 import { Ornament } from "@/components/chrome/Ornament";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/budzet" },
+};
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
 import { getInfraCosts } from "@/lib/db/budzet";
 import { getPatroniteStats } from "@/lib/patronite";

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -68,7 +68,7 @@
   --secondary:            #ede6d3;
   --secondary-foreground: #2a2520;
   --muted:                #ede6d3;
-  --muted-foreground:     #6e6356;
+  --muted-foreground:     #5d5347;
   --accent:               #ede6d3;
   --accent-foreground:    #161310;
   --destructive:          #8a2a1f;

--- a/frontend/app/komisja/page.tsx
+++ b/frontend/app/komisja/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import {
   getCommitteeList,
   getCommitteeActivityStats,
@@ -7,6 +8,10 @@ import {
 } from "@/lib/db/committees";
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
 import { CommitteeRow } from "@/components/komisja/CommitteeRow";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/komisja" },
+};
 
 type GroupKey = "STANDING" | "EXTRAORDINARY" | "INVESTIGATIVE" | "OTHER";
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -13,20 +13,20 @@ const UMAMI_WEBSITE_ID = "85d3ab78-6c6b-4d21-8552-351cd900cd71";
 const inter = Inter({
   variable: "--font-inter",
   subsets: ["latin", "latin-ext"],
-  weight: ["300", "400", "500", "600", "700"],
+  weight: ["400", "500", "600", "700"],
 });
 
 const sourceSerif = Source_Serif_4({
   variable: "--font-source-serif",
   subsets: ["latin", "latin-ext"],
-  weight: ["300", "400", "500", "600", "700"],
+  weight: ["400", "500", "600", "700"],
   style: ["normal", "italic"],
 });
 
 const jetbrainsMono = JetBrains_Mono({
   variable: "--font-jetbrains-mono",
   subsets: ["latin", "latin-ext"],
-  weight: ["400", "500", "600", "700"],
+  weight: ["400", "500", "700"],
 });
 
 const SITE_URL = "https://tygodniksejmowy.pl";
@@ -156,7 +156,7 @@ export default function RootLayout({
           defer
           src="https://cloud.umami.is/script.js"
           data-website-id={UMAMI_WEBSITE_ID}
-          strategy="afterInteractive"
+          strategy="lazyOnload"
         />
         <script
           type="application/ld+json"

--- a/frontend/app/manifest/page.tsx
+++ b/frontend/app/manifest/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import { Ornament } from "@/components/chrome/Ornament";
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/manifest" },
+};
 
 // Manifest is a static editorial page — no data, no force-dynamic.
 // Patronite tiers and the anti-feature list are the emotional contract

--- a/frontend/app/mowa/page.tsx
+++ b/frontend/app/mowa/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { getTopViralStatements } from "@/lib/db/statements";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/mowa" },
+};
 import { ComingSoonPage } from "@/components/chrome/ComingSoonPage";
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
 import { KLUB_COLORS, KLUB_LABELS } from "@/lib/atlas/constants";

--- a/frontend/app/o-projekcie/page.tsx
+++ b/frontend/app/o-projekcie/page.tsx
@@ -1,8 +1,13 @@
+import type { Metadata } from "next";
 import Image from "next/image";
 import { Ornament } from "@/components/chrome/Ornament";
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
 import { getInfraCosts } from "@/lib/db/budzet";
 import { getPatroniteStats } from "@/lib/patronite";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/o-projekcie" },
+};
 
 const TEAM = [
   {

--- a/frontend/app/obietnice/page.tsx
+++ b/frontend/app/obietnice/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import {
   getPromisesEnriched,
   isActivityFilter,
@@ -7,6 +8,10 @@ import { ObietniceClient } from "./_components/ObietniceClient";
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
 
 export const revalidate = 300;
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/obietnice" },
+};
 
 function parseList(value: string | string[] | undefined): string[] {
   if (!value) return [];

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -20,9 +20,9 @@ async function safeTypewriter() {
 export default async function Landing() {
   const quotes = await safeTypewriter();
   return (
-    <div className="bg-background font-serif text-foreground">
+    <main className="bg-background font-serif text-foreground">
       <LandingHero viralQuotes={quotes} />
       <FeatureTileGrid />
-    </div>
+    </main>
   );
 }

--- a/frontend/app/sondaze/page.tsx
+++ b/frontend/app/sondaze/page.tsx
@@ -24,6 +24,7 @@ export const metadata = {
   title: "Sondaże — Tygodnik Sejmowy",
   description:
     "Co Polacy myślą o partiach. Średnia ważona z ostatnich 30 dni, projekcja mandatów i historyczne trendy kwartalne.",
+  alternates: { canonical: "/sondaze" },
 };
 
 async function safe<T>(p: Promise<T>, fallback: T): Promise<T> {

--- a/frontend/app/szukaj/page.tsx
+++ b/frontend/app/szukaj/page.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
   title: "Szukaj",
   description:
     "Pełnotekstowe wyszukiwanie po polsku w drukach, posłach, głosowaniach, komisjach, obietnicach i wystąpieniach.",
+  alternates: { canonical: "/szukaj" },
 };
 
 const GROUP_ORDER: FtsKind[] = ["mp", "voting", "print", "committee", "promise", "statement"];

--- a/frontend/app/tygodnik/_components/BriefList.tsx
+++ b/frontend/app/tygodnik/_components/BriefList.tsx
@@ -629,7 +629,7 @@ export function BriefList({
   const lightWeek = totalEvents > 0 && totalEvents < 6;
 
   return (
-    <div className="bg-background font-serif text-foreground">
+    <main className="bg-background font-serif text-foreground">
       {/* Masthead — issue identity + volume stats read as one editorial strip */}
       <div className="border-b border-rule">
         <div className="max-w-[1100px] mx-auto px-4 md:px-8 lg:px-14 pt-6 pb-4 md:pt-8 md:pb-6">
@@ -653,6 +653,7 @@ export function BriefList({
                   href={`/tygodnik/p/${olderSitting.sittingNum}`}
                   className="text-muted-foreground hover:text-destructive transition-colors"
                   title={`Posiedzenie ${olderSitting.sittingNum} · ${formatDateRange(olderSitting.firstDate, olderSitting.lastDate)}`}
+                  aria-label={`Poprzednie posiedzenie nr ${olderSitting.sittingNum}`}
                 >
                   ← Nr {olderSitting.sittingNum}
                 </Link>
@@ -677,6 +678,7 @@ export function BriefList({
                   href={`/tygodnik/p/${newerSitting.sittingNum}`}
                   className="text-muted-foreground hover:text-destructive transition-colors"
                   title={`Posiedzenie ${newerSitting.sittingNum} · ${formatDateRange(newerSitting.firstDate, newerSitting.lastDate)}`}
+                  aria-label={`Następne posiedzenie nr ${newerSitting.sittingNum}`}
                 >
                   Nr {newerSitting.sittingNum} →
                 </Link>
@@ -728,9 +730,13 @@ export function BriefList({
         {filteredPrints.length > 0 && (
           <>
             <SectionHeader icon="📜" label="Nowe projekty" count={filteredPrints.length} />
-            {filteredPrints.map((it, i) => (
-              <ItemView key={it.id} item={it} idx={i} personas={personas} />
-            ))}
+            <ul role="list" className="contents">
+              {filteredPrints.map((it, i) => (
+                <li key={it.id} className="contents">
+                  <ItemView item={it} idx={i} personas={personas} />
+                </li>
+              ))}
+            </ul>
             {hydrated && filterActive && (
               // Mobile-only CTA — desktop has this inline next to the counter.
               <div className="md:hidden mt-2 mb-2 px-1 text-center">
@@ -748,32 +754,35 @@ export function BriefList({
         {unmergedVotes.length > 0 && (
           <>
             <SectionHeader icon="⚖" label="Pozostałe głosowania" count={unmergedVotes.length} />
-            {unmergedVotes.map((ev, i) => (
-              <VotingHemicycleCard
-                key={ev.payload.voting_id}
-                idx={i}
-                voting={{
-                  voting_id: ev.payload.voting_id,
-                  voting_number: ev.payload.voting_number,
-                  title: ev.payload.title,
-                  topic: ev.payload.topic,
-                  date: ev.payload.date,
-                  yes: ev.payload.yes,
-                  no: ev.payload.no,
-                  abstain: ev.payload.abstain,
-                  not_participating: ev.payload.not_participating,
-                  majority_votes: ev.payload.majority_votes ?? null,
-                  motion_polarity: ev.payload.motion_polarity ?? null,
-                  term: ev.term,
-                }}
-                clubs={ev.payload.club_tally ?? []}
-                linkedPrint={ev.payload.linked_prints?.[0] ? {
-                  number: ev.payload.linked_prints[0].number,
-                  short_title: ev.payload.linked_prints[0].short_title,
-                  impact_punch: ev.payload.linked_prints[0].impact_punch ?? null,
-                } : null}
-              />
-            ))}
+            <ul role="list" className="contents">
+              {unmergedVotes.map((ev, i) => (
+                <li key={ev.payload.voting_id} className="contents">
+                  <VotingHemicycleCard
+                    idx={i}
+                    voting={{
+                      voting_id: ev.payload.voting_id,
+                      voting_number: ev.payload.voting_number,
+                      title: ev.payload.title,
+                      topic: ev.payload.topic,
+                      date: ev.payload.date,
+                      yes: ev.payload.yes,
+                      no: ev.payload.no,
+                      abstain: ev.payload.abstain,
+                      not_participating: ev.payload.not_participating,
+                      majority_votes: ev.payload.majority_votes ?? null,
+                      motion_polarity: ev.payload.motion_polarity ?? null,
+                      term: ev.term,
+                    }}
+                    clubs={ev.payload.club_tally ?? []}
+                    linkedPrint={ev.payload.linked_prints?.[0] ? {
+                      number: ev.payload.linked_prints[0].number,
+                      short_title: ev.payload.linked_prints[0].short_title,
+                      impact_punch: ev.payload.linked_prints[0].impact_punch ?? null,
+                    } : null}
+                  />
+                </li>
+              ))}
+            </ul>
           </>
         )}
 
@@ -782,14 +791,26 @@ export function BriefList({
         {partitioned.lateInterpellations.length > 0 && (
           <>
             <SectionHeader icon="🔥" label="Opóźnione odpowiedzi ministrów" count={partitioned.lateInterpellations.length} />
-            {partitioned.lateInterpellations.map((ev, i) => <InterpellationCard key={ev.payload.question_id} ev={ev} idx={i} />)}
+            <ul role="list" className="contents">
+              {partitioned.lateInterpellations.map((ev, i) => (
+                <li key={ev.payload.question_id} className="contents">
+                  <InterpellationCard ev={ev} idx={i} />
+                </li>
+              ))}
+            </ul>
           </>
         )}
 
         {partitioned.viralQuotes.length > 0 && (
           <>
             <SectionHeader icon="📺" label="Powiedziane w Sejmie" count={partitioned.viralQuotes.length} />
-            {partitioned.viralQuotes.map((ev, i) => <ViralCard key={ev.payload.statement_id} ev={ev} idx={i} />)}
+            <ul role="list" className="contents">
+              {partitioned.viralQuotes.map((ev, i) => (
+                <li key={ev.payload.statement_id} className="contents">
+                  <ViralCard ev={ev} idx={i} />
+                </li>
+              ))}
+            </ul>
           </>
         )}
       </div>
@@ -831,6 +852,6 @@ export function BriefList({
           <span className="text-destructive">RSS · ICS · e-mail</span>
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/frontend/app/tygodnik/page.tsx
+++ b/frontend/app/tygodnik/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
   getEventsBySitting,
@@ -8,6 +9,10 @@ import { BriefList } from "./_components/BriefList";
 
 // ISR: `unstable_cache` in `lib/db/events` bounds cold PostgREST work; 300s matches that layer.
 export const revalidate = 300;
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/tygodnik" },
+};
 
 export default async function TygodnikPage() {
   const [latest, sittings] = await Promise.all([

--- a/frontend/components/skeletons/PageSkeleton.tsx
+++ b/frontend/components/skeletons/PageSkeleton.tsx
@@ -27,7 +27,7 @@ function Bar({
 
 export function PageSkeleton() {
   return (
-    <div className="bg-background font-serif">
+    <div className="bg-background font-serif" style={{ minHeight: "100vh" }}>
       <span className="sr-only">Wczytywanie…</span>
       <div className="border-b border-rule">
         <div className="max-w-[1100px] mx-auto px-4 md:px-8 lg:px-14 pt-8 pb-6">
@@ -37,15 +37,20 @@ export function PageSkeleton() {
           <Bar w="50%" h={14} />
         </div>
       </div>
-      <div className="max-w-[1100px] mx-auto px-4 md:px-8 lg:px-14 py-8 md:py-12 flex flex-col gap-3">
-        <Bar w="35%" h={14} className="mb-2" />
-        <Bar w="100%" h={11} />
-        <Bar w="92%" h={11} />
-        <Bar w="80%" h={11} />
-        <Bar w="100%" h={11} className="mt-4" />
-        <Bar w="88%" h={11} />
-        <Bar w="95%" h={11} />
-        <Bar w="60%" h={11} />
+      <div className="max-w-[1100px] mx-auto px-4 md:px-8 lg:px-14 py-8 md:py-12 flex flex-col gap-6">
+        <Bar w="35%" h={18} className="mb-1" />
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="border-t border-border/60 pt-5 flex flex-col gap-3"
+            style={{ minHeight: 140 }}
+          >
+            <Bar w="80%" h={20} />
+            <Bar w="100%" h={12} />
+            <Bar w="92%" h={12} />
+            <Bar w="50%" h={12} />
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/components/tygodnik/atoms/KpiStrip.tsx
+++ b/frontend/components/tygodnik/atoms/KpiStrip.tsx
@@ -21,10 +21,11 @@ export function KpiStrip({ slots }: { slots: KpiSlot[] }) {
           filtered.length === 1
             ? "minmax(0, 1fr)"
             : `repeat(${filtered.length}, minmax(0, 1fr))`,
+        minHeight: 72,
       }}
     >
       {filtered.map((s, i) => (
-        <div key={i} className="min-w-0">
+        <div key={i} className="min-w-0" style={{ minHeight: 60 }}>
           <div className="font-mono text-[9px] tracking-[0.18em] uppercase text-muted-foreground mb-1">
             {s.kicker}
           </div>

--- a/frontend/components/tygodnik/atoms/ProcessStageBar.tsx
+++ b/frontend/components/tygodnik/atoms/ProcessStageBar.tsx
@@ -89,7 +89,7 @@ export function ProcessStageBar({
   const currentIdx = stepIndexFor(currentStageType, processPassed);
 
   return (
-    <div className="mb-4">
+    <div className="mb-4" style={{ minHeight: 32 }}>
       <div className="flex items-center gap-1 mb-1.5">
         {STEPS.map((step, i) => {
           const done = i < currentIdx;

--- a/frontend/components/tygodnik/atoms/VoteResultBar.tsx
+++ b/frontend/components/tygodnik/atoms/VoteResultBar.tsx
@@ -54,8 +54,8 @@ export function VoteResultBar({ result }: { result: VoteResult }) {
   const motionLabel = motionTypeLabel(result.motionPolarity);
 
   return (
-    <div className="my-5">
-      <div className="flex items-baseline justify-between mb-2 gap-2">
+    <div className="my-5" style={{ minHeight: 76 }}>
+      <div className="flex items-baseline justify-between mb-2 gap-2" style={{ minHeight: 20 }}>
         <span className="font-mono text-[10px] tracking-[0.16em] uppercase text-muted-foreground">
           wynik głosowania nr {result.votingNumber}
           {motionLabel && (

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -7,6 +7,33 @@ const nextConfig: NextConfig = {
   output: "standalone",
   // cacheComponents disabled — pages still hit dynamic APIs (Date(), useProfile)
   // without Suspense/use-cache wrappers. Re-enable after sweep.
+  productionBrowserSourceMaps: false,
+  images: { formats: ["image/avif", "image/webp"] },
+  experimental: {
+    optimizePackageImports: [
+      "lucide-react",
+      "radix-ui",
+      "@base-ui/react",
+      "date-fns",
+      "recharts",
+    ],
+  },
+  async headers() {
+    return [
+      {
+        source: "/_next/static/:path*",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
+        ],
+      },
+      {
+        source: "/:path*\\.(png|jpg|jpeg|svg|webp|avif|ico|woff2)",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=2592000, immutable" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- next.config: optimizePackageImports for lucide/radix/base-ui/date-fns/recharts, AVIF+WebP image formats, immutable cache headers on _next/static and assets, productionBrowserSourceMaps off.
- tsconfig: target ES2022 to drop legacy polyfills (~13 KiB).
- layout: drop weight 300 across all fonts and weight 600 on mono; Umami → lazyOnload so analytics no longer blocks LCP.
- Add <main> landmark to homepage and /tygodnik (Lighthouse a11y).
- Canonicals: /tygodnik plus alerty/atlas/budzet/komisja/manifest/mowa/ o-projekcie/obietnice/sondaze/szukaj (root layout's "/" canonical was flagged as wrong on /tygodnik).
- CLS: PageSkeleton now matches real page footprint; min-heights on KpiStrip / VoteResultBar / ProcessStageBar.
- A11y: wrap section item maps in <ul>/<li>, aria-label on prev/next sitting nav links, darken --muted-foreground for AA contrast.
- Lazy-load + width/height on club-logo <img> tags below the fold.