### PR TITLE
feat(frontend): /proces filter parity with /posel + shared list UI

### DIFF
--- a/frontend/app/posel/_components/PoselDirectoryClient.tsx
+++ b/frontend/app/posel/_components/PoselDirectoryClient.tsx
@@ -6,6 +6,10 @@ import { useProfile } from "@/lib/profile";
 import type { MpListItem } from "@/lib/db/mps";
 import { ClubBadge } from "@/components/clubs/ClubBadge";
 import { KLUB_COLORS, KLUB_LABELS } from "@/lib/atlas/constants";
+import { SearchHero } from "@/components/lists/SearchHero";
+import { FilterChipRow, type FilterChipOption } from "@/components/lists/FilterChipRow";
+import { SortButtons } from "@/components/lists/SortButtons";
+import { ViewToggle } from "@/components/lists/ViewToggle";
 
 type MpRow = MpListItem & {
   attendancePct: number | null;
@@ -82,81 +86,30 @@ export function PoselDirectoryClient({ mps }: { mps: MpRow[] }) {
     return arr.slice().sort(cmp[sortBy]);
   }, [mps, query, klubFilter, districtOnly, district, sortBy]);
 
+  const klubChipOptions: FilterChipOption[] = clubCounts.map(([k, n]) => ({
+    id: k,
+    label: KLUB_LABELS[k] ?? k,
+    count: n,
+    color: KLUB_COLORS[k] ?? "var(--muted-foreground)",
+    leading: <ClubBadge klub={k} size="xs" variant="logo" />,
+  }));
+
   return (
     <div className="min-w-0">
-      {/* Search hero */}
-      <div className="relative mb-5">
-        <span
-          aria-hidden
-          className="absolute left-2 sm:left-3 top-1/2 -translate-y-1/2 font-serif text-destructive pointer-events-none"
-          style={{ fontSize: "clamp(20px, 5vw, 26px)" }}
-        >
-          ⌕
-        </span>
-        <input
-          type="search"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Szukaj posła — nazwisko, klub, okręg…"
-          className="w-full bg-transparent outline-none font-serif text-foreground placeholder:italic placeholder:text-muted-foreground"
-          style={{
-            fontSize: "clamp(16px, 3.2vw, 22px)",
-            padding: "14px 96px 14px 40px",
-            borderBottom: "2px solid var(--foreground)",
-            fontStyle: query ? "normal" : "italic",
-          }}
-        />
-        <span
-          aria-hidden
-          className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 font-mono text-[11px] tracking-wide text-muted-foreground"
-        >
-          {filtered.length} / {mps.length}
-        </span>
-      </div>
+      <SearchHero
+        value={query}
+        onChange={setQuery}
+        placeholder="Szukaj posła — nazwisko, klub, okręg…"
+        filteredCount={filtered.length}
+        totalCount={mps.length}
+      />
 
-      {/* Klub chips — horizontal scroll on mobile, wrap on desktop */}
-      <div
-        className="flex gap-1.5 mb-3 font-sans text-[12px] overflow-x-auto sm:overflow-visible sm:flex-wrap -mx-3 sm:mx-0 px-3 sm:px-0 [scrollbar-width:thin]"
-        style={{ scrollSnapType: "x proximity" }}
-      >
-        <button
-          type="button"
-          onClick={() => setKlubFilter("all")}
-          className="cursor-pointer rounded-full px-3 py-1.5 shrink-0"
-          style={{
-            border: `1px solid ${klubFilter === "all" ? "var(--foreground)" : "var(--border)"}`,
-            background: klubFilter === "all" ? "var(--foreground)" : "transparent",
-            color: klubFilter === "all" ? "var(--background)" : "var(--secondary-foreground)",
-            scrollSnapAlign: "start",
-          }}
-        >
-          Wszystkie
-        </button>
-        {clubCounts.map(([k, n]) => {
-          const on = klubFilter === k;
-          const color = KLUB_COLORS[k] ?? "var(--muted-foreground)";
-          return (
-            <button
-              key={k}
-              type="button"
-              onClick={() => setKlubFilter(on ? "all" : k)}
-              className="cursor-pointer rounded-full px-2.5 py-1.5 flex items-center gap-1.5 shrink-0"
-              style={{
-                border: `1px solid ${on ? color : "var(--border)"}`,
-                background: on ? `${color}1a` : "transparent",
-                color: on ? color : "var(--secondary-foreground)",
-                scrollSnapAlign: "start",
-              }}
-            >
-              <ClubBadge klub={k} size="xs" variant="logo" />
-              <span>{KLUB_LABELS[k] ?? k}</span>
-              <span className="font-mono text-[10px] opacity-70">{n}</span>
-            </button>
-          );
-        })}
-      </div>
+      <FilterChipRow
+        options={klubChipOptions}
+        selected={klubFilter}
+        onChange={setKlubFilter}
+      />
 
-      {/* Filters row */}
       <div className="flex flex-wrap items-center gap-3 mb-6 font-sans text-[12px]">
         {district ? (
           <button
@@ -180,47 +133,16 @@ export function PoselDirectoryClient({ mps }: { mps: MpRow[] }) {
 
         <span className="flex-1" aria-hidden />
 
-        <div className="flex items-center gap-0 flex-wrap">
-          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground mr-2">
-            Sortuj
-          </span>
-          {SORT_OPTIONS.map((o) => {
-            const on = sortBy === o.id;
-            return (
-              <button
-                key={o.id}
-                type="button"
-                onClick={() => setSortBy(o.id)}
-                title={o.tip}
-                className="cursor-pointer px-2.5 py-1.5"
-                style={{
-                  color: on ? "var(--destructive)" : "var(--secondary-foreground)",
-                  borderBottom: on ? "2px solid var(--destructive)" : "2px solid transparent",
-                }}
-              >
-                {o.label}
-              </button>
-            );
-          })}
-        </div>
+        <SortButtons options={SORT_OPTIONS} value={sortBy} onChange={setSortBy} />
 
-        <div className="flex border border-border ml-2">
-          {(["grid", "tabela"] as const).map((id) => (
-            <button
-              key={id}
-              type="button"
-              onClick={() => setView(id)}
-              className="cursor-pointer px-3 py-1.5"
-              style={{
-                background: view === id ? "var(--foreground)" : "transparent",
-                color: view === id ? "var(--background)" : "var(--secondary-foreground)",
-              }}
-              aria-label={id === "grid" ? "Widok kafli" : "Widok tabeli"}
-            >
-              {id === "grid" ? "▦" : "☰"}
-            </button>
-          ))}
-        </div>
+        <ViewToggle<"grid" | "tabela">
+          options={[
+            { id: "grid", glyph: "▦", ariaLabel: "Widok kafli" },
+            { id: "tabela", glyph: "☰", ariaLabel: "Widok tabeli" },
+          ]}
+          value={view}
+          onChange={setView}
+        />
       </div>
 
       {filtered.length === 0 ? (

--- a/frontend/app/proces/_components/ProcesDirectoryClient.tsx
+++ b/frontend/app/proces/_components/ProcesDirectoryClient.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ProcessSummary } from "@/lib/db/threads";
+import { stageLabel } from "@/lib/stages";
+import {
+  PROCES_GROUP_BLURB,
+  PROCES_GROUP_HEADING,
+  SPONSOR_LABEL,
+  classifyInFlight,
+  type ProcesGroupKey,
+} from "@/lib/proces-classify";
+import { SearchHero } from "@/components/lists/SearchHero";
+import { FilterChipRow, type FilterChipOption } from "@/components/lists/FilterChipRow";
+import { SortButtons } from "@/components/lists/SortButtons";
+
+export type ProcesListItem = ProcessSummary & {
+  groupKey: ProcesGroupKey;
+};
+
+type SortKey = "recent" | "oldest" | "longest" | "druk";
+
+const SORT_OPTIONS: { id: SortKey; label: string; tip?: string }[] = [
+  { id: "recent", label: "ostatnia aktywność" },
+  { id: "longest", label: "najdłużej w procesie", tip: "Sortuj od projektów najdłużej procedowanych" },
+  { id: "oldest", label: "najstarsze aktywności" },
+  { id: "druk", label: "druk" },
+];
+
+const GROUP_ORDER: ProcesGroupKey[] = ["sejm", "senat", "prezydent", "uchwalone"];
+
+function shortDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("pl-PL", { day: "2-digit", month: "2-digit", year: "2-digit" });
+}
+
+function daysBetween(iso: string | null, now = Date.now()): number | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return null;
+  return Math.max(0, Math.floor((now - t) / (24 * 60 * 60 * 1000)));
+}
+
+function pluralDni(n: number): string {
+  if (n === 1) return "dzień";
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) return "dni";
+  return "dni";
+}
+
+function parseDrukAsc(a: string, b: string): number {
+  const na = parseInt(a, 10);
+  const nb = parseInt(b, 10);
+  if (Number.isFinite(na) && Number.isFinite(nb) && na !== nb) return na - nb;
+  return a.localeCompare(b, "pl");
+}
+
+export function ProcesDirectoryClient({ items }: { items: ProcesListItem[] }) {
+  const [query, setQuery] = useState("");
+  const [groupFilter, setGroupFilter] = useState<string>("all");
+  const [sortBy, setSortBy] = useState<SortKey>("recent");
+
+  const groupCounts = useMemo(() => {
+    const counts: Record<ProcesGroupKey, number> = {
+      sejm: 0,
+      senat: 0,
+      prezydent: 0,
+      uchwalone: 0,
+    };
+    for (const it of items) counts[it.groupKey] += 1;
+    return counts;
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    const arr = items.filter((it) => {
+      if (groupFilter !== "all" && it.groupKey !== groupFilter) return false;
+      if (needle) {
+        const blob = `${it.number} ${it.shortTitle ?? ""} ${it.title}`.toLowerCase();
+        if (!blob.includes(needle)) return false;
+      }
+      return true;
+    });
+    const cmp: Record<SortKey, (a: ProcesListItem, b: ProcesListItem) => number> = {
+      recent: (a, b) => {
+        const da = a.lastStageDate ? Date.parse(a.lastStageDate) : 0;
+        const db = b.lastStageDate ? Date.parse(b.lastStageDate) : 0;
+        return db - da;
+      },
+      oldest: (a, b) => {
+        const da = a.lastStageDate ? Date.parse(a.lastStageDate) : Number.POSITIVE_INFINITY;
+        const db = b.lastStageDate ? Date.parse(b.lastStageDate) : Number.POSITIVE_INFINITY;
+        return da - db;
+      },
+      longest: (a, b) => {
+        const da = a.firstStageDate ? Date.parse(a.firstStageDate) : Number.POSITIVE_INFINITY;
+        const db = b.firstStageDate ? Date.parse(b.firstStageDate) : Number.POSITIVE_INFINITY;
+        return da - db; // earliest first-stage = longest in pipeline = top
+      },
+      druk: (a, b) => parseDrukAsc(a.number, b.number),
+    };
+    return arr.slice().sort(cmp[sortBy]);
+  }, [items, query, groupFilter, sortBy]);
+
+  const chipOptions: FilterChipOption[] = GROUP_ORDER.map((k) => ({
+    id: k,
+    label: PROCES_GROUP_HEADING[k],
+    count: groupCounts[k],
+    color:
+      k === "uchwalone"
+        ? "var(--success)"
+        : k === "prezydent"
+          ? "var(--destructive)"
+          : k === "senat"
+            ? "var(--warning)"
+            : "var(--foreground)",
+  }));
+
+  const activeBlurb =
+    groupFilter !== "all" && groupFilter in PROCES_GROUP_BLURB
+      ? PROCES_GROUP_BLURB[groupFilter as ProcesGroupKey]
+      : null;
+
+  return (
+    <div className="min-w-0">
+      <SearchHero
+        value={query}
+        onChange={setQuery}
+        placeholder="Szukaj projektu — druk, tytuł, słowo kluczowe…"
+        filteredCount={filtered.length}
+        totalCount={items.length}
+      />
+
+      <FilterChipRow
+        options={chipOptions}
+        selected={groupFilter}
+        onChange={setGroupFilter}
+      />
+
+      {activeBlurb && (
+        <p className="font-sans text-[12px] italic text-secondary-foreground leading-[1.55] mb-4 max-w-[760px]">
+          {activeBlurb}
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-3 mb-6 font-sans text-[12px]">
+        <span className="flex-1" aria-hidden />
+        <SortButtons options={SORT_OPTIONS} value={sortBy} onChange={setSortBy} />
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="font-serif italic text-muted-foreground py-12 text-center">
+          Brak procesów spełniających kryteria filtra.
+        </p>
+      ) : (
+        <ul className="border-t border-rule">
+          {filtered.map((p) => (
+            <ProcessRow key={`${p.term}-${p.number}`} p={p} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ProcessRow({ p }: { p: ProcesListItem }) {
+  const passed = p.groupKey === "uchwalone";
+  const lastDays = daysBetween(p.lastStageDate);
+  const pipelineDays = daysBetween(p.firstStageDate);
+  const stageText = stageLabel(p.lastStageType, p.lastStageName);
+  const sponsorLabel = p.sponsorAuthority ? SPONSOR_LABEL[p.sponsorAuthority] ?? null : null;
+
+  return (
+    <li className="py-4 border-b border-dotted border-border">
+      <a
+        href={`/proces/${p.term}/${encodeURIComponent(p.number)}`}
+        className="grid gap-x-5 gap-y-1.5 group"
+        style={{ gridTemplateColumns: "minmax(0, 1fr) auto" }}
+      >
+        <div className="min-w-0">
+          <div className="font-sans text-[10px] tracking-[0.16em] uppercase text-muted-foreground mb-1.5 flex items-center gap-2 flex-wrap">
+            <span className="font-mono tracking-wide normal-case text-destructive">
+              druk {p.number}
+            </span>
+            <span className="text-border">·</span>
+            <span>{stageText}</span>
+            {lastDays != null && (
+              <>
+                <span className="text-border">·</span>
+                <span className="font-mono tracking-wide normal-case">
+                  {passed
+                    ? lastDays === 0
+                      ? "uchwalono dziś"
+                      : `uchwalono ${lastDays} ${pluralDni(lastDays)} temu`
+                    : lastDays === 0
+                      ? "dziś"
+                      : `${lastDays} ${pluralDni(lastDays)} temu`}
+                </span>
+              </>
+            )}
+          </div>
+          <h2
+            className="font-serif font-medium leading-[1.2] text-foreground group-hover:text-destructive transition-colors m-0"
+            style={{ fontSize: "clamp(1rem, 1.8vw, 1.25rem)", letterSpacing: "-0.015em" }}
+          >
+            {p.shortTitle || p.title || `Druk ${p.number}`}
+          </h2>
+          {(sponsorLabel || (pipelineDays != null && pipelineDays > 0)) && (
+            <div className="font-sans text-[11px] text-secondary-foreground mt-1.5 flex items-center gap-2 flex-wrap">
+              {sponsorLabel && (
+                <span
+                  className="font-mono uppercase tracking-[0.12em] text-[9.5px] px-1.5 py-0.5 border border-border"
+                  style={{ color: "var(--secondary-foreground)" }}
+                >
+                  {sponsorLabel}
+                </span>
+              )}
+              {pipelineDays != null && pipelineDays > 0 && (
+                <span className="font-mono text-[11px] text-muted-foreground tabular-nums">
+                  {pipelineDays} {pluralDni(pipelineDays)} w procesie
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="self-center font-mono text-[11px] text-muted-foreground whitespace-nowrap tabular-nums">
+          {shortDate(p.lastStageDate)}
+        </div>
+      </a>
+    </li>
+  );
+}

--- a/frontend/app/proces/page.tsx
+++ b/frontend/app/proces/page.tsx
@@ -3,158 +3,18 @@ import {
   getPassedProcesses,
   type ProcessSummary,
 } from "@/lib/db/threads";
-import { stageLabel } from "@/lib/stages";
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
+import { classifyInFlight } from "@/lib/proces-classify";
+import {
+  ProcesDirectoryClient,
+  type ProcesListItem,
+} from "@/app/proces/_components/ProcesDirectoryClient";
 
 export const metadata = {
   title: "Procesy legislacyjne — Tygodnik Sejmowy",
   description:
-    "Wszystkie projekty ustaw w 10. kadencji Sejmu — pogrupowane po fazie procesu. Sejm, Senat, Prezydent, ostatnio uchwalone.",
+    "Wszystkie projekty ustaw w 10. kadencji Sejmu — z filtrami po fazie procesu, wyszukiwarką i sortowaniem.",
 };
-
-type InFlightKey = "sejm" | "senat" | "prezydent";
-type GroupKey = InFlightKey | "uchwalone";
-
-const GROUP_HEADING: Record<GroupKey, string> = {
-  sejm: "W Sejmie",
-  senat: "W Senacie",
-  prezydent: "U Prezydenta",
-  uchwalone: "Ostatnio uchwalone",
-};
-
-const GROUP_BLURB: Record<GroupKey, string> = {
-  sejm: "Projekty po wpłynięciu, w komisjach albo w czytaniach plenarnych.",
-  senat: "Sejm zakończył pracę, Senat ma 30 dni na decyzję (20 — budżet, 14 — pilna).",
-  prezydent: "Po głosowaniach w obu izbach. Prezydent ma 21 dni (7 — pilna/budżet) na podpis, weto lub TK.",
-  uchwalone: "Uchwalone w ciągu ostatnich 90 dni — opublikowane lub czekające na Dz.U.",
-};
-
-const SENATE_STAGE_TYPES = new Set([
-  "SenatePosition",
-  "SenatePositionConsideration",
-  "SenateAmendments",
-]);
-
-const PRESIDENT_STAGE_TYPES = new Set([
-  "ToPresident",
-  "PresidentSignature",
-  "PresidentVeto",
-  "Veto",
-  "PresidentMotionConsideration",
-  "ConstitutionalTribunal",
-]);
-
-function classify(p: ProcessSummary): InFlightKey {
-  const t = p.lastStageType ?? "";
-  if (SENATE_STAGE_TYPES.has(t)) return "senat";
-  if (PRESIDENT_STAGE_TYPES.has(t)) return "prezydent";
-  return "sejm";
-}
-
-function shortDate(iso: string | null): string {
-  if (!iso) return "—";
-  return new Date(iso).toLocaleDateString("pl-PL", { day: "2-digit", month: "2-digit", year: "2-digit" });
-}
-
-function daysAgo(iso: string | null): number | null {
-  if (!iso) return null;
-  const t = Date.parse(iso);
-  if (!Number.isFinite(t)) return null;
-  return Math.max(0, Math.floor((Date.now() - t) / (24 * 60 * 60 * 1000)));
-}
-
-function ProcessRow({ p, passed }: { p: ProcessSummary; passed: boolean }) {
-  const days = daysAgo(p.lastStageDate);
-  const stageText = stageLabel(p.lastStageType, p.lastStageName);
-  return (
-    <li className="py-4 border-b border-dotted border-border">
-      <a
-        href={`/proces/${p.term}/${encodeURIComponent(p.number)}`}
-        className="grid gap-x-5 gap-y-1.5 group"
-        style={{ gridTemplateColumns: "minmax(0, 1fr) auto" }}
-      >
-        <div className="min-w-0">
-          <div className="font-sans text-[10px] tracking-[0.16em] uppercase text-muted-foreground mb-1.5 flex items-center gap-2 flex-wrap">
-            <span className="font-mono tracking-wide normal-case text-destructive">
-              druk {p.number}
-            </span>
-            <span className="text-border">·</span>
-            <span>{stageText}</span>
-            {days != null && (
-              <>
-                <span className="text-border">·</span>
-                <span className="font-mono tracking-wide normal-case">
-                  {passed
-                    ? days === 0
-                      ? "uchwalono dziś"
-                      : `uchwalono ${days} dni temu`
-                    : days === 0
-                      ? "dziś"
-                      : `${days} dni temu`}
-                </span>
-              </>
-            )}
-          </div>
-          <h2
-            className="font-serif font-medium leading-[1.2] text-foreground group-hover:text-destructive transition-colors m-0"
-            style={{ fontSize: "clamp(1rem, 1.8vw, 1.25rem)", letterSpacing: "-0.015em" }}
-          >
-            {p.shortTitle || p.title || `Druk ${p.number}`}
-          </h2>
-        </div>
-        <div className="self-center font-mono text-[11px] text-muted-foreground whitespace-nowrap tabular-nums">
-          {shortDate(p.lastStageDate)}
-        </div>
-      </a>
-    </li>
-  );
-}
-
-function GroupSection({
-  k,
-  items,
-  passed,
-}: {
-  k: GroupKey;
-  items: ProcessSummary[];
-  passed: boolean;
-}) {
-  return (
-    <section className="mt-10">
-      <div className="border-b border-foreground pb-2 mb-1 flex items-baseline justify-between gap-4 flex-wrap">
-        <h2
-          className="font-serif font-medium m-0 text-foreground"
-          style={{ fontSize: 22, letterSpacing: "-0.015em" }}
-        >
-          {GROUP_HEADING[k]}
-        </h2>
-        <span className="font-mono text-[11px] text-muted-foreground">
-          {items.length === 0
-            ? "brak"
-            : items.length === 1
-              ? "1 proces"
-              : items.length < 5
-                ? `${items.length} procesy`
-                : `${items.length} procesów`}
-        </span>
-      </div>
-      <p className="font-sans text-[12px] text-secondary-foreground leading-[1.55] mt-2 mb-3 max-w-[760px]">
-        {GROUP_BLURB[k]}
-      </p>
-      {items.length === 0 ? (
-        <p className="font-serif italic text-muted-foreground py-3">
-          Brak procesów w tej fazie.
-        </p>
-      ) : (
-        <ul className="mt-1">
-          {items.map((p) => (
-            <ProcessRow key={`${p.term}-${p.number}`} p={p} passed={passed} />
-          ))}
-        </ul>
-      )}
-    </section>
-  );
-}
 
 async function safe<T>(p: Promise<T>, fallback: T): Promise<T> {
   try {
@@ -171,25 +31,20 @@ export default async function ProcesIndexPage() {
     safe(getPassedProcesses(50, 90), [] as ProcessSummary[]),
   ]);
 
-  const grouped: Record<InFlightKey, ProcessSummary[]> = {
-    sejm: [],
-    senat: [],
-    prezydent: [],
-  };
-  for (const p of inFlight) grouped[classify(p)].push(p);
+  const items: ProcesListItem[] = [
+    ...inFlight.map((p) => ({ ...p, groupKey: classifyInFlight(p) })),
+    ...passed.map((p) => ({ ...p, groupKey: "uchwalone" as const })),
+  ];
 
   return (
     <main className="bg-background text-foreground font-serif pb-20">
       <div className="max-w-[1100px] mx-auto px-4 md:px-8 lg:px-14 pt-8 md:pt-10">
         <PageBreadcrumb
           items={[{ label: "Procesy" }]}
-          subtitle="Projekty ustaw w 10. kadencji — pogrupowane wg fazy procesu. Aktywność w ostatnich 90 dniach."
+          subtitle="Projekty ustaw w 10. kadencji — wyszukaj po druku lub tytule, filtruj po fazie. Aktywność w ostatnich 90 dniach."
         />
 
-        <GroupSection k="sejm" items={grouped.sejm} passed={false} />
-        <GroupSection k="senat" items={grouped.senat} passed={false} />
-        <GroupSection k="prezydent" items={grouped.prezydent} passed={false} />
-        <GroupSection k="uchwalone" items={passed} passed={true} />
+        <ProcesDirectoryClient items={items} />
       </div>
     </main>
   );

--- a/frontend/components/lists/FilterChipRow.tsx
+++ b/frontend/components/lists/FilterChipRow.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export type FilterChipOption = {
+  id: string;
+  label: string;
+  count?: number;
+  color?: string;
+  leading?: ReactNode;
+};
+
+export function FilterChipRow({
+  options,
+  selected,
+  onChange,
+  allLabel = "Wszystkie",
+}: {
+  options: FilterChipOption[];
+  selected: string;
+  onChange: (id: string) => void;
+  allLabel?: string;
+}) {
+  return (
+    <div
+      className="flex gap-1.5 mb-3 font-sans text-[12px] overflow-x-auto sm:overflow-visible sm:flex-wrap -mx-3 sm:mx-0 px-3 sm:px-0 [scrollbar-width:thin]"
+      style={{ scrollSnapType: "x proximity" }}
+    >
+      <button
+        type="button"
+        onClick={() => onChange("all")}
+        className="cursor-pointer rounded-full px-3 py-1.5 shrink-0"
+        style={{
+          border: `1px solid ${selected === "all" ? "var(--foreground)" : "var(--border)"}`,
+          background: selected === "all" ? "var(--foreground)" : "transparent",
+          color: selected === "all" ? "var(--background)" : "var(--secondary-foreground)",
+          scrollSnapAlign: "start",
+        }}
+      >
+        {allLabel}
+      </button>
+      {options.map((o) => {
+        const on = selected === o.id;
+        const color = o.color ?? "var(--muted-foreground)";
+        return (
+          <button
+            key={o.id}
+            type="button"
+            onClick={() => onChange(on ? "all" : o.id)}
+            className="cursor-pointer rounded-full px-2.5 py-1.5 flex items-center gap-1.5 shrink-0"
+            style={{
+              border: `1px solid ${on ? color : "var(--border)"}`,
+              background: on ? `${color}1a` : "transparent",
+              color: on ? color : "var(--secondary-foreground)",
+              scrollSnapAlign: "start",
+            }}
+          >
+            {o.leading}
+            <span>{o.label}</span>
+            {o.count != null && (
+              <span className="font-mono text-[10px] opacity-70">{o.count}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/components/lists/SearchHero.tsx
+++ b/frontend/components/lists/SearchHero.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+
+export function SearchHero({
+  value,
+  onChange,
+  placeholder,
+  filteredCount,
+  totalCount,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+  filteredCount: number;
+  totalCount: number;
+}) {
+  return (
+    <div className="relative mb-5">
+      <span
+        aria-hidden
+        className="absolute left-2 sm:left-3 top-1/2 -translate-y-1/2 font-serif text-destructive pointer-events-none"
+        style={{ fontSize: "clamp(20px, 5vw, 26px)" }}
+      >
+        ⌕
+      </span>
+      <input
+        type="search"
+        value={value}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full bg-transparent outline-none font-serif text-foreground placeholder:italic placeholder:text-muted-foreground"
+        style={{
+          fontSize: "clamp(16px, 3.2vw, 22px)",
+          padding: "14px 96px 14px 40px",
+          borderBottom: "2px solid var(--foreground)",
+          fontStyle: value ? "normal" : "italic",
+        }}
+      />
+      <span
+        aria-hidden
+        className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 font-mono text-[11px] tracking-wide text-muted-foreground"
+      >
+        {filteredCount} / {totalCount}
+      </span>
+    </div>
+  );
+}

--- a/frontend/components/lists/SortButtons.tsx
+++ b/frontend/components/lists/SortButtons.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+export type SortOption<Id extends string> = {
+  id: Id;
+  label: string;
+  tip?: string;
+};
+
+export function SortButtons<Id extends string>({
+  options,
+  value,
+  onChange,
+  label = "Sortuj",
+}: {
+  options: SortOption<Id>[];
+  value: Id;
+  onChange: (id: Id) => void;
+  label?: string;
+}) {
+  return (
+    <div className="flex items-center gap-0 flex-wrap">
+      <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground mr-2">
+        {label}
+      </span>
+      {options.map((o) => {
+        const on = value === o.id;
+        return (
+          <button
+            key={o.id}
+            type="button"
+            onClick={() => onChange(o.id)}
+            title={o.tip}
+            className="cursor-pointer px-2.5 py-1.5"
+            style={{
+              color: on ? "var(--destructive)" : "var(--secondary-foreground)",
+              borderBottom: on ? "2px solid var(--destructive)" : "2px solid transparent",
+            }}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/components/lists/ViewToggle.tsx
+++ b/frontend/components/lists/ViewToggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export type ViewToggleOption<Id extends string> = {
+  id: Id;
+  glyph: ReactNode;
+  ariaLabel: string;
+};
+
+export function ViewToggle<Id extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: ViewToggleOption<Id>[];
+  value: Id;
+  onChange: (id: Id) => void;
+}) {
+  return (
+    <div className="flex border border-border ml-2">
+      {options.map((o) => (
+        <button
+          key={o.id}
+          type="button"
+          onClick={() => onChange(o.id)}
+          className="cursor-pointer px-3 py-1.5"
+          style={{
+            background: value === o.id ? "var(--foreground)" : "transparent",
+            color: value === o.id ? "var(--background)" : "var(--secondary-foreground)",
+          }}
+          aria-label={o.ariaLabel}
+        >
+          {o.glyph}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/lib/db/threads.ts
+++ b/frontend/lib/db/threads.ts
@@ -2,6 +2,9 @@ import "server-only";
 
 import { normalizeActSourceUrl } from "@/lib/isap";
 import { supabase } from "@/lib/supabase";
+import type { SponsorAuthority } from "@/lib/db/prints";
+
+export type { SponsorAuthority } from "@/lib/db/prints";
 
 // Voting tally rendered inline next to a stage row (yes/no/abstain pill).
 // May come either from process_stages.voting jsonb or from voting_print_links
@@ -60,6 +63,10 @@ export type ProcessSummary = {
   lastStageName: string | null;
   lastStageDate: string | null;
   lastRefreshedAt: string | null;
+  // Earliest top-level (depth=0) stage date — powers "N dni w procesie".
+  firstStageDate: string | null;
+  // From prints.sponsor_authority; coarse origin of the bill.
+  sponsorAuthority: SponsorAuthority;
 };
 
 // Threads currently moving through Sejm — passed=false AND a top-level stage
@@ -121,34 +128,49 @@ export async function getThreadsInFlight(limit = 30, cutoffDays = 90): Promise<P
   }>;
   if (rows.length === 0) return [];
 
-  // Hydrate short_title from prints (term, number). PostgREST has no
-  // composite-IN, so we filter the cartesian and dedupe client-side.
+  // Hydrate short_title + sponsor_authority from prints (term, number).
+  // PostgREST has no composite-IN, so we filter the cartesian and dedupe
+  // client-side.
   const { data: printRows } = await sb
     .from("prints")
-    .select("term, number, short_title")
+    .select("term, number, short_title, sponsor_authority")
     .in("term", Array.from(new Set(rows.map((r) => r.term))))
     .in("number", Array.from(new Set(rows.map((r) => r.number))));
   const shortByKey = new Map<string, string | null>();
+  const sponsorByKey = new Map<string, SponsorAuthority>();
   for (const r of (printRows ?? []) as Array<{
     term: number;
     number: string;
     short_title: string | null;
+    sponsor_authority: string | null;
   }>) {
     shortByKey.set(`${r.term}::${r.number}`, r.short_title ?? null);
+    sponsorByKey.set(
+      `${r.term}::${r.number}`,
+      (r.sponsor_authority as SponsorAuthority) ?? null,
+    );
   }
+
+  // Earliest depth=0 stage_date per process — powers "days in pipeline".
+  // No cutoff filter here: processes that have been around for years still
+  // need a real start date.
+  const firstStageByProc = await fetchFirstStageDates(sb, procIds);
 
   const summaries: ProcessSummary[] = rows.map((r) => {
     const latest = latestByProc.get(r.id)!; // guaranteed by procIds derivation
+    const key = `${r.term}::${r.number}`;
     return {
       processId: r.id,
       term: r.term,
       number: r.number,
       title: r.title ?? "",
-      shortTitle: shortByKey.get(`${r.term}::${r.number}`) ?? null,
+      shortTitle: shortByKey.get(key) ?? null,
       lastStageType: latest.stageType,
       lastStageName: latest.stageName,
       lastStageDate: latest.stageDate,
       lastRefreshedAt: r.last_refreshed_at ?? null,
+      firstStageDate: firstStageByProc.get(r.id) ?? null,
+      sponsorAuthority: sponsorByKey.get(key) ?? null,
     };
   });
 
@@ -193,29 +215,70 @@ export async function getPassedProcesses(limit = 30, cutoffDays = 90): Promise<P
 
   const { data: printRows } = await sb
     .from("prints")
-    .select("term, number, short_title")
+    .select("term, number, short_title, sponsor_authority")
     .in("term", Array.from(new Set(rows.map((r) => r.term))))
     .in("number", Array.from(new Set(rows.map((r) => r.number))));
   const shortByKey = new Map<string, string | null>();
+  const sponsorByKey = new Map<string, SponsorAuthority>();
   for (const r of (printRows ?? []) as Array<{
     term: number;
     number: string;
     short_title: string | null;
+    sponsor_authority: string | null;
   }>) {
     shortByKey.set(`${r.term}::${r.number}`, r.short_title ?? null);
+    sponsorByKey.set(
+      `${r.term}::${r.number}`,
+      (r.sponsor_authority as SponsorAuthority) ?? null,
+    );
   }
 
-  return rows.map((r) => ({
-    processId: r.id,
-    term: r.term,
-    number: r.number,
-    title: r.title ?? "",
-    shortTitle: shortByKey.get(`${r.term}::${r.number}`) ?? null,
-    lastStageType: "Promulgation",
-    lastStageName: "Uchwalono",
-    lastStageDate: r.closure_date,
-    lastRefreshedAt: r.last_refreshed_at ?? null,
-  }));
+  const firstStageByProc = await fetchFirstStageDates(
+    sb,
+    rows.map((r) => r.id),
+  );
+
+  return rows.map((r) => {
+    const key = `${r.term}::${r.number}`;
+    return {
+      processId: r.id,
+      term: r.term,
+      number: r.number,
+      title: r.title ?? "",
+      shortTitle: shortByKey.get(key) ?? null,
+      lastStageType: "Promulgation",
+      lastStageName: "Uchwalono",
+      lastStageDate: r.closure_date,
+      lastRefreshedAt: r.last_refreshed_at ?? null,
+      firstStageDate: firstStageByProc.get(r.id) ?? null,
+      sponsorAuthority: sponsorByKey.get(key) ?? null,
+    };
+  });
+}
+
+// PostgREST has no GROUP BY / aggregate, so over-fetch all depth=0 stages for
+// the given process_ids and reduce client-side to min(stage_date) per process.
+// Used by both list queries (in-flight + passed) to populate firstStageDate.
+async function fetchFirstStageDates(
+  sb: ReturnType<typeof supabase>,
+  procIds: number[],
+): Promise<Map<number, string>> {
+  const out = new Map<number, string>();
+  if (procIds.length === 0) return out;
+  const { data } = await sb
+    .from("process_stages")
+    .select("process_id, stage_date")
+    .eq("depth", 0)
+    .in("process_id", procIds)
+    .not("stage_date", "is", null)
+    .order("stage_date", { ascending: true })
+    .limit(5000);
+  for (const r of (data ?? []) as Array<{ process_id: number; stage_date: string | null }>) {
+    if (!r.stage_date) continue;
+    if (out.has(r.process_id)) continue; // first wins, already asc-sorted
+    out.set(r.process_id, r.stage_date);
+  }
+  return out;
 }
 
 // Pick a recently-active mid-pipeline thread — one whose latest stage is past
@@ -285,11 +348,17 @@ export async function getLatestThread(): Promise<ProcessSummary | null> {
 
   const { data: printRows } = await sb
     .from("prints")
-    .select("short_title")
+    .select("short_title, sponsor_authority")
     .eq("term", proc.term)
     .eq("number", proc.number)
     .limit(1);
-  const shortTitle = ((printRows ?? [])[0] as { short_title: string | null } | undefined)?.short_title ?? null;
+  const printRow = (printRows ?? [])[0] as
+    | { short_title: string | null; sponsor_authority: string | null }
+    | undefined;
+  const shortTitle = printRow?.short_title ?? null;
+  const sponsorAuthority = (printRow?.sponsor_authority as SponsorAuthority) ?? null;
+
+  const firstStageByProc = await fetchFirstStageDates(sb, [proc.id]);
 
   return {
     processId: proc.id,
@@ -301,6 +370,8 @@ export async function getLatestThread(): Promise<ProcessSummary | null> {
     lastStageName: latest?.stage_name ?? null,
     lastStageDate: latest?.stage_date ?? null,
     lastRefreshedAt: proc.last_refreshed_at ?? null,
+    firstStageDate: firstStageByProc.get(proc.id) ?? null,
+    sponsorAuthority,
   };
 }
 

--- a/frontend/lib/proces-classify.ts
+++ b/frontend/lib/proces-classify.ts
@@ -1,0 +1,59 @@
+import type { ProcessSummary } from "@/lib/db/threads";
+
+// Coarse legislative-phase grouping used by /proces list page.
+//
+// `sejm`/`senat`/`prezydent` derive from `lastStageType` for in-flight rows.
+// `uchwalone` is set externally by the loader for passed rows (closure_date
+// known, no live stage). Single source of truth — both the server fetch
+// merge and the client filter chip row consume this.
+export type ProcesGroupKey = "sejm" | "senat" | "prezydent" | "uchwalone";
+
+export const PROCES_GROUP_HEADING: Record<ProcesGroupKey, string> = {
+  sejm: "W Sejmie",
+  senat: "W Senacie",
+  prezydent: "U Prezydenta",
+  uchwalone: "Ostatnio uchwalone",
+};
+
+export const PROCES_GROUP_BLURB: Record<ProcesGroupKey, string> = {
+  sejm: "Projekty po wpłynięciu, w komisjach albo w czytaniach plenarnych.",
+  senat: "Sejm zakończył pracę, Senat ma 30 dni na decyzję (20 — budżet, 14 — pilna).",
+  prezydent:
+    "Po głosowaniach w obu izbach. Prezydent ma 21 dni (7 — pilna/budżet) na podpis, weto lub TK.",
+  uchwalone: "Uchwalone w ciągu ostatnich 90 dni — opublikowane lub czekające na Dz.U.",
+};
+
+const SENATE_STAGE_TYPES = new Set([
+  "SenatePosition",
+  "SenatePositionConsideration",
+  "SenateAmendments",
+]);
+
+const PRESIDENT_STAGE_TYPES = new Set([
+  "ToPresident",
+  "PresidentSignature",
+  "PresidentVeto",
+  "Veto",
+  "PresidentMotionConsideration",
+  "ConstitutionalTribunal",
+]);
+
+export function classifyInFlight(p: ProcessSummary): Exclude<ProcesGroupKey, "uchwalone"> {
+  const t = p.lastStageType ?? "";
+  if (SENATE_STAGE_TYPES.has(t)) return "senat";
+  if (PRESIDENT_STAGE_TYPES.has(t)) return "prezydent";
+  return "sejm";
+}
+
+// Polish labels for `prints.sponsor_authority` enum. Null/unknown values fall
+// through to "—" at render time — callers should gate display on truthy label.
+export const SPONSOR_LABEL: Record<string, string> = {
+  rzad: "Rząd",
+  prezydent: "Prezydent",
+  klub_poselski: "Posłowie",
+  senat: "Senat",
+  komisja: "Komisja",
+  prezydium: "Prezydium",
+  obywatele: "Obywatele",
+  inne: "Inne",
+};


### PR DESCRIPTION
- Extract SearchHero, FilterChipRow, SortButtons, ViewToggle into components/lists/ so /posel and /proces share the same filter chrome.
- New /proces client component: search by druk/title, chip filter by legislative phase (Sejm/Senat/Prezydent/Uchwalone) with live counts, sort by recent activity / longest in pipeline / oldest / druk.
- Surface sponsor authority chip (Rząd/Posłowie/...) and "N dni w procesie" derived from earliest depth=0 stage_date per process.
- Extend ProcessSummary with firstStageDate + sponsorAuthority; one extra over-fetch of process_stages per list query for the min-date reduction (PostgREST has no aggregate).