### PR TITLE
fix(frontend): wire breadcrumb parents + add /glosowanie list

### DIFF
--- a/frontend/app/glosowanie/[id]/page.tsx
+++ b/frontend/app/glosowanie/[id]/page.tsx
@@ -45,7 +45,7 @@ export default async function VotingDetailPage({
       <div className="max-w-[1240px] mx-auto px-4 md:px-8 lg:px-14 pt-6">
         <PageBreadcrumb
           items={[
-            { label: "Głosowania" },
+            { label: "Głosowania", href: "/glosowanie" },
             { label: header.title || `Głosowanie nr ${id}` },
           ]}
           subtitle={`Posiedzenie ${header.sitting} · ${new Date(header.date).toLocaleDateString("pl-PL", { day: "numeric", month: "long", year: "numeric" })}`}

--- a/frontend/app/glosowanie/_components/GlosowanieDirectoryClient.tsx
+++ b/frontend/app/glosowanie/_components/GlosowanieDirectoryClient.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { VotingListItem } from "@/lib/db/voting";
+import { SearchHero } from "@/components/lists/SearchHero";
+import { VotingRow } from "@/components/voting/VotingRow";
+
+const PAGE_SIZE = 50;
+
+export function GlosowanieDirectoryClient({ rows }: { rows: VotingListItem[] }) {
+  const [query, setQuery] = useState("");
+  const [shown, setShown] = useState(PAGE_SIZE);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return rows;
+    return rows.filter((r) => {
+      const blob = `${r.title} nr ${r.voting_number} pos ${r.sitting}`.toLowerCase();
+      return blob.includes(needle);
+    });
+  }, [rows, query]);
+
+  const slice = filtered.slice(0, shown);
+  const hasMore = shown < filtered.length;
+
+  return (
+    <div className="min-w-0">
+      <SearchHero
+        value={query}
+        onChange={(v) => {
+          setQuery(v);
+          setShown(PAGE_SIZE);
+        }}
+        placeholder="Szukaj głosowania — tytuł, numer, posiedzenie…"
+        filteredCount={filtered.length}
+        totalCount={rows.length}
+      />
+
+      {filtered.length === 0 ? (
+        <p className="font-serif italic text-muted-foreground text-center py-12">
+          Brak wyników.
+        </p>
+      ) : (
+        <>
+          <ul>
+            {slice.map((r) => (
+              <VotingRow
+                key={r.id}
+                votingId={r.id}
+                date={r.date}
+                title={r.title || `Głosowanie nr ${r.voting_number}`}
+                yes={r.yes}
+                no={r.no}
+                abstain={r.abstain}
+                badge={{ label: `pos. ${r.sitting}` }}
+              />
+            ))}
+          </ul>
+          {hasMore && (
+            <div className="text-center mt-6">
+              <button
+                type="button"
+                onClick={() => setShown((s) => s + PAGE_SIZE)}
+                className="font-sans text-[12px] text-destructive underline decoration-dotted underline-offset-4 cursor-pointer"
+              >
+                Pokaż następne {Math.min(PAGE_SIZE, filtered.length - shown)} z {filtered.length - shown}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/glosowanie/page.tsx
+++ b/frontend/app/glosowanie/page.tsx
@@ -1,0 +1,34 @@
+import { getAllVotings } from "@/lib/db/voting";
+import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
+import { GlosowanieDirectoryClient } from "./_components/GlosowanieDirectoryClient";
+
+export const metadata = {
+  title: "Głosowania — Tygodnik Sejmowy",
+  description:
+    "Wszystkie głosowania X kadencji. Wyszukaj po tytule, numerze lub numerze posiedzenia.",
+};
+
+async function safe<T>(p: Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await p;
+  } catch {
+    return fallback;
+  }
+}
+
+export default async function GlosowanieIndexPage() {
+  const rows = await safe(getAllVotings(), []);
+
+  return (
+    <main className="bg-background text-foreground font-serif pb-12 sm:pb-16 min-w-0">
+      <div className="max-w-[1280px] mx-auto px-3 sm:px-8 md:px-14 pt-8 sm:pt-12 min-w-0">
+        <PageBreadcrumb
+          items={[{ label: "Głosowania" }]}
+          subtitle={`${rows.length} głosowań w X kadencji — wyszukaj po tytule, numerze lub posiedzeniu.`}
+        />
+
+        <GlosowanieDirectoryClient rows={rows} />
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/proces/[term]/[number]/page.tsx
+++ b/frontend/app/proces/[term]/[number]/page.tsx
@@ -97,8 +97,7 @@ export default async function DrukPage({
       <div className="max-w-[1280px] mx-auto px-4 md:px-8 lg:px-14 pt-7 md:pt-9">
         <PageBreadcrumb
           items={[
-            { label: "Druki" },
-            { label: `Kadencja ${print.term}` },
+            { label: "Procesy", href: "/proces" },
             { label: print.shortTitle || print.title || `Druk ${print.number}` },
           ]}
           subtitle={

--- a/frontend/lib/db/voting.ts
+++ b/frontend/lib/db/voting.ts
@@ -35,6 +35,40 @@ export type ClubTallyRow = {
   total: number;
 };
 
+export type VotingListItem = {
+  id: number;
+  voting_number: number;
+  title: string;
+  date: string;
+  sitting: number;
+  yes: number;
+  no: number;
+  abstain: number;
+};
+
+export async function getAllVotings(term = 10): Promise<VotingListItem[]> {
+  const sb = supabase();
+  const PAGE = 1000;
+  const rows: VotingListItem[] = [];
+  let from = 0;
+  // Term 10 has thousands of votings; PostgREST caps each request at ~1000 rows.
+  while (true) {
+    const { data, error } = await sb
+      .from("votings")
+      .select("id, voting_number, title, date, sitting, yes, no, abstain")
+      .eq("term", term)
+      .order("date", { ascending: false })
+      .order("voting_number", { ascending: false })
+      .range(from, from + PAGE - 1);
+    if (error) throw error;
+    const batch = (data ?? []) as VotingListItem[];
+    rows.push(...batch);
+    if (batch.length < PAGE) break;
+    from += PAGE;
+  }
+  return rows;
+}
+
 export async function getVotingHeader(votingId: number): Promise<VotingHeader | null> {
   const sb = supabase();
   const { data, error } = await sb


### PR DESCRIPTION
- /proces/[term]/[number]: replace `Druki › Kadencja N › <title>` with `Procesy › <title>` linking to /proces. Whole site is term-10-only so the cadence crumb is redundant.
- /glosowanie/[id]: add href to the `Głosowania` crumb so it navigates to the new index.
- New `/glosowanie` list page mirroring the /posel directory pattern: server page + client directory with single search input and 50-row paginated list reusing VotingRow. Backed by new `getAllVotings()` in lib/db/voting.ts (paginates past the PostgREST 1000-row cap).