### PR TITLE
fix(mowa): left-join proceeding_day so /mowa/[id] resolves viral-quot…

### DIFF
--- a/frontend/lib/db/statements.ts
+++ b/frontend/lib/db/statements.ts
@@ -60,9 +60,15 @@ type RawStatement = {
   } | null;
 };
 
+// Left-joined: a statement row may exist before its proceeding_day /
+// proceeding linkage is backfilled. getTopViralStatements / list views can
+// surface such rows; if we forced !inner here, /mowa/[id] would 404 on a
+// link the user just clicked. Downstream readers null-chain through
+// r.proceeding_day and day.proceeding, and buildTranscriptUrl returns
+// {url: null, dayIdx: null} when sitting/dayDate is absent.
 const SELECT_COLS =
   "id, term, num, mp_id, speaker_name, function, body_text, start_datetime, end_datetime, " +
-  "proceeding_day:proceeding_days!inner(date, proceeding:proceedings!inner(number, title, dates))";
+  "proceeding_day:proceeding_days(date, proceeding:proceedings(number, title, dates))";
 
 function buildTranscriptUrl(
   term: number,


### PR DESCRIPTION
…e links

getTopViralStatements (and getRecentStatementSnippets fallback) can surface proceeding_statements rows whose proceeding_day / proceeding linkage hasn't been backfilled yet — the landing TypewriterCitation and Tile 04 then generate /mowa/{id} links that 404 because getStatementById's SELECT_COLS inner-joins those tables.

Drop !inner from SELECT_COLS; the two callers (getStatementById, getStatements) already null-chain r.proceeding_day / day.proceeding, and buildTranscriptUrl returns {url: null, dayIdx: null} when day data is missing — so partial-link rows render with a degraded hero/sidebar instead of a branded 404.