### PR TITLE
ci(release): publish GitHub Release with auto-generated notes on v* tags

### DIFF
--- a/.github/workflows/frontend-image.yml
+++ b/.github/workflows/frontend-image.yml
@@ -1,4 +1,5 @@
-# CD only — builds frontend Docker image and pushes to GHCR on v* tags.
+# CD only — builds frontend Docker image and pushes to GHCR on v* tags,
+# then publishes a GitHub Release for the tag with auto-generated notes.
 # No PR/CI runs. Triggers exclusively on tag push or manual dispatch.
 #
 # Image: ghcr.io/miskibin/tygodnik-sejmowy-frontend:<tag> + :latest
@@ -75,3 +76,16 @@ jobs:
           # GHA cache keeps subsequent builds fast (~1 min vs ~4 min cold).
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  release:
+    name: Create GitHub Release
+    needs: build-push
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
Adds a `release` job to the tag-triggered workflow that runs after the GHCR image push and creates a GitHub Release for the pushed tag using softprops/action-gh-release. Release notes are auto-generated from PRs merged since the previous tag. Skipped on workflow_dispatch (no tag ref).