### PR TITLE
fix(landing): calmer countdown animation + add &quot;obrady&quot; pill

### DIFF
--- a/frontend/app/_components/ElectionCountdown.tsx
+++ b/frontend/app/_components/ElectionCountdown.tsx
@@ -1,133 +1,212 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { NextSittingInfo } from "@/lib/events-types";
 
 // Estimated dates — Polish constitutional cycles, exact dates set ~90 days
-// before by Marszałek (parl.) / Marszałek Sejmu (pres.). Update when
-// announced. References:
+// before by Marszałek. Update when announced.
 //  · 10th-term Sejm convened 2023-11-13 → 4-year term ends Nov 2027
 //  · Presidential inauguration 2025-08-06 → 5-year term, next 2030
 const PARLIAMENTARY_TARGET = new Date("2027-11-07T08:00:00+01:00");
 const PRESIDENTIAL_TARGET = new Date("2030-05-19T08:00:00+02:00");
 
-type Parts = { d: number; h: number; m: number; s: number; total: number };
+const MS_DAY = 86_400_000;
 
-function diffParts(target: Date, now: number): Parts {
-  const total = Math.max(0, target.getTime() - now);
-  const s = Math.floor(total / 1000);
-  return {
-    d: Math.floor(s / 86400),
-    h: Math.floor((s % 86400) / 3600),
-    m: Math.floor((s % 3600) / 60),
-    s: s % 60,
-    total,
-  };
+// Whole-day diff anchored at Europe/Warsaw midnight — avoids "off-by-one"
+// across DST/timezone boundaries when the user sits in a non-Warsaw locale.
+function daysUntil(target: Date, now: number): number {
+  const fmt = new Intl.DateTimeFormat("sv-SE", { timeZone: "Europe/Warsaw" });
+  const todayISO = fmt.format(new Date(now));
+  const targetISO = fmt.format(target);
+  const a = Date.parse(`${todayISO}T00:00:00Z`);
+  const b = Date.parse(`${targetISO}T00:00:00Z`);
+  return Math.max(0, Math.round((b - a) / MS_DAY));
 }
 
-function fmtDays(n: number): string {
-  // 1 466 → with NBSP thousand separator, fits Polish typography
-  return n.toLocaleString("pl-PL").replace(/\s/g, " ");
+function daysUntilISO(iso: string, now: number): number {
+  const todayISO = new Intl.DateTimeFormat("sv-SE", { timeZone: "Europe/Warsaw" }).format(new Date(now));
+  const a = Date.parse(`${todayISO}T00:00:00Z`);
+  const b = Date.parse(`${iso}T00:00:00Z`);
+  return Math.round((b - a) / MS_DAY);
 }
 
-function pad(n: number): string {
-  return n.toString().padStart(2, "0");
+function fmtCount(n: number): string {
+  // pl-PL emits NBSP (U+00A0) or narrow NBSP (U+202F) as the thousand
+  // separator depending on ICU build. Normalize all space-likes to
+  // NBSP so the value never wraps mid-number.
+  return n.toLocaleString("pl-PL").replace(/[\s  ]/g, " ");
 }
 
-function CountdownItem({
-  label,
-  target,
-  now,
-  delay,
-}: {
+// Polish noun agreement: 1 dzień / 2–4 dni / 5+ dni / 22 dni / 23 dni…
+// Pattern: ends in 2/3/4 but not 12/13/14 → "dni" plural form is still "dni"
+// in modern Polish for the countdown context. We just need "dzień" vs "dni".
+function daysWord(n: number): string {
+  return n === 1 ? "dzień" : "dni";
+}
+
+const MONTHS_PL = [
+  "stycznia", "lutego", "marca", "kwietnia", "maja", "czerwca",
+  "lipca", "sierpnia", "września", "października", "listopada", "grudnia",
+];
+
+function parseISODate(iso: string): { y: number; m: number; d: number } {
+  const [y, m, d] = iso.split("-").map((x) => parseInt(x, 10));
+  return { y, m, d };
+}
+
+// "28–30 kwietnia" or "30 kwietnia – 2 maja" or "5 maja" (single day)
+function fmtSittingRange(firstISO: string, lastISO: string): string {
+  if (!firstISO) return "";
+  const a = parseISODate(firstISO);
+  if (!lastISO || firstISO === lastISO) {
+    return `${a.d} ${MONTHS_PL[a.m - 1]}`;
+  }
+  const b = parseISODate(lastISO);
+  if (a.m === b.m) return `${a.d}–${b.d} ${MONTHS_PL[a.m - 1]}`;
+  return `${a.d} ${MONTHS_PL[a.m - 1]} – ${b.d} ${MONTHS_PL[b.m - 1]}`;
+}
+
+type ItemProps = {
   label: string;
-  target: Date;
-  now: number;
+  value: string;
+  suffix?: string;
   delay: number;
-}) {
-  const p = diffParts(target, now);
+  accent?: boolean;
+};
+
+function Item({ label, value, suffix, delay, accent }: ItemProps) {
   return (
     <div
-      className="ec-item flex items-baseline gap-2.5"
+      className="ec-item flex items-baseline gap-2"
       style={{ animationDelay: `${delay}ms` }}
     >
       <span className="font-sans text-[10px] tracking-[0.18em] uppercase text-muted-foreground">
         {label}
       </span>
-      <span className="font-serif text-[17px] md:text-[19px] tabular-nums text-foreground leading-none">
-        {fmtDays(p.d)}
-      </span>
-      <span className="font-sans text-[10.5px] italic text-muted-foreground -ml-1">
-        dni
-      </span>
       <span
-        key={`${p.h}:${p.m}:${p.s}`}
-        className="ec-tick font-mono text-[10.5px] tabular-nums text-secondary-foreground/70 hidden sm:inline"
+        className={
+          "font-serif text-[16px] md:text-[17px] tabular-nums leading-none " +
+          (accent ? "text-destructive" : "text-foreground")
+        }
       >
-        {pad(p.h)}:{pad(p.m)}:{pad(p.s)}
+        {value}
       </span>
+      {suffix && (
+        <span className="font-sans text-[10.5px] italic text-muted-foreground">
+          {suffix}
+        </span>
+      )}
     </div>
   );
 }
 
-export function ElectionCountdown() {
+export function ElectionCountdown({
+  nextSitting,
+}: {
+  nextSitting: NextSittingInfo | null;
+}) {
   const [now, setNow] = useState<number | null>(null);
 
   useEffect(() => {
     setNow(Date.now());
-    const id = setInterval(() => setNow(Date.now()), 1000);
+    // Update once per minute — days-precision countdown doesn't need
+    // sub-second ticking and per-second updates were the source of the
+    // visible jitter on the previous version.
+    const id = setInterval(() => setNow(Date.now()), 60_000);
     return () => clearInterval(id);
   }, []);
 
-  // Reserve layout pre-hydration; render nothing until mounted to avoid SSR
-  // mismatch on the live time.
+  // Pre-hydration: reserve approximate height so layout doesn't jump in.
   if (now === null) {
-    return <div aria-hidden className="h-[44px] md:h-[40px]" />;
+    return <div aria-hidden className="h-[44px] md:h-[44px]" />;
+  }
+
+  const parlDays = daysUntil(PARLIAMENTARY_TARGET, now);
+  const presDays = daysUntil(PRESIDENTIAL_TARGET, now);
+
+  // Sitting: "trwają (28–30 maja)" if active, else "za 12 dni · 26 maja",
+  // else fall through (no scheduled sitting in the index).
+  let sittingItem: React.ReactNode = null;
+  if (nextSitting) {
+    const range = fmtSittingRange(nextSitting.firstDate, nextSitting.lastDate);
+    if (nextSitting.isActive) {
+      sittingItem = (
+        <Item
+          label="Obrady"
+          value="trwają"
+          suffix={range}
+          delay={360}
+          accent
+        />
+      );
+    } else {
+      const d = daysUntilISO(nextSitting.firstDate, now);
+      const valueText = d === 0 ? "dziś" : `za ${fmtCount(d)} ${daysWord(d)}`;
+      sittingItem = (
+        <Item
+          label="Obrady"
+          value={valueText}
+          suffix={range}
+          delay={360}
+        />
+      );
+    }
   }
 
   return (
     <section
-      aria-label="Licznik do wyborów"
+      aria-label="Licznik do wyborów i najbliższych obrad"
       className="px-4 md:px-8 lg:px-14 border-b border-rule"
     >
       <div className="max-w-[1100px] mx-auto py-2.5 md:py-3 flex items-center gap-x-6 gap-y-1.5 flex-wrap">
         <div
-          className="ec-lead flex items-center gap-2 font-sans text-[10px] tracking-[0.2em] uppercase text-destructive"
+          className="ec-item flex items-center gap-2 font-sans text-[10px] tracking-[0.2em] uppercase text-destructive"
           style={{ animationDelay: "0ms" }}
         >
           <span aria-hidden className="ec-pulse inline-block size-1.5 rounded-full bg-destructive" />
           do wyborów
         </div>
-        <CountdownItem label="Parlamentarne" target={PARLIAMENTARY_TARGET} now={now} delay={120} />
+
+        <Item
+          label="Parlamentarne"
+          value={fmtCount(parlDays)}
+          suffix={daysWord(parlDays)}
+          delay={120}
+        />
         <span aria-hidden className="text-border hidden md:inline">·</span>
-        <CountdownItem label="Prezydenckie" target={PRESIDENTIAL_TARGET} now={now} delay={240} />
+        <Item
+          label="Prezydenckie"
+          value={fmtCount(presDays)}
+          suffix={daysWord(presDays)}
+          delay={240}
+        />
+
+        {sittingItem && (
+          <>
+            <span aria-hidden className="text-border hidden md:inline">·</span>
+            {sittingItem}
+          </>
+        )}
       </div>
 
       <style>{`
-        @keyframes ec-rise {
-          from { opacity: 0; transform: translateY(4px); }
-          to   { opacity: 1; transform: translateY(0); }
+        @keyframes ec-fade {
+          from { opacity: 0; }
+          to   { opacity: 1; }
         }
         @keyframes ec-pulse {
-          0%, 100% { opacity: 0.55; transform: scale(1); }
-          50%      { opacity: 1;    transform: scale(1.35); }
+          0%, 100% { opacity: 0.45; }
+          50%      { opacity: 1; }
         }
-        @keyframes ec-flip {
-          from { opacity: 0.35; transform: translateY(-2px); }
-          to   { opacity: 1;    transform: translateY(0); }
-        }
-        .ec-lead, .ec-item {
+        .ec-item {
           opacity: 0;
-          animation: ec-rise 520ms cubic-bezier(.2,.7,.2,1) forwards;
+          animation: ec-fade 700ms ease-out forwards;
         }
         .ec-pulse {
-          animation: ec-pulse 2.4s ease-in-out infinite;
-        }
-        .ec-tick {
-          animation: ec-flip 240ms ease-out;
-          display: inline-block;
+          animation: ec-pulse 2.6s ease-in-out infinite;
         }
         @media (prefers-reduced-motion: reduce) {
-          .ec-lead, .ec-item, .ec-pulse, .ec-tick { animation: none; opacity: 1; }
+          .ec-item, .ec-pulse { animation: none; opacity: 1; }
         }
       `}</style>
     </section>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@ import { LandingHero } from "./_components/LandingHero";
 import { FeatureTileGrid } from "./_components/FeatureTileGrid";
 import { ElectionCountdown } from "./_components/ElectionCountdown";
 import { getTopViralStatements } from "@/lib/db/statements";
+import { getNextOrCurrentSitting } from "@/lib/db/events";
 
 async function safeTypewriter() {
   try {
@@ -18,12 +19,24 @@ async function safeTypewriter() {
   }
 }
 
+async function safeNextSitting() {
+  try {
+    return await getNextOrCurrentSitting(10);
+  } catch (err) {
+    console.error("[landing] getNextOrCurrentSitting failed", err);
+    return null;
+  }
+}
+
 export default async function Landing() {
-  const quotes = await safeTypewriter();
+  const [quotes, nextSitting] = await Promise.all([
+    safeTypewriter(),
+    safeNextSitting(),
+  ]);
   return (
     <main className="bg-background font-serif text-foreground">
       <LandingHero viralQuotes={quotes} />
-      <ElectionCountdown />
+      <ElectionCountdown nextSitting={nextSitting} />
       <FeatureTileGrid />
     </main>
   );

--- a/frontend/lib/db/events.ts
+++ b/frontend/lib/db/events.ts
@@ -7,6 +7,7 @@ import {
   topicsFromDb,
   SECTION_LIMITS,
   type EventType,
+  type NextSittingInfo,
   type SittingInfo,
   type WeeklyEvent,
 } from "@/lib/events-types";
@@ -14,7 +15,7 @@ import {
 // Re-export for callers that hit this module — keeps import paths stable
 // while pure types live in lib/events-types.ts (so client components can
 // pull types without dragging in the server-only data layer).
-export type { SittingInfo, WeeklyEvent, EventType };
+export type { NextSittingInfo, SittingInfo, WeeklyEvent, EventType };
 
 // Batches PostgREST work; keeps prerender + ISR under budget and cuts warm latency.
 const EVENTS_REVALIDATE_SEC = 300;
@@ -75,6 +76,46 @@ export function getLatestSittingWithEvents(term = 10): Promise<SittingInfo | nul
   return unstable_cache(
     async () => loadLatestSittingWithEvents(term),
     ["tygodnik-latest-sitting", String(term)],
+    { revalidate: EVENTS_REVALIDATE_SEC },
+  )();
+}
+
+function warsawToday(): string {
+  // sv-SE locale formats as YYYY-MM-DD; timeZone pins to Warsaw so the
+  // "is sitting active today?" check doesn't drift on UTC-running servers.
+  return new Intl.DateTimeFormat("sv-SE", { timeZone: "Europe/Warsaw" }).format(new Date());
+}
+
+async function loadNextOrCurrentSitting(term: number): Promise<NextSittingInfo | null> {
+  const today = warsawToday();
+  const sb = supabase();
+  const { data, error } = await sb
+    .from("tygodnik_sittings")
+    .select("term, sitting_num, first_date, last_date")
+    .eq("term", term)
+    .gte("last_date", today)
+    .order("first_date", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data) return null;
+  const firstDate = (data.first_date as string) ?? "";
+  const lastDate = (data.last_date as string) ?? "";
+  return {
+    term: data.term as number,
+    sittingNum: data.sitting_num as number,
+    firstDate,
+    lastDate,
+    isActive: today >= firstDate && today <= lastDate,
+  };
+}
+
+export function getNextOrCurrentSitting(term = 10): Promise<NextSittingInfo | null> {
+  return unstable_cache(
+    async () => loadNextOrCurrentSitting(term),
+    ["tygodnik-next-sitting", String(term)],
+    // 5-minute cache: posiedzenie schedule doesn't churn intra-day, but
+    // we want the "trwają" flag to flip soon after first/last date crosses.
     { revalidate: EVENTS_REVALIDATE_SEC },
   )();
 }

--- a/frontend/lib/events-types.ts
+++ b/frontend/lib/events-types.ts
@@ -225,6 +225,14 @@ export type SittingInfo = {
   topTopics: TopicId[];
 };
 
+export type NextSittingInfo = {
+  term: number;
+  sittingNum: number;
+  firstDate: string; // YYYY-MM-DD (Europe/Warsaw)
+  lastDate: string;
+  isActive: boolean;
+};
+
 const TOPIC_ALLOWED = new Set<string>([
   "sady-prawa", "bezpieczenstwo-obrona", "biznes-podatki",
   "praca-zus", "zdrowie", "edukacja-rodzina", "emerytury",


### PR DESCRIPTION
## Co i dlaczego

**Animacja na pasku skakała** — poprzednia wersja miała `key={...}` na elemencie z `HH:MM:SS`, więc React odmontowywał go co sekundę i restartował keyframe `ec-flip` z `translateY(-2px)`. Do tego pulsująca kropka skalowała się do `1.35`. Razem dawało to wrażenie szarpania co tick.

**Naprawione:**
- Usunąłem sekundy całkowicie — w paskiu zostają tylko dni (do wyborów to skala tygodni/miesięcy, sekundy były tylko hałasem).
- Animacje wyłącznie na `opacity` (fade-in 700 ms na mount, slow pulse 2.6 s na kropce). Bez `translate`, bez `scale`.
- Interval z 1 s → 60 s.
- Liczenie dni zakotwiczone w `Europe/Warsaw` (Intl + UTC midnight), więc nie ucieka na DST ani na serwerze UTC.

## Nowy element: „Obrady"

Dodany kolejny człon w tym samym pasku:
- **Trwają teraz:** `Obrady · trwają · 28–30 maja` (akcent na czerwono)
- **Najbliższe:** `Obrady · za 12 dni · 26 maja`
- **Brak w indeksie:** człon się nie renderuje.

Pod spodem nowy server-fn `getNextOrCurrentSitting(term=10)` w `lib/db/events.ts` — query do widoku `tygodnik_sittings`, najwcześniejszy wiersz z `last_date >= today (Warsaw)`. `isActive` wyliczane lokalnie z porównania stringów `YYYY-MM-DD` (leksykograficznie OK). Cache `unstable_cache` 300 s, spójny z innymi funkcjami w pliku.

## Test plan
- [ ] Hero pokazuje pasek bez skakania (porównanie z poprzednią wersją)
- [ ] Liczby dni są sensowne wobec szacowanych dat (parl. 2027-11-07, prez. 2030-05-19)
- [ ] `Obrady` pokazuje `trwają` w dniach posiedzenia z `proceedings` (sprawdzić na bieżącej dacie 2026-05-14 wobec `tygodnik_sittings`)
- [ ] `Obrady` pokazuje `za N dni` poza dniami posiedzenia
- [ ] `prefers-reduced-motion`: brak animacji, pełna widoczność

https://claude.ai/code/session_019RmjBqzYafbtTK5GZh9Z5m

---
_Generated by [Claude Code](https://claude.ai/code/session_019RmjBqzYafbtTK5GZh9Z5m)_