### PR TITLE
feat(proces): show plenary agenda points where the print was procedowany

### DIFF
--- a/frontend/app/proces/[term]/[number]/_components/ProceedingPoints.tsx
+++ b/frontend/app/proces/[term]/[number]/_components/ProceedingPoints.tsx
@@ -1,0 +1,158 @@
+import type { ProceedingPoint } from "@/lib/db/prints";
+
+function SectionHead({ title, subtitle }: { title: string; subtitle?: string | null }) {
+  return (
+    <div className="mb-5 flex items-baseline gap-4 border-b border-border pb-3">
+      <h2
+        className="font-serif font-medium text-foreground m-0"
+        style={{ fontSize: 22, lineHeight: 1, letterSpacing: "-0.015em" }}
+      >
+        {title}
+      </h2>
+      {subtitle && (
+        <span className="font-sans text-[11.5px] text-muted-foreground ml-auto">{subtitle}</span>
+      )}
+    </div>
+  );
+}
+
+function pluralPosiedzen(n: number): string {
+  if (n === 1) return "1 posiedzenie";
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return `${n} posiedzenia`;
+  return `${n} posiedzeń`;
+}
+
+function pluralPunktow(n: number): string {
+  if (n === 1) return "1 punkt";
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return `${n} punkty`;
+  return `${n} punktów`;
+}
+
+function pluralWypowiedzi(n: number): string {
+  if (n === 1) return "1 wypowiedź";
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return `${n} wypowiedzi`;
+  return `${n} wypowiedzi`;
+}
+
+function formatSittingDates(dates: string[]): string {
+  if (dates.length === 0) return "—";
+  const fmt = new Intl.DateTimeFormat("pl-PL", { day: "numeric", month: "long", year: "numeric" });
+  if (dates.length === 1) return fmt.format(new Date(dates[0]));
+  const first = new Date(dates[0]);
+  const last = new Date(dates[dates.length - 1]);
+  const sameYear = first.getFullYear() === last.getFullYear();
+  const sameMonth = sameYear && first.getMonth() === last.getMonth();
+  if (sameMonth) {
+    const monthYear = new Intl.DateTimeFormat("pl-PL", { month: "long", year: "numeric" }).format(first);
+    return `${first.getDate()}–${last.getDate()} ${monthYear}`;
+  }
+  return `${fmt.format(first)} – ${fmt.format(last)}`;
+}
+
+type SittingGroup = {
+  sittingNum: number;
+  sittingTitle: string;
+  sittingDates: string[];
+  points: ProceedingPoint[];
+};
+
+function groupBySitting(points: ProceedingPoint[]): SittingGroup[] {
+  const byNum = new Map<number, SittingGroup>();
+  for (const p of points) {
+    let g = byNum.get(p.sittingNum);
+    if (!g) {
+      g = {
+        sittingNum: p.sittingNum,
+        sittingTitle: p.sittingTitle,
+        sittingDates: p.sittingDates,
+        points: [],
+      };
+      byNum.set(p.sittingNum, g);
+    }
+    g.points.push(p);
+  }
+  return Array.from(byNum.values()).sort((a, b) => a.sittingNum - b.sittingNum);
+}
+
+export function ProceedingPoints({ points }: { points: ProceedingPoint[] }) {
+  if (points.length === 0) return null;
+  const groups = groupBySitting(points);
+
+  return (
+    <section className="py-12 px-3 md:px-4 lg:px-5 border-b border-border">
+      <div className="max-w-[1280px] mx-auto">
+        <SectionHead
+          title="Punkty obrad plenarnych"
+          subtitle={pluralPosiedzen(groups.length)}
+        />
+
+        <ol className="list-none p-0 m-0">
+          {groups.map((g) => (
+            <SittingGroupRow key={g.sittingNum} group={g} />
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}
+
+function SittingGroupRow({ group }: { group: SittingGroup }) {
+  return (
+    <li className="py-5 border-b border-border last:border-b-0">
+      <div className="flex items-baseline gap-3 flex-wrap mb-3">
+        <h3
+          className="font-serif font-medium m-0 text-foreground"
+          style={{ fontSize: 18, letterSpacing: "-0.005em" }}
+        >
+          Posiedzenie nr {group.sittingNum}
+        </h3>
+        <span
+          className="font-mono uppercase"
+          style={{ fontSize: 10, color: "var(--muted-foreground)", letterSpacing: "0.12em" }}
+        >
+          {formatSittingDates(group.sittingDates)}
+        </span>
+        <span className="font-sans text-[11px] text-muted-foreground ml-auto">
+          {pluralPunktow(group.points.length)}
+        </span>
+      </div>
+
+      <ul className="list-none p-0 m-0 space-y-2">
+        {group.points.map((p) => (
+          <li
+            key={p.agendaItemId}
+            className="flex items-baseline gap-3"
+            style={{ paddingLeft: 4 }}
+          >
+            <span
+              className="font-mono text-muted-foreground shrink-0"
+              style={{ fontSize: 12, minWidth: 28 }}
+            >
+              pkt {p.ord}
+            </span>
+            <span
+              className="font-serif text-secondary-foreground flex-1"
+              style={{ fontSize: 14.5, lineHeight: 1.5, textWrap: "pretty" as never }}
+            >
+              {p.title}
+            </span>
+            {p.statementCount > 0 && (
+              <span
+                className="font-sans text-muted-foreground shrink-0"
+                style={{ fontSize: 11, letterSpacing: "0.02em" }}
+              >
+                {pluralWypowiedzi(p.statementCount)}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </li>
+  );
+}

--- a/frontend/app/proces/[term]/[number]/page.tsx
+++ b/frontend/app/proces/[term]/[number]/page.tsx
@@ -10,6 +10,7 @@ import { Timeline } from "./_components/Timeline";
 import { Summary } from "./_components/Summary";
 import { Votings } from "./_components/Votings";
 import { Committees } from "./_components/Committees";
+import { ProceedingPoints } from "./_components/ProceedingPoints";
 import { Sources } from "./_components/Sources";
 
 
@@ -88,6 +89,7 @@ export default async function DrukPage({
     matchedPromises,
     outcome,
     attachments,
+    proceedingPoints,
   } = data;
 
   const processStillOpen = !outcome?.passed && !print.currentStageType?.match(/^(End|Withdrawn|Rejected)$/);
@@ -145,6 +147,7 @@ export default async function DrukPage({
           processStillOpen={!!processStillOpen}
         />
         <Committees stages={stages} committeeSittings={committeeSittings} />
+        <ProceedingPoints points={proceedingPoints} />
 
         {/* Dz.U. publication banner — kept from old layout, repositioned here. */}
         {outcome?.passed && outcome.act && (

--- a/frontend/lib/db/prints.ts
+++ b/frontend/lib/db/prints.ts
@@ -225,6 +225,21 @@ export type MainVotingSeat = {
   vote: string;
 };
 
+// Agenda point of a plenary sitting where this print was procedowany.
+// Sourced from agenda_item_prints (mig 0028); statement count from
+// statement_print_links (mig 0047) narrowed to source='agenda_item' so we
+// only count speeches anchored to the same agenda item, not stray druk
+// mentions elsewhere in the sitting.
+export type ProceedingPoint = {
+  agendaItemId: number;
+  sittingNum: number;
+  sittingTitle: string;
+  sittingDates: string[];
+  ord: number;
+  title: string;
+  statementCount: number;
+};
+
 export type PrintWithStages = {
   print: PrintDetail;
   stages: ProcessStage[];
@@ -247,6 +262,10 @@ export type PrintWithStages = {
   outcome: ProcessOutcome | null;
   // Attachments for the main print (ordered by ordinal).
   attachments: string[];
+  // Plenary sitting agenda points where this print appeared. Grouped per
+  // sitting in the UI. Empty when the print never made it to a plenary agenda
+  // (e.g. still in committee, or only mentioned indirectly).
+  proceedingPoints: ProceedingPoint[];
 };
 
 const SELECT_DETAIL =
@@ -517,6 +536,62 @@ export async function getPrint(term: number, number: string): Promise<PrintWithS
     })
     .filter((x): x is MatchedPromise => !!x);
 
+  // Plenary agenda points (mig 0028) where this print is referenced. Joined
+  // up to proceedings for sitting num/title/dates. Statement counts pulled in
+  // a second pass keyed on agenda_item_id.
+  const { data: aipRows } = await sb
+    .from("agenda_item_prints")
+    .select(
+      "agenda_items:agenda_item_id(id, ord, title, proceedings:proceeding_id(number, title, dates))",
+    )
+    .eq("term", term)
+    .eq("print_number", number);
+
+  type AgendaItemJoined = {
+    id: number;
+    ord: number;
+    title: string;
+    proceedings: { number: number; title: string; dates: string[] } | { number: number; title: string; dates: string[] }[] | null;
+  };
+  const agendaItems: AgendaItemJoined[] = (aipRows ?? [])
+    .map((r) => {
+      const ai = (r as { agenda_items: AgendaItemJoined | AgendaItemJoined[] | null }).agenda_items;
+      return Array.isArray(ai) ? ai[0] : ai;
+    })
+    .filter((x): x is AgendaItemJoined => !!x);
+
+  const stmtCountByItem = new Map<number, number>();
+  if (agendaItems.length > 0) {
+    const { data: linkRows } = await sb
+      .from("statement_print_links")
+      .select("agenda_item_id")
+      .eq("print_id", printId)
+      .not("agenda_item_id", "is", null);
+    for (const r of (linkRows ?? []) as Array<{ agenda_item_id: number }>) {
+      stmtCountByItem.set(r.agenda_item_id, (stmtCountByItem.get(r.agenda_item_id) ?? 0) + 1);
+    }
+  }
+
+  const proceedingPoints: ProceedingPoint[] = agendaItems
+    .map((ai): ProceedingPoint | null => {
+      const proc = Array.isArray(ai.proceedings) ? ai.proceedings[0] : ai.proceedings;
+      if (!proc) return null;
+      return {
+        agendaItemId: ai.id,
+        sittingNum: proc.number,
+        sittingTitle: proc.title,
+        sittingDates: proc.dates ?? [],
+        ord: ai.ord,
+        title: ai.title,
+        statementCount: stmtCountByItem.get(ai.id) ?? 0,
+      };
+    })
+    .filter((x): x is ProceedingPoint => !!x)
+    .sort((a, b) => {
+      if (a.sittingNum !== b.sittingNum) return a.sittingNum - b.sittingNum;
+      return a.ord - b.ord;
+    });
+
   const sponsorMpsRaw = p.sponsor_mps as unknown;
   const sponsorMps: string[] = Array.isArray(sponsorMpsRaw)
     ? (sponsorMpsRaw.filter((x) => typeof x === "string") as string[])
@@ -565,6 +640,7 @@ export async function getPrint(term: number, number: string): Promise<PrintWithS
     matchedPromises,
     outcome,
     attachments,
+    proceedingPoints,
   };
 }
 

--- a/tests/supagraf/e2e/test_proceeding_points_e2e.py
+++ b/tests/supagraf/e2e/test_proceeding_points_e2e.py
@@ -1,0 +1,268 @@
+"""E2E completeness tests for the "Punkty obrad" section on the print page.
+
+Validates that the data path
+    agenda_item_prints -> agenda_items -> proceedings
+                       \\-> statement_print_links (count)
+that the frontend reads in `lib/db/prints.ts:getPrint` returns complete,
+non-orphaned rows for every print that has any plenary agenda presence.
+
+Priority: completeness — we want to be loud when we silently drop points
+(e.g. a stray NULL proceedings join, FK rot, or backfill regression).
+
+Strategy: invariants on the full table + a random sample of 20 prints whose
+end-to-end chain we walk exactly the way the frontend does.
+
+Skipped by default. Enable with `RUN_E2E=1`.
+"""
+from __future__ import annotations
+
+import os
+import random
+
+import pytest
+
+from supagraf.db import supabase
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_E2E") != "1",
+    reason="e2e against live Supabase; set RUN_E2E=1 to enable",
+)
+
+TERM = 10
+SAMPLE_SIZE = 20
+RNG_SEED = 42  # deterministic sample across runs
+
+
+@pytest.fixture(scope="module")
+def sb():
+    return supabase()
+
+
+# ---------------------------------------------------------------------------
+# Whole-table invariants — fast, no sampling.
+# ---------------------------------------------------------------------------
+
+def test_agenda_item_prints_reference_real_prints(sb):
+    """Every (term, print_number) in agenda_item_prints must resolve to a
+    prints row. FK enforces this, but verifying covers DB drift / migration
+    bugs that would silently drop frontend rows."""
+    aip = sb.table("agenda_item_prints").select("term, print_number").eq("term", TERM).execute().data or []
+    if not aip:
+        pytest.skip("no agenda_item_prints rows for term — nothing to verify")
+    pairs = {(r["term"], r["print_number"]) for r in aip}
+    # Pull just the keys we need; supabase select can't IN across composite keys
+    # easily, so fetch the whole term's prints index (cheap).
+    prints = sb.table("prints").select("term, number").eq("term", TERM).execute().data or []
+    real = {(r["term"], r["number"]) for r in prints}
+    missing = pairs - real
+    assert not missing, f"agenda_item_prints references {len(missing)} non-existent prints; sample: {list(missing)[:5]}"
+
+
+def test_agenda_items_reference_real_proceedings(sb):
+    """agenda_items.proceeding_id must point to a real proceedings row.
+    A NULL/orphan here silently drops the entire sitting group on the
+    frontend (proceedings join returns null → row filtered out)."""
+    items = sb.table("agenda_items").select("id, proceeding_id").execute().data or []
+    if not items:
+        pytest.skip("no agenda_items rows")
+    proc_ids = {r["proceeding_id"] for r in items}
+    procs = sb.table("proceedings").select("id").in_("id", list(proc_ids)).execute().data or []
+    real = {r["id"] for r in procs}
+    missing = proc_ids - real
+    assert not missing, f"agenda_items reference {len(missing)} non-existent proceedings; sample: {list(missing)[:5]}"
+
+
+def test_statement_print_links_agenda_item_consistent_with_aip(sb):
+    """When statement_print_links.agenda_item_id is set, the (print_id, that
+    agenda_item) must also appear in agenda_item_prints. Otherwise the count
+    we display includes statements anchored to an agenda item that doesn't
+    actually reference this print — a backfill bug we'd never notice in UI."""
+    links = (
+        sb.table("statement_print_links")
+        .select("print_id, agenda_item_id")
+        .not_.is_("agenda_item_id", "null")
+        .execute()
+        .data
+        or []
+    )
+    if not links:
+        pytest.skip("no statement_print_links with agenda_item_id (backfill not run)")
+
+    # Build (agenda_item_id -> term, print_number) from prints + agenda_item_prints
+    aip = sb.table("agenda_item_prints").select("agenda_item_id, term, print_number").execute().data or []
+    # Map agenda_item_prints to print_id via prints
+    prints = sb.table("prints").select("id, term, number").eq("term", TERM).execute().data or []
+    pid_by_key = {(r["term"], r["number"]): r["id"] for r in prints}
+    valid_pairs: set[tuple[int, int]] = set()
+    for r in aip:
+        pid = pid_by_key.get((r["term"], r["print_number"]))
+        if pid is not None:
+            valid_pairs.add((pid, r["agenda_item_id"]))
+
+    inconsistent = [
+        (lnk["print_id"], lnk["agenda_item_id"])
+        for lnk in links
+        if (lnk["print_id"], lnk["agenda_item_id"]) not in valid_pairs
+    ]
+    assert not inconsistent, (
+        f"{len(inconsistent)} statement_print_links rows have agenda_item_id "
+        f"that does not appear in agenda_item_prints for that print; "
+        f"sample: {inconsistent[:5]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sampled end-to-end walk — mirrors the frontend query path.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def sampled_print_ids(sb):
+    """Pick 20 random prints (by id) that have at least one agenda_item_prints
+    row. Deterministic via RNG_SEED so failures reproduce."""
+    aip = sb.table("agenda_item_prints").select("term, print_number").eq("term", TERM).execute().data or []
+    if not aip:
+        pytest.skip("no agenda_item_prints rows for term")
+    distinct = sorted({(r["term"], r["print_number"]) for r in aip})
+    rng = random.Random(RNG_SEED)
+    rng.shuffle(distinct)
+    return distinct[:SAMPLE_SIZE]
+
+
+def test_sampled_prints_have_complete_proceeding_chain(sb, sampled_print_ids):
+    """For each sampled print, every agenda_item_prints row resolves to a full
+    chain (agenda_item with non-empty title/ord, proceedings with non-empty
+    dates and a positive sitting number). A NULL anywhere = a row the frontend
+    silently filters out."""
+    failures: list[str] = []
+    for term, number in sampled_print_ids:
+        aip = (
+            sb.table("agenda_item_prints")
+            .select("agenda_item_id")
+            .eq("term", term)
+            .eq("print_number", number)
+            .execute()
+            .data
+            or []
+        )
+        ai_ids = [r["agenda_item_id"] for r in aip]
+        if not ai_ids:
+            failures.append(f"{term}/{number}: aip empty but listed in sample")
+            continue
+        items = (
+            sb.table("agenda_items")
+            .select("id, ord, title, proceeding_id")
+            .in_("id", ai_ids)
+            .execute()
+            .data
+            or []
+        )
+        if len(items) != len(ai_ids):
+            failures.append(f"{term}/{number}: {len(ai_ids) - len(items)} agenda_items missing")
+            continue
+        for ai in items:
+            if ai["ord"] is None or ai["ord"] <= 0:
+                failures.append(f"{term}/{number}: agenda_item {ai['id']} has invalid ord={ai['ord']}")
+            if not ai.get("title"):
+                failures.append(f"{term}/{number}: agenda_item {ai['id']} has empty title")
+        proc_ids = sorted({ai["proceeding_id"] for ai in items})
+        procs = (
+            sb.table("proceedings")
+            .select("id, number, title, dates")
+            .in_("id", proc_ids)
+            .execute()
+            .data
+            or []
+        )
+        if len(procs) != len(proc_ids):
+            failures.append(f"{term}/{number}: {len(proc_ids) - len(procs)} proceedings missing")
+            continue
+        for proc in procs:
+            if not proc.get("number") or proc["number"] <= 0:
+                failures.append(f"{term}/{number}: proceeding {proc['id']} has invalid number={proc.get('number')}")
+            if not proc.get("dates"):
+                failures.append(f"{term}/{number}: proceeding {proc['id']} has empty dates")
+    assert not failures, "\n".join(failures[:30])
+
+
+def test_sampled_prints_statement_counts_are_nonnegative(sb, sampled_print_ids):
+    """statement_print_links agenda_item_id may resolve to a count. Verify
+    counts are sane (>= 0) and that counts > 0 imply agenda_item is in this
+    print's agenda_item_prints."""
+    # Resolve sample (term, number) -> print_id
+    prints = sb.table("prints").select("id, term, number").eq("term", TERM).execute().data or []
+    pid_by_key = {(r["term"], r["number"]): r["id"] for r in prints}
+
+    failures: list[str] = []
+    for term, number in sampled_print_ids:
+        printid = pid_by_key.get((term, number))
+        if printid is None:
+            failures.append(f"{term}/{number}: not in prints table")
+            continue
+        # Agenda items the frontend would show
+        aip = (
+            sb.table("agenda_item_prints")
+            .select("agenda_item_id")
+            .eq("term", term)
+            .eq("print_number", number)
+            .execute()
+            .data
+            or []
+        )
+        agenda_set = {r["agenda_item_id"] for r in aip}
+
+        # Statement links keyed on this print
+        links = (
+            sb.table("statement_print_links")
+            .select("agenda_item_id")
+            .eq("print_id", printid)
+            .not_.is_("agenda_item_id", "null")
+            .execute()
+            .data
+            or []
+        )
+        for lnk in links:
+            aid = lnk["agenda_item_id"]
+            if aid not in agenda_set:
+                failures.append(
+                    f"{term}/{number}: statement_print_links has agenda_item_id={aid} "
+                    "but it is not in agenda_item_prints for this print"
+                )
+    assert not failures, "\n".join(failures[:30])
+
+
+def test_sampled_prints_grouping_by_sitting_yields_distinct_ords(sb, sampled_print_ids):
+    """Within a single sitting, the same print should not appear at the same
+    agenda ord twice — that would indicate a duplicate agenda_item row, which
+    breaks the per-sitting grouping in the UI."""
+    failures: list[str] = []
+    for term, number in sampled_print_ids:
+        aip = (
+            sb.table("agenda_item_prints")
+            .select("agenda_item_id")
+            .eq("term", term)
+            .eq("print_number", number)
+            .execute()
+            .data
+            or []
+        )
+        ai_ids = [r["agenda_item_id"] for r in aip]
+        if not ai_ids:
+            continue
+        items = (
+            sb.table("agenda_items")
+            .select("id, ord, proceeding_id")
+            .in_("id", ai_ids)
+            .execute()
+            .data
+            or []
+        )
+        # Group by proceeding_id, check ord uniqueness
+        by_proc: dict[int, list[int]] = {}
+        for ai in items:
+            by_proc.setdefault(ai["proceeding_id"], []).append(ai["ord"])
+        for pid, ords in by_proc.items():
+            if len(ords) != len(set(ords)):
+                failures.append(
+                    f"{term}/{number}: proceeding {pid} has duplicate ords {sorted(ords)}"
+                )
+    assert not failures, "\n".join(failures[:30])


### PR DESCRIPTION
Adds a "Punkty obrad plenarnych" section to /proces/[term]/[number],
grouped per sitting with statement counts. Surfaces older prints that
return on later sittings via agenda_items — a path the existing
print_sitting_assignment view ignores because it derives only from
process_stages.

Source: agenda_item_prints (mig 0028) joined up to proceedings;
statement counts from statement_print_links (mig 0047, source=agenda_item).

Tests: e2e completeness invariants + 20-print random sample walking the
same chain the frontend does. Gated by RUN_E2E=1.