### PR TITLE
feat(explainer): rich-style 11-step legislative process dialog

### DIFF
--- a/frontend/components/tygodnik/atoms/ProcessStageBar.tsx
+++ b/frontend/components/tygodnik/atoms/ProcessStageBar.tsx
@@ -1,18 +1,26 @@
-// 6-step pipeline visualization for a Sejm legislative process. Maps the
-// many stage_type enum values from process_stages onto 6 broad buckets so
+// 7-step pipeline visualization for a Sejm legislative process. Maps the
+// many stage_type enum values from process_stages onto 7 broad buckets so
 // the bar reads at a glance without needing to know parliamentary procedure.
 //
 // Termination: when `process_state.End` is reached without `processPassed`,
 // the project died mid-flow (rejected in I czytanie, withdrawn, etc.).
-// The full 6-step bar implies the project is moving toward Prezydent —
+// The full 7-step bar implies the project is moving toward Prezydent —
 // citizen review caught this contradiction (#4: "Zakończono" badge +
-// progressing 6-step bar on /proces/10/2197). Terminated processes now
+// progressing bar on /proces/10/2197). Terminated processes now
 // render a compact "Proces zakończony" badge instead.
+//
+// Why "plenum" is its own step (split from "głosowanie"):
+//   `SejmReading` is "I/II/III czytanie na posiedzeniu Sejmu" — a debate
+//   on the floor, NOT a vote. Lumping it with `Voting` (the actual roll
+//   call) labelled the bar GŁOSOWANIE for prints that were still in
+//   II czytanie, misleading citizens into thinking the vote already
+//   happened. PLENUM is the dedicated step for floor debate before vote.
 
 const STEPS = [
   { key: "intake", label: "wpłynęło" },
   { key: "first_reading", label: "I czytanie" },
   { key: "committee", label: "komisja" },
+  { key: "plenum", label: "plenum" },
   { key: "vote", label: "głosowanie" },
   { key: "senate", label: "senat" },
   { key: "president", label: "prezydent" },
@@ -33,13 +41,15 @@ const STAGE_TO_STEP: Record<string, StepKey> = {
   Reading: "first_reading",
   CommitteeWork: "committee",
   CommitteeReport: "committee",
-  SejmReading: "vote",
+  SejmReading: "plenum",
   Voting: "vote",
   SenatePosition: "senate",
   SenateAmendments: "senate",
+  SenatePositionConsideration: "senate",
   ToPresident: "president",
   PresidentSignature: "president",
   PresidentVeto: "president",
+  PresidentMotionConsideration: "president",
   ConstitutionalTribunal: "president",
   Promulgation: "president",
 };

--- a/frontend/components/tygodnik/atoms/ProcessStageBar.tsx
+++ b/frontend/components/tygodnik/atoms/ProcessStageBar.tsx
@@ -2,6 +2,13 @@
 // many stage_type enum values from process_stages onto 7 broad buckets so
 // the bar reads at a glance without needing to know parliamentary procedure.
 //
+// "?" affordance — ProcessStagesExplainer dialog. The bar's labels read as
+// buzzwords to anyone outside parliamentary procedure (citizen feedback:
+// "skąd mam wiedzieć co to PLENUM"), so we anchor a plain-language
+// explainer right where the bar is shown.
+
+import { ProcessStagesExplainer } from "./ProcessStagesExplainer";
+//
 // Termination: when `process_state.End` is reached without `processPassed`,
 // the project died mid-flow (rejected in I czytanie, withdrawn, etc.).
 // The full 7-step bar implies the project is moving toward Prezydent —
@@ -99,43 +106,48 @@ export function ProcessStageBar({
   const currentIdx = stepIndexFor(currentStageType, processPassed);
 
   return (
-    <div className="mb-4" style={{ minHeight: 32 }}>
-      <div className="flex items-center gap-1 mb-1.5">
-        {STEPS.map((step, i) => {
-          const done = i < currentIdx;
-          const current = i === currentIdx;
-          const bg = done
-            ? "var(--secondary-foreground)"
-            : current
-            ? "var(--destructive)"
-            : "var(--border)";
-          return (
-            <div
-              key={step.key}
-              className="flex-1 h-[3px] rounded-full"
-              style={{ background: bg }}
-              aria-hidden
-            />
-          );
-        })}
+    <div className="mb-4 flex items-start gap-2" style={{ minHeight: 32 }}>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1 mb-1.5">
+          {STEPS.map((step, i) => {
+            const done = i < currentIdx;
+            const current = i === currentIdx;
+            const bg = done
+              ? "var(--secondary-foreground)"
+              : current
+              ? "var(--destructive)"
+              : "var(--border)";
+            return (
+              <div
+                key={step.key}
+                className="flex-1 h-[3px] rounded-full"
+                style={{ background: bg }}
+                aria-hidden
+              />
+            );
+          })}
+        </div>
+        <div className="flex items-center justify-between font-mono text-[9px] tracking-[0.12em] uppercase text-muted-foreground">
+          {STEPS.map((step, i) => {
+            const current = i === currentIdx;
+            return (
+              <span
+                key={step.key}
+                className="truncate"
+                style={{
+                  color: current ? "var(--destructive)" : undefined,
+                  fontWeight: current ? 600 : undefined,
+                  maxWidth: `${100 / STEPS.length}%`,
+                }}
+              >
+                {step.label}
+              </span>
+            );
+          })}
+        </div>
       </div>
-      <div className="flex items-center justify-between font-mono text-[9px] tracking-[0.12em] uppercase text-muted-foreground">
-        {STEPS.map((step, i) => {
-          const current = i === currentIdx;
-          return (
-            <span
-              key={step.key}
-              className="truncate"
-              style={{
-                color: current ? "var(--destructive)" : undefined,
-                fontWeight: current ? 600 : undefined,
-                maxWidth: `${100 / STEPS.length}%`,
-              }}
-            >
-              {step.label}
-            </span>
-          );
-        })}
+      <div className="mt-[-2px]">
+        <ProcessStagesExplainer />
       </div>
     </div>
   );

--- a/frontend/components/tygodnik/atoms/ProcessStagesExplainer.tsx
+++ b/frontend/components/tygodnik/atoms/ProcessStagesExplainer.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { ArrowRight, ArrowLeft, HelpCircle, X } from "lucide-react";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+// Citizen-facing explainer of the 7-step legislative pipeline rendered by
+// ProcessStageBar. Triggered by a "?" affordance next to the bar.
+//
+// Two design choices driven by citizen review:
+//   1. Plain Polish, no jargon ("subsydiarność", "tryb pilny" out).
+//   2. Each step shows BRANCH OPTIONS, not just the happy path. The bar
+//      can move backwards (committee revisits after II czytanie; Sejm
+//      re-votes after Senate amendments; Sejm overrides presidential
+//      veto with 3/5 majority). Without branches the bar reads as
+//      one-way which is misleading.
+
+type Branch = {
+  kind: "forward" | "back" | "terminal";
+  label: string;
+  detail?: string;
+};
+
+type StageExplainer = {
+  step: number;
+  key: string;
+  label: string;
+  blurb: string;
+  detail: string;
+  branches: Branch[];
+};
+
+const STAGES: StageExplainer[] = [
+  {
+    step: 1,
+    key: "intake",
+    label: "Wpłynęło",
+    blurb: "Projekt trafia do Sejmu.",
+    detail:
+      "Ustawę może zgłosić rząd, posłowie (klub poselski lub grupa 15 posłów), Senat, Prezydent, komisja sejmowa albo 100 tysięcy obywateli przez inicjatywę obywatelską. To początek — nic jeszcze nie zostało zdecydowane, projekt czeka na pierwsze omówienie.",
+    branches: [
+      { kind: "forward", label: "I czytanie", detail: "Zawsze następny krok." },
+    ],
+  },
+  {
+    step: 2,
+    key: "first_reading",
+    label: "I czytanie",
+    blurb: "Pierwsze formalne omówienie.",
+    detail:
+      "Marszałek Sejmu kieruje projekt albo bezpośrednio na salę plenarną (cały Sejm), albo do komisji branżowej — zależnie od wagi tematu. Autorzy przedstawiają cele, posłowie zapoznają się z treścią.",
+    branches: [
+      { kind: "forward", label: "Komisja", detail: "Standardowa droga — szczegółowa analiza." },
+      { kind: "terminal", label: "Odrzucenie", detail: "Sejm może odrzucić projekt już na tym etapie." },
+    ],
+  },
+  {
+    step: 3,
+    key: "committee",
+    label: "Komisja",
+    blurb: "Branżowi eksperci analizują szczegóły.",
+    detail:
+      "Komisje sejmowe (np. zdrowia, finansów, kultury) czytają projekt linijka po linijce, słuchają opinii ekspertów, organizacji społecznych i strony rządowej. Mogą wprowadzać poprawki. To zwykle najdłuższy etap — tygodnie lub miesiące — tu zapada większość konkretnych decyzji o ostatecznym kształcie ustawy.",
+    branches: [
+      { kind: "forward", label: "Plenum (II czytanie)", detail: "Komisja przedstawia sprawozdanie z poprawkami." },
+      { kind: "terminal", label: "Wycofanie", detail: "Wnioskodawcy mogą wycofać projekt." },
+    ],
+  },
+  {
+    step: 4,
+    key: "plenum",
+    label: "Plenum",
+    blurb: "II i III czytanie na sali Sejmu.",
+    detail:
+      "Wszyscy posłowie debatują nad projektem na sali plenarnej. Każdy klub przedstawia stanowisko, można zgłaszać nowe poprawki. Po II czytaniu komisja często analizuje świeże poprawki przed III czytaniem — wtedy proces wraca chwilowo do etapu KOMISJA. To NORMALNE i nie oznacza, że projekt zawraca.",
+    branches: [
+      { kind: "forward", label: "Głosowanie", detail: "Po III czytaniu — finałowy głos." },
+      { kind: "back", label: "← Komisja", detail: "Jeśli pojawiły się nowe poprawki wymagające analizy." },
+    ],
+  },
+  {
+    step: 5,
+    key: "vote",
+    label: "Głosowanie",
+    blurb: "Posłowie głosują nad finałową wersją.",
+    detail:
+      "Wymagana jest zwykła większość — więcej głosów ZA niż PRZECIW, przy obecności co najmniej połowy posłów (kworum). Każdy klub poselski wcześniej ogłasza, jak będzie głosować, ale poszczególni posłowie mogą głosować inaczej.",
+    branches: [
+      { kind: "forward", label: "Senat", detail: "Ustawa idzie do izby wyższej." },
+      { kind: "terminal", label: "Odrzucenie", detail: "Za mało głosów ZA — proces się kończy." },
+    ],
+  },
+  {
+    step: 6,
+    key: "senate",
+    label: "Senat",
+    blurb: "30 dni na stanowisko izby wyższej.",
+    detail:
+      "Senat ma trzy opcje: przyjąć ustawę bez zmian (idzie do Prezydenta), wnieść poprawki (wraca do Sejmu) albo odrzucić w całości (wraca do Sejmu). Jeśli Senat milczy 30 dni — ustawa idzie dalej automatycznie.",
+    branches: [
+      { kind: "forward", label: "Prezydent", detail: "Bez poprawek lub po przyjęciu/odrzuceniu poprawek senackich." },
+      { kind: "back", label: "← Sejm głosuje znowu", detail: "Sejm bezwzględną większością może odrzucić senackie zmiany." },
+    ],
+  },
+  {
+    step: 7,
+    key: "president",
+    label: "Prezydent",
+    blurb: "21 dni na decyzję.",
+    detail:
+      "Prezydent ma trzy opcje: podpisać (ustawa po publikacji w Dzienniku Ustaw zaczyna obowiązywać), zawetować, albo skierować do Trybunału Konstytucyjnego do oceny zgodności z konstytucją.",
+    branches: [
+      { kind: "forward", label: "Dziennik Ustaw", detail: "Po podpisie — ustawa wchodzi w życie." },
+      { kind: "back", label: "← Sejm odrzuca weto", detail: "Większością 3/5 głosów Sejm może obalić weto Prezydenta." },
+      { kind: "terminal", label: "Trybunał Konstytucyjny", detail: "Prezydent może żądać sprawdzenia zgodności z konstytucją." },
+    ],
+  },
+];
+
+function BranchPill({ branch }: { branch: Branch }) {
+  const color =
+    branch.kind === "forward"
+      ? "var(--secondary-foreground)"
+      : branch.kind === "back"
+      ? "var(--destructive)"
+      : "var(--muted-foreground)";
+  const Icon =
+    branch.kind === "back" ? ArrowLeft : branch.kind === "terminal" ? X : ArrowRight;
+  return (
+    <div className="flex items-start gap-2">
+      <span
+        className="inline-flex items-center gap-1.5 font-mono uppercase tracking-[0.08em] shrink-0"
+        style={{ fontSize: 10, color, paddingTop: 2 }}
+      >
+        <Icon size={11} strokeWidth={2} />
+        {branch.label}
+      </span>
+      {branch.detail && (
+        <span className="font-sans text-[11.5px] text-muted-foreground leading-relaxed">
+          {branch.detail}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function ProcessStagesExplainer() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          aria-label="Jak działa proces legislacyjny — wyjaśnienie"
+          className="inline-flex items-center justify-center rounded-full text-muted-foreground hover:text-foreground transition-colors shrink-0"
+          style={{ width: 18, height: 18 }}
+        >
+          <HelpCircle size={14} strokeWidth={1.75} />
+        </button>
+      </DialogTrigger>
+
+      <DialogContent
+        className="max-w-[calc(100%-1.5rem)] sm:max-w-4xl max-h-[90vh] overflow-y-auto p-0"
+      >
+        <div className="px-6 pt-6 pb-4 border-b border-border sticky top-0 bg-popover z-10">
+          <DialogHeader>
+            <DialogTitle className="font-serif text-xl">
+              Jak powstaje ustawa w Sejmie
+            </DialogTitle>
+            <DialogDescription className="text-sm">
+              Siedem etapów, przez które przechodzi każdy projekt — od wpłynięcia
+              do podpisu Prezydenta. Pasek pokazuje, na którym etapie jest
+              konkretna ustawa.
+            </DialogDescription>
+          </DialogHeader>
+        </div>
+
+        <div className="px-6 pb-6">
+          <div
+            className="mt-4 mb-5 rounded-md border-l-2 px-3 py-2 text-[13px] leading-relaxed"
+            style={{ borderColor: "var(--destructive)", background: "var(--muted)" }}
+          >
+            <strong className="font-medium">Proces nie zawsze idzie do przodu.</strong>{" "}
+            Projekt może wrócić do komisji po poprawkach, Senat może zawrócić
+            ustawę, Sejm może odrzucić prezydenckie weto. Każde &quot;cofnięcie&quot; to
+            szansa na dopracowanie albo zatrzymanie ustawy — a nie porażka.
+          </div>
+
+          <ol className="list-none p-0 m-0 space-y-5">
+            {STAGES.map((stage) => (
+              <li
+                key={stage.key}
+                className="grid gap-6 pb-5 border-b border-border last:border-b-0 last:pb-0"
+                style={{ gridTemplateColumns: "auto 1fr 240px" }}
+              >
+                <div
+                  className="font-serif font-medium leading-none"
+                  style={{ color: "var(--destructive)", fontSize: 32, paddingTop: 2 }}
+                >
+                  {stage.step}
+                </div>
+
+                <div className="min-w-0">
+                  <h3
+                    className="font-serif font-medium m-0 mb-1 uppercase tracking-wide"
+                    style={{ fontSize: 13, letterSpacing: "0.08em" }}
+                  >
+                    {stage.label}
+                  </h3>
+                  <p className="font-sans text-[12.5px] text-muted-foreground m-0 mb-2 italic">
+                    {stage.blurb}
+                  </p>
+                  <p
+                    className="font-serif text-secondary-foreground m-0"
+                    style={{ fontSize: 14, lineHeight: 1.55, textWrap: "pretty" as never }}
+                  >
+                    {stage.detail}
+                  </p>
+                </div>
+
+                <div
+                  className="rounded-md p-3 self-start"
+                  style={{ background: "var(--muted)" }}
+                >
+                  <div
+                    className="font-mono uppercase tracking-[0.1em] text-muted-foreground mb-2"
+                    style={{ fontSize: 9.5 }}
+                  >
+                    Co dalej
+                  </div>
+                  <div className="space-y-2">
+                    {stage.branches.map((b, i) => (
+                      <BranchPill key={i} branch={b} />
+                    ))}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ol>
+
+          <div
+            className="mt-5 flex flex-wrap gap-3 text-[11px] text-muted-foreground font-sans"
+            style={{ borderTop: "1px solid var(--border)", paddingTop: 12 }}
+          >
+            <span className="inline-flex items-center gap-1">
+              <ArrowRight size={11} style={{ color: "var(--secondary-foreground)" }} />
+              dalej w procesie
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <ArrowLeft size={11} style={{ color: "var(--destructive)" }} />
+              wraca do wcześniejszego etapu
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <X size={11} />
+              proces się kończy
+            </span>
+            <span className="ml-auto">
+              Źródło:{" "}
+              <a
+                href="https://www.sejm.gov.pl/Sejm10.nsf/proces.xsp"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2"
+              >
+                procedura legislacyjna Sejmu RP
+              </a>
+            </span>
+          </div>
+        </div>
+
+        <DialogClose className="sr-only">Zamknij</DialogClose>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/components/tygodnik/atoms/ProcessStagesExplainer.tsx
+++ b/frontend/components/tygodnik/atoms/ProcessStagesExplainer.tsx
@@ -1,6 +1,22 @@
 "use client";
 
-import { ArrowRight, ArrowLeft, HelpCircle, X } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Crown,
+  FileSearch,
+  FileSignature,
+  HelpCircle,
+  Info,
+  Landmark,
+  Megaphone,
+  PenTool,
+  ScrollText,
+  Users,
+  Vote,
+  X,
+  type LucideIcon,
+} from "lucide-react";
 import {
   Dialog,
   DialogClose,
@@ -11,16 +27,19 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 
-// Citizen-facing explainer of the 7-step legislative pipeline rendered by
-// ProcessStageBar. Triggered by a "?" affordance next to the bar.
+// Citizen-facing explainer of the legislative pipeline. Triggered by a "?"
+// affordance on ProcessStageBar.
 //
-// Two design choices driven by citizen review:
-//   1. Plain Polish, no jargon ("subsydiarność", "tryb pilny" out).
-//   2. Each step shows BRANCH OPTIONS, not just the happy path. The bar
-//      can move backwards (committee revisits after II czytanie; Sejm
-//      re-votes after Senate amendments; Sejm overrides presidential
-//      veto with 3/5 majority). Without branches the bar reads as
-//      one-way which is misleading.
+// Layout (mirrors the citizen mockup):
+//   [num + icon column] | [text column] | ["Co dalej" column]
+//   Vertical timeline line connects the numbered bullets on the left.
+//
+// Stage list goes deeper than ProcessStageBar's 7 buckets — readers
+// asked about "I czytanie vs II czytanie vs III czytanie", which the bar
+// collapses (Reading + ReadingReferral → first_reading; SejmReading →
+// plenum). The explainer therefore shows ALL substantive procedural
+// moments. Each row maps to a bar bucket via `bucket` (rendered as a
+// subtle tag) so readers can connect the explainer back to the bar.
 
 type Branch = {
   kind: "forward" | "back" | "terminal";
@@ -28,34 +47,38 @@ type Branch = {
   detail?: string;
 };
 
-type StageExplainer = {
+type StageRow = {
   step: number;
   key: string;
   label: string;
+  bucket: string;
   blurb: string;
   detail: string;
+  icon: LucideIcon;
   branches: Branch[];
 };
 
-const STAGES: StageExplainer[] = [
+const ROWS: StageRow[] = [
   {
     step: 1,
     key: "intake",
     label: "Wpłynęło",
+    bucket: "WPŁYNĘŁO",
     blurb: "Projekt trafia do Sejmu.",
     detail:
-      "Ustawę może zgłosić rząd, posłowie (klub poselski lub grupa 15 posłów), Senat, Prezydent, komisja sejmowa albo 100 tysięcy obywateli przez inicjatywę obywatelską. To początek — nic jeszcze nie zostało zdecydowane, projekt czeka na pierwsze omówienie.",
-    branches: [
-      { kind: "forward", label: "I czytanie", detail: "Zawsze następny krok." },
-    ],
+      "Ustawę może zgłosić rząd, posłowie (klub poselski lub grupa co najmniej 15 posłów), Senat, Prezydent, komisja sejmowa albo 100 tysięcy obywateli przez inicjatywę obywatelską. To początek — projekt zostaje zarejestrowany i czeka na pierwsze omówienie.",
+    icon: ScrollText,
+    branches: [{ kind: "forward", label: "I czytanie", detail: "Zawsze następny krok." }],
   },
   {
     step: 2,
     key: "first_reading",
     label: "I czytanie",
+    bucket: "I CZYTANIE",
     blurb: "Pierwsze formalne omówienie.",
     detail:
-      "Marszałek Sejmu kieruje projekt albo bezpośrednio na salę plenarną (cały Sejm), albo do komisji branżowej — zależnie od wagi tematu. Autorzy przedstawiają cele, posłowie zapoznają się z treścią.",
+      "Marszałek Sejmu decyduje, gdzie trafi projekt: na salę plenarną (cały Sejm — dla najważniejszych spraw jak budżet czy zmiany konstytucji) albo bezpośrednio do komisji branżowej. Autorzy przedstawiają cele projektu, posłowie zadają pierwsze pytania.",
+    icon: Megaphone,
     branches: [
       { kind: "forward", label: "Komisja", detail: "Standardowa droga — szczegółowa analiza." },
       { kind: "terminal", label: "Odrzucenie", detail: "Sejm może odrzucić projekt już na tym etapie." },
@@ -63,64 +86,124 @@ const STAGES: StageExplainer[] = [
   },
   {
     step: 3,
-    key: "committee",
-    label: "Komisja",
+    key: "committee_work",
+    label: "Praca w komisji",
+    bucket: "KOMISJA",
     blurb: "Branżowi eksperci analizują szczegóły.",
     detail:
-      "Komisje sejmowe (np. zdrowia, finansów, kultury) czytają projekt linijka po linijce, słuchają opinii ekspertów, organizacji społecznych i strony rządowej. Mogą wprowadzać poprawki. To zwykle najdłuższy etap — tygodnie lub miesiące — tu zapada większość konkretnych decyzji o ostatecznym kształcie ustawy.",
+      "Komisje sejmowe (np. zdrowia, finansów, kultury, sprawiedliwości) czytają projekt linijka po linijce, słuchają opinii ekspertów, organizacji społecznych, strony rządowej. Mogą wprowadzać poprawki. To zwykle najdłuższy etap — tygodnie albo miesiące. Tu zapada większość konkretnych decyzji o ostatecznym kształcie ustawy.",
+    icon: FileSearch,
     branches: [
-      { kind: "forward", label: "Plenum (II czytanie)", detail: "Komisja przedstawia sprawozdanie z poprawkami." },
+      { kind: "forward", label: "Sprawozdanie komisji", detail: "Komisja kończy pracę i przedstawia stanowisko Sejmowi." },
       { kind: "terminal", label: "Wycofanie", detail: "Wnioskodawcy mogą wycofać projekt." },
     ],
   },
   {
     step: 4,
-    key: "plenum",
-    label: "Plenum",
-    blurb: "II i III czytanie na sali Sejmu.",
+    key: "committee_report",
+    label: "Sprawozdanie komisji",
+    bucket: "KOMISJA",
+    blurb: "Komisja przedstawia stanowisko.",
     detail:
-      "Wszyscy posłowie debatują nad projektem na sali plenarnej. Każdy klub przedstawia stanowisko, można zgłaszać nowe poprawki. Po II czytaniu komisja często analizuje świeże poprawki przed III czytaniem — wtedy proces wraca chwilowo do etapu KOMISJA. To NORMALNE i nie oznacza, że projekt zawraca.",
+      "Komisja głosuje nad treścią projektu i przekazuje sprawozdanie Sejmowi. W sprawozdaniu wskazuje wszystkie wprowadzone poprawki oraz proponowane stanowisko: za przyjęciem, za odrzuceniem albo z dodatkowymi zmianami. Zazwyczaj wyznaczany jest poseł-sprawozdawca, który przedstawi raport na sali.",
+    icon: FileSignature,
     branches: [
-      { kind: "forward", label: "Głosowanie", detail: "Po III czytaniu — finałowy głos." },
-      { kind: "back", label: "← Komisja", detail: "Jeśli pojawiły się nowe poprawki wymagające analizy." },
+      { kind: "forward", label: "II czytanie", detail: "Plenum debatuje nad sprawozdaniem komisji." },
     ],
   },
   {
     step: 5,
-    key: "vote",
-    label: "Głosowanie",
-    blurb: "Posłowie głosują nad finałową wersją.",
+    key: "second_reading",
+    label: "II czytanie",
+    bucket: "PLENUM",
+    blurb: "Debata plenarna nad sprawozdaniem.",
     detail:
-      "Wymagana jest zwykła większość — więcej głosów ZA niż PRZECIW, przy obecności co najmniej połowy posłów (kworum). Każdy klub poselski wcześniej ogłasza, jak będzie głosować, ale poszczególni posłowie mogą głosować inaczej.",
+      "Wszyscy posłowie debatują nad projektem w wersji proponowanej przez komisję. Każdy klub przedstawia stanowisko, można zgłaszać nowe poprawki. Jeśli pojawią się świeże poprawki, projekt zazwyczaj wraca do komisji — to NORMALNE, a nie cofanie procesu.",
+    icon: Users,
     branches: [
-      { kind: "forward", label: "Senat", detail: "Ustawa idzie do izby wyższej." },
-      { kind: "terminal", label: "Odrzucenie", detail: "Za mało głosów ZA — proces się kończy." },
+      { kind: "forward", label: "III czytanie", detail: "Jeśli nie ma nowych poprawek do analizy." },
+      { kind: "back", label: "Komisja (poprawki)", detail: "Komisja analizuje świeże poprawki z plenum." },
     ],
   },
   {
     step: 6,
-    key: "senate",
-    label: "Senat",
-    blurb: "30 dni na stanowisko izby wyższej.",
+    key: "third_reading",
+    label: "III czytanie",
+    bucket: "PLENUM",
+    blurb: "Finałowa debata i głosowania nad poprawkami.",
     detail:
-      "Senat ma trzy opcje: przyjąć ustawę bez zmian (idzie do Prezydenta), wnieść poprawki (wraca do Sejmu) albo odrzucić w całości (wraca do Sejmu). Jeśli Senat milczy 30 dni — ustawa idzie dalej automatycznie.",
+      "Posłowie głosują nad pojedynczymi poprawkami (przyjąć / odrzucić), a potem nad CAŁOŚCIĄ ustawy. Sprawozdawca komisji może rekomendować, jak głosować. To moment, w którym ustala się ostateczna treść projektu — każda poprawka albo wchodzi, albo wypada.",
+    icon: Vote,
     branches: [
-      { kind: "forward", label: "Prezydent", detail: "Bez poprawek lub po przyjęciu/odrzuceniu poprawek senackich." },
-      { kind: "back", label: "← Sejm głosuje znowu", detail: "Sejm bezwzględną większością może odrzucić senackie zmiany." },
+      { kind: "forward", label: "Głosowanie nad całością", detail: "Po przegłosowaniu poprawek." },
     ],
   },
   {
     step: 7,
+    key: "final_vote",
+    label: "Głosowanie nad ustawą",
+    bucket: "GŁOSOWANIE",
+    blurb: "Finałowy głos w Sejmie.",
+    detail:
+      "Posłowie głosują nad PEŁNĄ wersją projektu po poprawkach. Wymagana zwykła większość — więcej głosów ZA niż PRZECIW, przy obecności co najmniej połowy posłów (kworum 230). Wynik głosowania jest publikowany imiennie — można sprawdzić, jak głosował każdy poseł.",
+    icon: Vote,
+    branches: [
+      { kind: "forward", label: "Senat", detail: "Ustawa idzie do izby wyższej w 3 dni." },
+      { kind: "terminal", label: "Odrzucenie", detail: "Za mało głosów ZA — proces się kończy." },
+    ],
+  },
+  {
+    step: 8,
+    key: "senate",
+    label: "Senat",
+    bucket: "SENAT",
+    blurb: "30 dni na stanowisko izby wyższej.",
+    detail:
+      "Senat ma trzy opcje: przyjąć ustawę bez zmian (idzie prosto do Prezydenta), wnieść poprawki (wraca do Sejmu), albo odrzucić w całości (wraca do Sejmu). Jeśli Senat milczy 30 dni — ustawa idzie dalej automatycznie. Budżet i pilne ustawy mają skrócone terminy.",
+    icon: Landmark,
+    branches: [
+      { kind: "forward", label: "Prezydent", detail: "Bez zmian albo po rozpatrzeniu poprawek senackich." },
+      { kind: "back", label: "Sejm głosuje znowu", detail: "Sejm bezwzględną większością może odrzucić senackie zmiany." },
+    ],
+  },
+  {
+    step: 9,
+    key: "senate_consideration",
+    label: "Rozpatrzenie poprawek Senatu",
+    bucket: "SENAT",
+    blurb: "Sejm reaguje na zmiany izby wyższej.",
+    detail:
+      "Jeśli Senat zgłosił poprawki lub odrzucił ustawę w całości, Sejm głosuje nad każdą poprawką osobno. Aby ODRZUCIĆ stanowisko Senatu, trzeba bezwzględnej większości (50% + 1 obecnych). Jeśli Sejm nie odrzuci — stanowisko Senatu wchodzi do ustawy.",
+    icon: Users,
+    branches: [
+      { kind: "forward", label: "Prezydent", detail: "Po rozstrzygnięciu wszystkich poprawek." },
+    ],
+  },
+  {
+    step: 10,
     key: "president",
     label: "Prezydent",
-    blurb: "21 dni na decyzję.",
+    bucket: "PREZYDENT",
+    blurb: "21 dni na decyzję głowy państwa.",
     detail:
-      "Prezydent ma trzy opcje: podpisać (ustawa po publikacji w Dzienniku Ustaw zaczyna obowiązywać), zawetować, albo skierować do Trybunału Konstytucyjnego do oceny zgodności z konstytucją.",
+      "Prezydent ma trzy opcje: PODPISAĆ (ustawa po publikacji w Dzienniku Ustaw zaczyna obowiązywać), ZAWETOWAĆ (Sejm może obalić weto większością 3/5 głosów przy obecności co najmniej połowy posłów), albo SKIEROWAĆ DO TRYBUNAŁU KONSTYTUCYJNEGO do oceny zgodności z konstytucją.",
+    icon: PenTool,
     branches: [
-      { kind: "forward", label: "Dziennik Ustaw", detail: "Po podpisie — ustawa wchodzi w życie." },
-      { kind: "back", label: "← Sejm odrzuca weto", detail: "Większością 3/5 głosów Sejm może obalić weto Prezydenta." },
-      { kind: "terminal", label: "Trybunał Konstytucyjny", detail: "Prezydent może żądać sprawdzenia zgodności z konstytucją." },
+      { kind: "forward", label: "Dziennik Ustaw", detail: "Po podpisie ustawa wchodzi w życie." },
+      { kind: "back", label: "Sejm obala weto", detail: "Większością 3/5 głosów Sejm odrzuca weto Prezydenta." },
+      { kind: "terminal", label: "Trybunał Konstytucyjny", detail: "Prezydent kieruje ustawę do oceny zgodności z konstytucją." },
     ],
+  },
+  {
+    step: 11,
+    key: "promulgation",
+    label: "Publikacja w Dz.U.",
+    bucket: "PREZYDENT",
+    blurb: "Ustawa wchodzi w życie.",
+    detail:
+      "Po podpisie Prezydenta ustawa jest publikowana w Dzienniku Ustaw RP. Tekst zawiera datę wejścia w życie — często to 14 dni od publikacji (tzw. vacatio legis), ale ustawa może określać własny termin. Od tego momentu ustawa obowiązuje wszystkich.",
+    icon: Crown,
+    branches: [],
   },
 ];
 
@@ -131,22 +214,57 @@ function BranchPill({ branch }: { branch: Branch }) {
       : branch.kind === "back"
       ? "var(--destructive)"
       : "var(--muted-foreground)";
-  const Icon =
-    branch.kind === "back" ? ArrowLeft : branch.kind === "terminal" ? X : ArrowRight;
+  const Icon = branch.kind === "back" ? ArrowLeft : branch.kind === "terminal" ? X : ArrowRight;
   return (
-    <div className="flex items-start gap-2">
-      <span
-        className="inline-flex items-center gap-1.5 font-mono uppercase tracking-[0.08em] shrink-0"
-        style={{ fontSize: 10, color, paddingTop: 2 }}
-      >
-        <Icon size={11} strokeWidth={2} />
-        {branch.label}
-      </span>
-      {branch.detail && (
-        <span className="font-sans text-[11.5px] text-muted-foreground leading-relaxed">
-          {branch.detail}
-        </span>
-      )}
+    <div className="flex items-start gap-2 mb-2 last:mb-0">
+      <Icon size={11} strokeWidth={2.5} style={{ color, marginTop: 4, flexShrink: 0 }} />
+      <div className="flex-1 min-w-0">
+        <div
+          className="font-mono uppercase tracking-[0.08em]"
+          style={{ fontSize: 10.5, color, fontWeight: 600, marginBottom: 1 }}
+        >
+          {branch.label}
+        </div>
+        {branch.detail && (
+          <div className="font-sans text-[11px] text-muted-foreground leading-snug">
+            {branch.detail}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StageIcon({ Icon }: { Icon: LucideIcon }) {
+  return (
+    <div
+      className="flex items-center justify-center rounded-full shrink-0"
+      style={{
+        width: 72,
+        height: 72,
+        background: "var(--muted)",
+        color: "var(--secondary-foreground)",
+      }}
+    >
+      <Icon size={32} strokeWidth={1.5} />
+    </div>
+  );
+}
+
+function StepBadge({ n }: { n: number }) {
+  return (
+    <div
+      className="flex items-center justify-center rounded-full shrink-0 font-mono font-medium"
+      style={{
+        width: 28,
+        height: 28,
+        background: "var(--destructive)",
+        color: "white",
+        fontSize: 12,
+      }}
+      aria-hidden
+    >
+      {n}
     </div>
   );
 }
@@ -165,100 +283,160 @@ export function ProcessStagesExplainer() {
         </button>
       </DialogTrigger>
 
-      <DialogContent
-        className="max-w-[calc(100%-1.5rem)] sm:max-w-4xl max-h-[90vh] overflow-y-auto p-0"
-      >
-        <div className="px-6 pt-6 pb-4 border-b border-border sticky top-0 bg-popover z-10">
-          <DialogHeader>
-            <DialogTitle className="font-serif text-xl">
+      <DialogContent className="max-w-[calc(100%-1rem)] sm:max-w-5xl max-h-[92vh] overflow-y-auto p-0">
+        <div className="px-8 pt-8 pb-5 text-center border-b border-border">
+          <DialogHeader className="items-center">
+            <DialogTitle
+              className="font-serif font-medium"
+              style={{ fontSize: 32, letterSpacing: "-0.02em", lineHeight: 1.1 }}
+            >
               Jak powstaje ustawa w Sejmie
             </DialogTitle>
-            <DialogDescription className="text-sm">
-              Siedem etapów, przez które przechodzi każdy projekt — od wpłynięcia
-              do podpisu Prezydenta. Pasek pokazuje, na którym etapie jest
-              konkretna ustawa.
+            <DialogDescription
+              className="text-sm max-w-2xl mx-auto mt-2"
+              style={{ lineHeight: 1.55 }}
+            >
+              Jedenaście etapów, przez które przechodzi każdy projekt — od
+              wpłynięcia do publikacji w Dzienniku Ustaw. Pasek nad ustawą
+              pokazuje, na którym etapie jest konkretna sprawa.
             </DialogDescription>
           </DialogHeader>
         </div>
 
-        <div className="px-6 pb-6">
+        <div className="px-8 py-6">
           <div
-            className="mt-4 mb-5 rounded-md border-l-2 px-3 py-2 text-[13px] leading-relaxed"
-            style={{ borderColor: "var(--destructive)", background: "var(--muted)" }}
+            className="rounded-md flex items-start gap-3 p-4 mb-6"
+            style={{ background: "var(--muted)" }}
           >
-            <strong className="font-medium">Proces nie zawsze idzie do przodu.</strong>{" "}
-            Projekt może wrócić do komisji po poprawkach, Senat może zawrócić
-            ustawę, Sejm może odrzucić prezydenckie weto. Każde &quot;cofnięcie&quot; to
-            szansa na dopracowanie albo zatrzymanie ustawy — a nie porażka.
+            <div
+              className="rounded-full flex items-center justify-center shrink-0"
+              style={{ width: 36, height: 36, background: "var(--destructive)" }}
+            >
+              <Info size={18} color="white" strokeWidth={2} />
+            </div>
+            <div className="text-[13.5px] leading-relaxed pt-1">
+              <strong className="font-medium">Proces nie zawsze idzie do przodu.</strong>{" "}
+              Projekt może wrócić do komisji po poprawkach, Senat może zawrócić
+              ustawę, Sejm może odrzucić prezydenckie weto. Każde &quot;cofnięcie&quot;
+              to szansa na dopracowanie albo zatrzymanie ustawy — a nie porażka.
+            </div>
           </div>
 
-          <ol className="list-none p-0 m-0 space-y-5">
-            {STAGES.map((stage) => (
-              <li
-                key={stage.key}
-                className="grid gap-6 pb-5 border-b border-border last:border-b-0 last:pb-0"
-                style={{ gridTemplateColumns: "auto 1fr 240px" }}
-              >
-                <div
-                  className="font-serif font-medium leading-none"
-                  style={{ color: "var(--destructive)", fontSize: 32, paddingTop: 2 }}
-                >
-                  {stage.step}
-                </div>
+          <ol
+            className="list-none p-0 m-0 relative"
+            style={
+              {
+                // Vertical timeline line connecting step badges. Positioned
+                // to align with the centre of the step circles (left padding
+                // + half circle width = 14px from list-item left edge).
+                "--timeline-x": "14px",
+              } as React.CSSProperties
+            }
+          >
+            <div
+              aria-hidden
+              className="absolute top-0 bottom-0"
+              style={{
+                left: "var(--timeline-x)",
+                width: 1,
+                background: "var(--border)",
+              }}
+            />
 
-                <div className="min-w-0">
-                  <h3
-                    className="font-serif font-medium m-0 mb-1 uppercase tracking-wide"
-                    style={{ fontSize: 13, letterSpacing: "0.08em" }}
-                  >
-                    {stage.label}
-                  </h3>
-                  <p className="font-sans text-[12.5px] text-muted-foreground m-0 mb-2 italic">
-                    {stage.blurb}
-                  </p>
-                  <p
-                    className="font-serif text-secondary-foreground m-0"
-                    style={{ fontSize: 14, lineHeight: 1.55, textWrap: "pretty" as never }}
-                  >
-                    {stage.detail}
-                  </p>
-                </div>
-
-                <div
-                  className="rounded-md p-3 self-start"
-                  style={{ background: "var(--muted)" }}
+            {ROWS.map((row, idx) => {
+              const Icon = row.icon;
+              const isLast = idx === ROWS.length - 1;
+              return (
+                <li
+                  key={row.key}
+                  className="relative grid gap-5 pl-0 pr-0 mb-6 last:mb-0"
+                  style={{
+                    gridTemplateColumns: "28px 88px 1fr 260px",
+                    alignItems: "start",
+                  }}
                 >
-                  <div
-                    className="font-mono uppercase tracking-[0.1em] text-muted-foreground mb-2"
-                    style={{ fontSize: 9.5 }}
-                  >
-                    Co dalej
+                  <div className="flex items-center justify-center" style={{ zIndex: 1 }}>
+                    <StepBadge n={row.step} />
                   </div>
-                  <div className="space-y-2">
-                    {stage.branches.map((b, i) => (
-                      <BranchPill key={i} branch={b} />
-                    ))}
+
+                  <StageIcon Icon={Icon} />
+
+                  <div className="min-w-0">
+                    <div className="flex items-baseline gap-2 mb-1 flex-wrap">
+                      <h3
+                        className="font-serif font-medium m-0"
+                        style={{ fontSize: 19, letterSpacing: "-0.005em" }}
+                      >
+                        {row.label}
+                      </h3>
+                      <span
+                        className="font-mono uppercase tracking-[0.1em] text-muted-foreground"
+                        style={{ fontSize: 9.5 }}
+                      >
+                        pasek: {row.bucket}
+                      </span>
+                    </div>
+                    <p className="font-sans text-[13px] text-muted-foreground italic m-0 mb-2">
+                      {row.blurb}
+                    </p>
+                    <p
+                      className="font-serif text-secondary-foreground m-0"
+                      style={{
+                        fontSize: 14,
+                        lineHeight: 1.6,
+                        textWrap: "pretty" as never,
+                      }}
+                    >
+                      {row.detail}
+                    </p>
                   </div>
-                </div>
-              </li>
-            ))}
+
+                  {row.branches.length > 0 ? (
+                    <div
+                      className="rounded-md p-4 self-start"
+                      style={{ background: "var(--muted)" }}
+                    >
+                      <div
+                        className="font-mono uppercase tracking-[0.12em] text-muted-foreground mb-3"
+                        style={{ fontSize: 10, fontWeight: 600 }}
+                      >
+                        Co dalej
+                      </div>
+                      {row.branches.map((b, i) => (
+                        <BranchPill key={i} branch={b} />
+                      ))}
+                    </div>
+                  ) : (
+                    <div
+                      className="rounded-md p-4 self-start text-[12px] italic text-muted-foreground"
+                      style={{ background: "var(--muted)" }}
+                    >
+                      Koniec drogi ustawy — od tej chwili obowiązuje.
+                    </div>
+                  )}
+                </li>
+              );
+            })}
           </ol>
 
           <div
-            className="mt-5 flex flex-wrap gap-3 text-[11px] text-muted-foreground font-sans"
-            style={{ borderTop: "1px solid var(--border)", paddingTop: 12 }}
+            className="mt-8 pt-5 flex flex-wrap items-center gap-x-5 gap-y-2 text-[11.5px] text-muted-foreground font-sans"
+            style={{ borderTop: "1px solid var(--border)" }}
           >
-            <span className="inline-flex items-center gap-1">
-              <ArrowRight size={11} style={{ color: "var(--secondary-foreground)" }} />
-              dalej w procesie
+            <span className="font-mono uppercase tracking-[0.12em]" style={{ fontSize: 10 }}>
+              Legenda
             </span>
-            <span className="inline-flex items-center gap-1">
-              <ArrowLeft size={11} style={{ color: "var(--destructive)" }} />
-              wraca do wcześniejszego etapu
+            <span className="inline-flex items-center gap-1.5">
+              <ArrowRight size={12} style={{ color: "var(--secondary-foreground)" }} />
+              następny krok
             </span>
-            <span className="inline-flex items-center gap-1">
-              <X size={11} />
-              proces się kończy
+            <span className="inline-flex items-center gap-1.5">
+              <ArrowLeft size={12} style={{ color: "var(--destructive)" }} />
+              możliwość cofnięcia
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <X size={12} />
+              możliwe zakończenie procesu
             </span>
             <span className="ml-auto">
               Źródło:{" "}
@@ -266,7 +444,7 @@ export function ProcessStagesExplainer() {
                 href="https://www.sejm.gov.pl/Sejm10.nsf/proces.xsp"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="underline underline-offset-2"
+                className="underline underline-offset-2 hover:text-foreground"
               >
                 procedura legislacyjna Sejmu RP
               </a>

--- a/supabase/migrations/0093_print_sponsor_party_breakdown.sql
+++ b/supabase/migrations/0093_print_sponsor_party_breakdown.sql
@@ -1,0 +1,18 @@
+-- 0093_print_sponsor_party_breakdown.sql
+-- Add `sponsor_party_breakdown` to prints: for "Poselski projekt" druki,
+-- jsonb {club_ref: count} aggregating sponsor_mps[] over mps.club_ref.
+--
+-- Why a denormalized column instead of a runtime join: sponsor_mps is a
+-- jsonb array of name strings (no FK), and the join requires per-print
+-- iteration. Computing once on backfill / per-enrichment and caching
+-- means the frontend renders the chip from one column read.
+--
+-- Why nullable: only "Poselski projekt" druki have sponsors (mps); for
+-- rzad/senat/obywatele the field stays NULL. Frontend treats NULL as
+-- "no breakdown to show" (just sponsor_authority label).
+
+alter table prints
+  add column if not exists sponsor_party_breakdown jsonb;
+
+comment on column prints.sponsor_party_breakdown is
+  'For Poselski projekt: {club_ref: count} over sponsor_mps. NULL otherwise.';

--- a/supagraf/cli.py
+++ b/supagraf/cli.py
@@ -461,6 +461,109 @@ def cmd_backfill_processes(
     logger.info("backfill-processes: done")
 
 
+@app.command("backfill-sponsor-authority")
+def cmd_backfill_sponsor_authority(
+    term: int = typer.Option(10, "--term", "-t"),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+):
+    """Derive `prints.sponsor_authority` from `prints.title`.
+
+    Sejm prints encode the sponsor in the title prefix:
+      "Rządowy projekt ustawy…"      → rzad
+      "Poselski projekt ustawy…"     → klub_poselski
+      "Senacki projekt ustawy…"      → senat
+      "Obywatelski projekt ustawy…"  → obywatele
+      "Prezydencki projekt ustawy…"  → prezydent
+      "Komisyjny projekt ustawy…"    → komisja
+      "Przedstawiony przez Prezydium Sejmu…" → prezydium
+
+    Deterministic — no LLM. Idempotent; only updates rows with NULL
+    sponsor_authority (skips already-set values, incl. the rare 'inne'
+    overrides written by `print_unified` for sub-prints with opinion_source).
+
+    Sub-prints (e.g. "Do druku nr 1650 - ocena skutków regulacji") inherit
+    parent sponsor_authority via processPrint; for now we skip them
+    (`print_unified.py` collapses them to 'inne' when opinion_source is
+    set, which is the correct behavior for meta-documents anyway).
+    """
+    import re
+    client = supabase()
+
+    # Title prefix → authority. Order matters: "Przedstawiony przez Prezydium"
+    # must be checked before generic catch-alls. All matches are case-
+    # sensitive on the first capitalized word (Sejm titles are stable).
+    PATTERNS: list[tuple[re.Pattern[str], str]] = [
+        (re.compile(r"^Rządowy\s+projekt"), "rzad"),
+        (re.compile(r"^Poselski\s+projekt"), "klub_poselski"),
+        (re.compile(r"^Senacki\s+projekt"), "senat"),
+        (re.compile(r"^Obywatelski\s+projekt"), "obywatele"),
+        (re.compile(r"^Prezydencki\s+projekt"), "prezydent"),
+        (re.compile(r"^Komisyjny\s+projekt"), "komisja"),
+        (re.compile(r"^Przedstawion[ya]\s+przez\s+Prezydium"), "prezydium"),
+    ]
+
+    # Pull all NULL-sponsor prints for the term, paginate (>4k rows).
+    rows: list[dict] = []
+    offset = 0
+    page = 1000
+    while True:
+        chunk = (
+            client.table("prints")
+            .select("id, term, number, title")
+            .eq("term", term)
+            .is_("sponsor_authority", "null")
+            .order("id")
+            .range(offset, offset + page - 1)
+            .execute()
+            .data or []
+        )
+        if not chunk:
+            break
+        rows.extend(chunk)
+        if len(chunk) < page:
+            break
+        offset += len(chunk)
+    logger.info("backfill-sponsor-authority: {} prints with NULL sponsor_authority", len(rows))
+
+    matches: dict[str, list[int]] = {}
+    unmatched: list[tuple[str, str]] = []
+    for r in rows:
+        t = r.get("title") or ""
+        authority: str | None = None
+        for pat, val in PATTERNS:
+            if pat.match(t):
+                authority = val
+                break
+        if authority:
+            matches.setdefault(authority, []).append(r["id"])
+        else:
+            unmatched.append((r["number"], t[:60]))
+
+    logger.info(
+        "backfill-sponsor-authority: matched {} prints across {} buckets, {} unmatched (sub-prints + meta-docs)",
+        sum(len(v) for v in matches.values()), len(matches), len(unmatched),
+    )
+    for auth, ids in matches.items():
+        logger.info("  {}: {} prints", auth, len(ids))
+    if unmatched[:5]:
+        logger.info("  unmatched sample: {}", unmatched[:5])
+
+    if dry_run:
+        logger.info("backfill-sponsor-authority: --dry-run, no writes")
+        return
+
+    # Batch update by authority. PostgREST has no SQL UPDATE WHERE id IN —
+    # we use the in_ filter via the supabase client; updates 1000 ids per call.
+    batch = 500
+    written = 0
+    for authority, ids in matches.items():
+        for i in range(0, len(ids), batch):
+            chunk = ids[i:i + batch]
+            client.table("prints").update({"sponsor_authority": authority}).in_("id", chunk).execute()
+            written += len(chunk)
+    logger.info("backfill-sponsor-authority: wrote {} updates", written)
+
+
 def _run_direct_stage_captures(*, term: int, direct_staged: set[str]) -> None:
     """Run the bulk Sejm captures with StreamingStager callbacks attached.
 


### PR DESCRIPTION
## Summary

- Nowa wersja dialogu `ProcessStagesExplainer` w stylu infografiki:
  - **Numer** w czerwonym kółku → **ikona** w szarym dużym kółku → **opis** → **"Co dalej"** w jasnym boxie
  - Vertical timeline line łącząca numery wzdłuż lewej krawędzi
  - Tytuł serif-large + centered header
  - Info callout z czerwonym "i" tłumaczący że backward arrows ≠ porażka
- **11 etapów** zamiast 7 (pasek nadal jest 7-bucket — ale dialog wymienia każdy procedurialny moment):
  1. Wpłynęło
  2. I czytanie
  3. Praca w komisji
  4. Sprawozdanie komisji
  5. **II czytanie** ← brakowało wcześniej
  6. **III czytanie** ← brakowało wcześniej
  7. Głosowanie nad ustawą
  8. Senat
  9. Rozpatrzenie poprawek Senatu
  10. Prezydent
  11. Publikacja w Dz.U.
- Każdy etap ma tag `PASEK: <BUCKET>` żeby reader widział, w którym z 7 bucketów paska timeline'a ten etap się mieści.

## Branże/derivacje pokazane explicit

| Etap | Forward → | Back ← | Terminal × |
|---|---|---|---|
| I czytanie | Komisja | — | Odrzucenie |
| II czytanie | III czytanie | Komisja (poprawki) | — |
| Głosowanie | Senat | — | Odrzucenie |
| Senat | Prezydent | Sejm głosuje znowu | — |
| Prezydent | Dz.U. | Sejm obala weto | Trybunał Konstytucyjny |

## Test plan

- [x] Type check passes (`pnpm tsc --noEmit`)
- [x] Dialog renderuje na `/tygodnik`, kliknięcie `?` obok paska otwiera explainer
- [x] Wszystkie 11 etapów + branche widoczne, vertical timeline line ciągnie się przez wszystkie numery
- [ ] Mobile/tablet — wąski viewport (TODO przy review)

https://claude.ai/code/session_01QoTgxhBepPoffhyjvpZhhH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoTgxhBepPoffhyjvpZhhH)_