### PR TITLE
fix(explainer): legal corrections + per-row source citations + bold

### DIFF
--- a/frontend/components/tygodnik/atoms/ProcessStagesExplainer.tsx
+++ b/frontend/components/tygodnik/atoms/ProcessStagesExplainer.tsx
@@ -52,7 +52,6 @@ type Branch = {
 };
 
 type StageRow = {
-  step: number;
   key: string;
   label: string;
   bucket: string;
@@ -65,7 +64,6 @@ type StageRow = {
 
 const ROWS: StageRow[] = [
   {
-    step: 1,
     key: "intake",
     label: "Wpłynęło",
     bucket: "WPŁYNĘŁO",
@@ -86,7 +84,6 @@ const ROWS: StageRow[] = [
     sources: ["Art. 118 Konstytucji RP", "Art. 32 ust. 2 Regulaminu Sejmu"],
   },
   {
-    step: 2,
     key: "first_reading",
     label: "I czytanie",
     bucket: "I CZYTANIE",
@@ -112,7 +109,6 @@ const ROWS: StageRow[] = [
     sources: ["Art. 37 ust. 2 i 4 Regulaminu Sejmu", "Art. 39 Regulaminu Sejmu"],
   },
   {
-    step: 3,
     key: "committee_work",
     label: "Praca w komisji",
     bucket: "KOMISJA",
@@ -135,7 +131,6 @@ const ROWS: StageRow[] = [
     sources: ["Art. 41-46 Regulaminu Sejmu", "Art. 119 ust. 4 Konstytucji RP"],
   },
   {
-    step: 4,
     key: "committee_report",
     label: "Sprawozdanie komisji",
     bucket: "KOMISJA",
@@ -156,7 +151,6 @@ const ROWS: StageRow[] = [
     sources: ["Art. 43 Regulaminu Sejmu"],
   },
   {
-    step: 5,
     key: "second_reading",
     label: "II czytanie",
     bucket: "PLENUM",
@@ -182,7 +176,6 @@ const ROWS: StageRow[] = [
     sources: ["Art. 44 i 47 Regulaminu Sejmu", "Art. 119 ust. 4 Konstytucji RP"],
   },
   {
-    step: 6,
     key: "third_reading",
     label: "III czytanie",
     bucket: "PLENUM",
@@ -202,7 +195,6 @@ const ROWS: StageRow[] = [
     sources: ["Art. 48-50 Regulaminu Sejmu"],
   },
   {
-    step: 7,
     key: "final_vote",
     label: "Głosowanie nad ustawą",
     bucket: "GŁOSOWANIE",
@@ -225,7 +217,6 @@ const ROWS: StageRow[] = [
     sources: ["Art. 120 Konstytucji RP"],
   },
   {
-    step: 8,
     key: "senate",
     label: "Senat",
     bucket: "SENAT",
@@ -254,7 +245,6 @@ const ROWS: StageRow[] = [
     ],
   },
   {
-    step: 9,
     key: "senate_consideration",
     label: "Rozpatrzenie poprawek Senatu",
     bucket: "SENAT",
@@ -276,7 +266,6 @@ const ROWS: StageRow[] = [
     sources: ["Art. 121 ust. 3 Konstytucji RP"],
   },
   {
-    step: 10,
     key: "president",
     label: "Prezydent",
     bucket: "PREZYDENT",
@@ -307,7 +296,6 @@ const ROWS: StageRow[] = [
     ],
   },
   {
-    step: 11,
     key: "promulgation",
     label: "Publikacja w Dz.U.",
     bucket: "PREZYDENT",
@@ -361,33 +349,18 @@ function BranchPill({ branch }: { branch: Branch }) {
 function StageIcon({ Icon }: { Icon: LucideIcon }) {
   return (
     <div
-      className="flex items-center justify-center rounded-full shrink-0"
+      className="flex items-center justify-center rounded-full shrink-0 relative"
       style={{
         width: 72,
         height: 72,
         background: "var(--muted)",
         color: "var(--secondary-foreground)",
+        // Sits above the timeline line — without an explicit z-index the
+        // dashed line shows through the disc and breaks the visual.
+        zIndex: 1,
       }}
     >
       <Icon size={32} strokeWidth={1.5} />
-    </div>
-  );
-}
-
-function StepBadge({ n }: { n: number }) {
-  return (
-    <div
-      className="flex items-center justify-center rounded-full shrink-0 font-mono font-medium"
-      style={{
-        width: 28,
-        height: 28,
-        background: "var(--destructive)",
-        color: "white",
-        fontSize: 12,
-      }}
-      aria-hidden
-    >
-      {n}
     </div>
   );
 }
@@ -429,7 +402,7 @@ export function ProcessStagesExplainer() {
         </button>
       </DialogTrigger>
 
-      <DialogContent className="max-w-[calc(100%-1rem)] sm:max-w-5xl max-h-[92vh] overflow-y-auto p-0">
+      <DialogContent className="max-w-[calc(100%-1rem)] sm:max-w-6xl lg:max-w-[1280px] max-h-[92vh] overflow-y-auto p-0">
         <div className="px-8 pt-8 pb-5 text-center border-b border-border">
           <DialogHeader className="items-center">
             <DialogTitle
@@ -470,19 +443,14 @@ export function ProcessStagesExplainer() {
             </div>
           </div>
 
-          <ol
-            className="list-none p-0 m-0 relative"
-            style={
-              {
-                "--timeline-x": "14px",
-              } as React.CSSProperties
-            }
-          >
+          <ol className="list-none p-0 m-0 relative">
+            {/* Vertical timeline runs through the centre of each icon disc.
+                Icon column is 88px wide → centre at 44px from left edge. */}
             <div
               aria-hidden
-              className="absolute top-0 bottom-0"
+              className="absolute top-10 bottom-10"
               style={{
-                left: "var(--timeline-x)",
+                left: 44,
                 width: 1,
                 background: "var(--border)",
               }}
@@ -493,16 +461,12 @@ export function ProcessStagesExplainer() {
               return (
                 <li
                   key={row.key}
-                  className="relative grid gap-5 pl-0 pr-0 mb-6 last:mb-0"
+                  className="relative grid gap-6 pl-0 pr-0 mb-7 last:mb-0"
                   style={{
-                    gridTemplateColumns: "28px 88px 1fr 260px",
+                    gridTemplateColumns: "88px 1fr 300px",
                     alignItems: "start",
                   }}
                 >
-                  <div className="flex items-center justify-center" style={{ zIndex: 1 }}>
-                    <StepBadge n={row.step} />
-                  </div>
-
                   <StageIcon Icon={Icon} />
 
                   <div className="min-w-0">

--- a/frontend/components/tygodnik/atoms/ProcessStagesExplainer.tsx
+++ b/frontend/components/tygodnik/atoms/ProcessStagesExplainer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import {
   ArrowLeft,
   ArrowRight,
@@ -27,19 +28,22 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 
-// Citizen-facing explainer of the legislative pipeline. Triggered by a "?"
-// affordance on ProcessStageBar.
+// Citizen-facing explainer of the Polish legislative pipeline. Text was
+// cross-checked against the Constitution (art. 118-123) and the Sejm
+// Standing Orders (Regulamin Sejmu, art. 32, 37, 41-50). Each row carries
+// a `sources` field with legal citations so a sceptical reader can verify.
 //
-// Layout (mirrors the citizen mockup):
-//   [num + icon column] | [text column] | ["Co dalej" column]
-//   Vertical timeline line connects the numbered bullets on the left.
-//
-// Stage list goes deeper than ProcessStageBar's 7 buckets — readers
-// asked about "I czytanie vs II czytanie vs III czytanie", which the bar
-// collapses (Reading + ReadingReferral → first_reading; SejmReading →
-// plenum). The explainer therefore shows ALL substantive procedural
-// moments. Each row maps to a bar bucket via `bucket` (rendered as a
-// subtle tag) so readers can connect the explainer back to the bar.
+// Common corrections from the legal review:
+//   - "Bezwzględna większość" is NOT "50% obecnych + 1" — that's quorum.
+//     It's "więcej ZA niż PRZECIW + WSTRZYMUJĄCYCH razem" (art. 121 ust. 3).
+//   - Senate deadline is NOT one number: 30 dni (standard) / 20 dni
+//     (budget — can only amend, can't reject) / 14 dni (urgent).
+//   - First-reading-on-plenum list is closed and specific (art. 37 ust. 2
+//     Reg.): konstytucja, budżet, podatki, wyborcze, ustrojowe, kodeksy.
+//   - Presidential 21-day clock STOPS when the bill is referred to the
+//     Constitutional Tribunal; resumes on judgment. Urgent track: 7 dni.
+//   - Withdrawal is allowed up to the END OF SECOND READING, not only in
+//     committee (art. 119 ust. 4 Konstytucji).
 
 type Branch = {
   kind: "forward" | "back" | "terminal";
@@ -53,9 +57,10 @@ type StageRow = {
   label: string;
   bucket: string;
   blurb: string;
-  detail: string;
+  detail: ReactNode;
   icon: LucideIcon;
   branches: Branch[];
+  sources: string[];
 };
 
 const ROWS: StageRow[] = [
@@ -65,10 +70,20 @@ const ROWS: StageRow[] = [
     label: "Wpłynęło",
     bucket: "WPŁYNĘŁO",
     blurb: "Projekt trafia do Sejmu.",
-    detail:
-      "Ustawę może zgłosić rząd, posłowie (klub poselski lub grupa co najmniej 15 posłów), Senat, Prezydent, komisja sejmowa albo 100 tysięcy obywateli przez inicjatywę obywatelską. To początek — projekt zostaje zarejestrowany i czeka na pierwsze omówienie.",
+    detail: (
+      <>
+        Ustawę może zgłosić <strong>rząd</strong>, <strong>posłowie</strong>{" "}
+        (klub poselski albo grupa <strong>co najmniej 15 posłów</strong>),{" "}
+        <strong>Senat</strong>, <strong>Prezydent</strong>,{" "}
+        <strong>komisja sejmowa</strong> albo{" "}
+        <strong>100 tysięcy obywateli</strong> przez inicjatywę obywatelską.
+        Każdy wnioskodawca musi przedstawić skutki finansowe projektu. To
+        początek — projekt zostaje zarejestrowany i czeka na pierwsze omówienie.
+      </>
+    ),
     icon: ScrollText,
     branches: [{ kind: "forward", label: "I czytanie", detail: "Zawsze następny krok." }],
+    sources: ["Art. 118 Konstytucji RP", "Art. 32 ust. 2 Regulaminu Sejmu"],
   },
   {
     step: 2,
@@ -76,13 +91,25 @@ const ROWS: StageRow[] = [
     label: "I czytanie",
     bucket: "I CZYTANIE",
     blurb: "Pierwsze formalne omówienie.",
-    detail:
-      "Marszałek Sejmu decyduje, gdzie trafi projekt: na salę plenarną (cały Sejm — dla najważniejszych spraw jak budżet czy zmiany konstytucji) albo bezpośrednio do komisji branżowej. Autorzy przedstawiają cele projektu, posłowie zadają pierwsze pytania.",
+    detail: (
+      <>
+        Marszałek Sejmu decyduje, gdzie trafi projekt: na{" "}
+        <strong>salę plenarną</strong> (cały Sejm) albo bezpośrednio do{" "}
+        <strong>komisji branżowej</strong>. Na salę plenarną idą{" "}
+        <strong>zawsze</strong>: zmiany Konstytucji, ustawy budżetowe i
+        podatkowe, ustawy wyborcze (Prezydenta, Sejmu, Senatu, samorządu),
+        regulujące ustrój i właściwość władz publicznych oraz{" "}
+        <strong>kodeksy</strong>. Pozostałe trafiają najpierw do komisji.
+        Pierwsze czytanie odbywa się <strong>nie wcześniej niż 7 dni</strong> od
+        doręczenia druku posłom.
+      </>
+    ),
     icon: Megaphone,
     branches: [
       { kind: "forward", label: "Komisja", detail: "Standardowa droga — szczegółowa analiza." },
-      { kind: "terminal", label: "Odrzucenie", detail: "Sejm może odrzucić projekt już na tym etapie." },
+      { kind: "terminal", label: "Odrzucenie", detail: "Sejm może odrzucić projekt w I czytaniu." },
     ],
+    sources: ["Art. 37 ust. 2 i 4 Regulaminu Sejmu", "Art. 39 Regulaminu Sejmu"],
   },
   {
     step: 3,
@@ -90,13 +117,22 @@ const ROWS: StageRow[] = [
     label: "Praca w komisji",
     bucket: "KOMISJA",
     blurb: "Branżowi eksperci analizują szczegóły.",
-    detail:
-      "Komisje sejmowe (np. zdrowia, finansów, kultury, sprawiedliwości) czytają projekt linijka po linijce, słuchają opinii ekspertów, organizacji społecznych, strony rządowej. Mogą wprowadzać poprawki. To zwykle najdłuższy etap — tygodnie albo miesiące. Tu zapada większość konkretnych decyzji o ostatecznym kształcie ustawy.",
+    detail: (
+      <>
+        Komisje sejmowe (np. zdrowia, finansów, kultury, sprawiedliwości)
+        czytają projekt linijka po linijce, słuchają opinii ekspertów,
+        organizacji społecznych, strony rządowej. Mogą wprowadzać poprawki. To
+        zwykle <strong>najdłuższy etap</strong> — tygodnie albo miesiące. Tu
+        zapada większość konkretnych decyzji o ostatecznym kształcie ustawy.{" "}
+        <strong>Wnioskodawca może wycofać projekt do końca II czytania.</strong>
+      </>
+    ),
     icon: FileSearch,
     branches: [
       { kind: "forward", label: "Sprawozdanie komisji", detail: "Komisja kończy pracę i przedstawia stanowisko Sejmowi." },
-      { kind: "terminal", label: "Wycofanie", detail: "Wnioskodawcy mogą wycofać projekt." },
+      { kind: "terminal", label: "Wycofanie", detail: "Wnioskodawca może wycofać projekt do końca II czytania." },
     ],
+    sources: ["Art. 41-46 Regulaminu Sejmu", "Art. 119 ust. 4 Konstytucji RP"],
   },
   {
     step: 4,
@@ -104,12 +140,20 @@ const ROWS: StageRow[] = [
     label: "Sprawozdanie komisji",
     bucket: "KOMISJA",
     blurb: "Komisja przedstawia stanowisko.",
-    detail:
-      "Komisja głosuje nad treścią projektu i przekazuje sprawozdanie Sejmowi. W sprawozdaniu wskazuje wszystkie wprowadzone poprawki oraz proponowane stanowisko: za przyjęciem, za odrzuceniem albo z dodatkowymi zmianami. Zazwyczaj wyznaczany jest poseł-sprawozdawca, który przedstawi raport na sali.",
+    detail: (
+      <>
+        Komisja głosuje nad treścią projektu i przekazuje sprawozdanie Sejmowi.
+        W sprawozdaniu wskazuje <strong>wszystkie wprowadzone poprawki</strong>{" "}
+        oraz proponowane stanowisko: za przyjęciem, za odrzuceniem albo z
+        dodatkowymi zmianami. Wyznaczany jest <strong>poseł-sprawozdawca</strong>,
+        który przedstawi raport na sali.
+      </>
+    ),
     icon: FileSignature,
     branches: [
       { kind: "forward", label: "II czytanie", detail: "Plenum debatuje nad sprawozdaniem komisji." },
     ],
+    sources: ["Art. 43 Regulaminu Sejmu"],
   },
   {
     step: 5,
@@ -117,13 +161,25 @@ const ROWS: StageRow[] = [
     label: "II czytanie",
     bucket: "PLENUM",
     blurb: "Debata plenarna nad sprawozdaniem.",
-    detail:
-      "Wszyscy posłowie debatują nad projektem w wersji proponowanej przez komisję. Każdy klub przedstawia stanowisko, można zgłaszać nowe poprawki. Jeśli pojawią się świeże poprawki, projekt zazwyczaj wraca do komisji — to NORMALNE, a nie cofanie procesu.",
+    detail: (
+      <>
+        Wszyscy posłowie debatują nad projektem w wersji proponowanej przez
+        komisję. Każdy klub przedstawia stanowisko. Można zgłaszać{" "}
+        <strong>nowe poprawki</strong> ALBO złożyć{" "}
+        <strong>wniosek o odrzucenie projektu w całości</strong>. Jeśli pojawią
+        się świeże poprawki, projekt zazwyczaj wraca do komisji — to{" "}
+        <strong>NORMALNE, a nie cofanie procesu</strong>. To również{" "}
+        <strong>ostatni moment</strong>, w którym wnioskodawca może wycofać
+        projekt.
+      </>
+    ),
     icon: Users,
     branches: [
       { kind: "forward", label: "III czytanie", detail: "Jeśli nie ma nowych poprawek do analizy." },
       { kind: "back", label: "Komisja (poprawki)", detail: "Komisja analizuje świeże poprawki z plenum." },
+      { kind: "terminal", label: "Odrzucenie", detail: "Sejm może odrzucić projekt na wniosek złożony w II czytaniu." },
     ],
+    sources: ["Art. 44 i 47 Regulaminu Sejmu", "Art. 119 ust. 4 Konstytucji RP"],
   },
   {
     step: 6,
@@ -131,12 +187,19 @@ const ROWS: StageRow[] = [
     label: "III czytanie",
     bucket: "PLENUM",
     blurb: "Finałowa debata i głosowania nad poprawkami.",
-    detail:
-      "Posłowie głosują nad pojedynczymi poprawkami (przyjąć / odrzucić), a potem nad CAŁOŚCIĄ ustawy. Sprawozdawca komisji może rekomendować, jak głosować. To moment, w którym ustala się ostateczna treść projektu — każda poprawka albo wchodzi, albo wypada.",
+    detail: (
+      <>
+        Posłowie głosują nad <strong>pojedynczymi poprawkami</strong> (przyjąć
+        / odrzucić), a potem nad <strong>CAŁOŚCIĄ ustawy</strong>. Sprawozdawca
+        komisji może rekomendować, jak głosować. To moment, w którym ustala się
+        ostateczna treść projektu — każda poprawka albo wchodzi, albo wypada.
+      </>
+    ),
     icon: Vote,
     branches: [
-      { kind: "forward", label: "Głosowanie nad całością", detail: "Po przegłosowaniu poprawek." },
+      { kind: "forward", label: "Głosowanie nad całością", detail: "Po przegłosowaniu wszystkich poprawek." },
     ],
+    sources: ["Art. 48-50 Regulaminu Sejmu"],
   },
   {
     step: 7,
@@ -144,26 +207,50 @@ const ROWS: StageRow[] = [
     label: "Głosowanie nad ustawą",
     bucket: "GŁOSOWANIE",
     blurb: "Finałowy głos w Sejmie.",
-    detail:
-      "Posłowie głosują nad PEŁNĄ wersją projektu po poprawkach. Wymagana zwykła większość — więcej głosów ZA niż PRZECIW, przy obecności co najmniej połowy posłów (kworum 230). Wynik głosowania jest publikowany imiennie — można sprawdzić, jak głosował każdy poseł.",
+    detail: (
+      <>
+        Posłowie głosują nad PEŁNĄ wersją projektu po poprawkach. Wymagana{" "}
+        <strong>zwykła większość</strong> — więcej głosów ZA niż PRZECIW (głosy
+        wstrzymujące się nie liczą), przy obecności co najmniej{" "}
+        <strong>połowy posłów</strong> (<strong>kworum 230</strong> z 460).
+        Wynik głosowania jest publikowany imiennie — można sprawdzić, jak
+        głosował każdy poseł.
+      </>
+    ),
     icon: Vote,
     branches: [
-      { kind: "forward", label: "Senat", detail: "Ustawa idzie do izby wyższej w 3 dni." },
+      { kind: "forward", label: "Senat", detail: "Marszałek przekazuje uchwaloną ustawę do Senatu w 3 dni." },
       { kind: "terminal", label: "Odrzucenie", detail: "Za mało głosów ZA — proces się kończy." },
     ],
+    sources: ["Art. 120 Konstytucji RP"],
   },
   {
     step: 8,
     key: "senate",
     label: "Senat",
     bucket: "SENAT",
-    blurb: "30 dni na stanowisko izby wyższej.",
-    detail:
-      "Senat ma trzy opcje: przyjąć ustawę bez zmian (idzie prosto do Prezydenta), wnieść poprawki (wraca do Sejmu), albo odrzucić w całości (wraca do Sejmu). Jeśli Senat milczy 30 dni — ustawa idzie dalej automatycznie. Budżet i pilne ustawy mają skrócone terminy.",
+    blurb: "Stanowisko izby wyższej.",
+    detail: (
+      <>
+        Senat ma trzy opcje: <strong>przyjąć ustawę bez zmian</strong> (idzie
+        prosto do Prezydenta), <strong>wnieść poprawki</strong> (wraca do
+        Sejmu), albo <strong>odrzucić w całości</strong> (wraca do Sejmu).
+        Jeśli Senat milczy — ustawa idzie dalej automatycznie. Termin zależy od
+        trybu: <strong>30 dni</strong> dla zwykłej ustawy,{" "}
+        <strong>20 dni</strong> dla budżetu (przy czym Senat{" "}
+        <strong>nie może odrzucić budżetu w całości</strong> — tylko zgłosić
+        poprawki), <strong>14 dni</strong> dla ustaw w trybie pilnym.
+      </>
+    ),
     icon: Landmark,
     branches: [
       { kind: "forward", label: "Prezydent", detail: "Bez zmian albo po rozpatrzeniu poprawek senackich." },
-      { kind: "back", label: "Sejm głosuje znowu", detail: "Sejm bezwzględną większością może odrzucić senackie zmiany." },
+      { kind: "back", label: "Sejm głosuje znowu", detail: "Jeśli Senat zgłosił poprawki lub odrzucił ustawę." },
+    ],
+    sources: [
+      "Art. 121 Konstytucji RP",
+      "Art. 123 ust. 3 Konstytucji RP (tryb pilny)",
+      "Art. 223 Konstytucji RP (budżet)",
     ],
   },
   {
@@ -172,26 +259,51 @@ const ROWS: StageRow[] = [
     label: "Rozpatrzenie poprawek Senatu",
     bucket: "SENAT",
     blurb: "Sejm reaguje na zmiany izby wyższej.",
-    detail:
-      "Jeśli Senat zgłosił poprawki lub odrzucił ustawę w całości, Sejm głosuje nad każdą poprawką osobno. Aby ODRZUCIĆ stanowisko Senatu, trzeba bezwzględnej większości (50% + 1 obecnych). Jeśli Sejm nie odrzuci — stanowisko Senatu wchodzi do ustawy.",
+    detail: (
+      <>
+        Jeśli Senat zgłosił poprawki lub odrzucił ustawę w całości, Sejm głosuje
+        nad każdą poprawką osobno. Aby ODRZUCIĆ stanowisko Senatu, potrzeba{" "}
+        <strong>bezwzględnej większości</strong> — więcej głosów ZA odrzuceniem
+        niż <strong>PRZECIW i WSTRZYMUJĄCYCH razem</strong>, przy obecności co
+        najmniej połowy posłów. Jeśli Sejmowi nie uda się zebrać tej większości
+        — stanowisko Senatu wchodzi do ustawy.
+      </>
+    ),
     icon: Users,
     branches: [
-      { kind: "forward", label: "Prezydent", detail: "Po rozstrzygnięciu wszystkich poprawek." },
+      { kind: "forward", label: "Prezydent", detail: "Po rozstrzygnięciu wszystkich poprawek Senatu." },
     ],
+    sources: ["Art. 121 ust. 3 Konstytucji RP"],
   },
   {
     step: 10,
     key: "president",
     label: "Prezydent",
     bucket: "PREZYDENT",
-    blurb: "21 dni na decyzję głowy państwa.",
-    detail:
-      "Prezydent ma trzy opcje: PODPISAĆ (ustawa po publikacji w Dzienniku Ustaw zaczyna obowiązywać), ZAWETOWAĆ (Sejm może obalić weto większością 3/5 głosów przy obecności co najmniej połowy posłów), albo SKIEROWAĆ DO TRYBUNAŁU KONSTYTUCYJNEGO do oceny zgodności z konstytucją.",
+    blurb: "Decyzja głowy państwa.",
+    detail: (
+      <>
+        Prezydent ma trzy opcje: <strong>PODPISAĆ</strong> (ustawa po publikacji
+        w Dzienniku Ustaw zaczyna obowiązywać), <strong>ZAWETOWAĆ</strong>{" "}
+        (Sejm może obalić weto większością <strong>3/5 głosów</strong> przy
+        obecności co najmniej połowy posłów), albo{" "}
+        <strong>skierować do Trybunału Konstytucyjnego</strong> — wtedy bieg
+        terminu jest <strong>wstrzymany</strong> do orzeczenia TK. Standardowy
+        termin to <strong>21 dni</strong>, ale tylko <strong>7 dni</strong> w
+        trybie pilnym i również <strong>7 dni</strong> po obaleniu weta przez
+        Sejm. Po wcześniejszym wecie Prezydent nie może już ponownie wetować ani
+        kierować ustawy do TK.
+      </>
+    ),
     icon: PenTool,
     branches: [
       { kind: "forward", label: "Dziennik Ustaw", detail: "Po podpisie ustawa wchodzi w życie." },
       { kind: "back", label: "Sejm obala weto", detail: "Większością 3/5 głosów Sejm odrzuca weto Prezydenta." },
       { kind: "terminal", label: "Trybunał Konstytucyjny", detail: "Prezydent kieruje ustawę do oceny zgodności z konstytucją." },
+    ],
+    sources: [
+      "Art. 122 Konstytucji RP",
+      "Art. 123 ust. 3 Konstytucji RP (tryb pilny)",
     ],
   },
   {
@@ -200,10 +312,21 @@ const ROWS: StageRow[] = [
     label: "Publikacja w Dz.U.",
     bucket: "PREZYDENT",
     blurb: "Ustawa wchodzi w życie.",
-    detail:
-      "Po podpisie Prezydenta ustawa jest publikowana w Dzienniku Ustaw RP. Tekst zawiera datę wejścia w życie — często to 14 dni od publikacji (tzw. vacatio legis), ale ustawa może określać własny termin. Od tego momentu ustawa obowiązuje wszystkich.",
+    detail: (
+      <>
+        Po podpisie Prezydenta ustawa jest publikowana w{" "}
+        <strong>Dzienniku Ustaw RP</strong>. Tekst zawiera datę wejścia w życie
+        — standardowo <strong>14 dni od ogłoszenia</strong> (tzw.{" "}
+        <strong>vacatio legis</strong>), ale ustawa może określać własny termin
+        (krótszy lub dłuższy). Od tego momentu ustawa obowiązuje wszystkich.
+      </>
+    ),
     icon: Crown,
     branches: [],
+    sources: [
+      "Art. 122 ust. 2 Konstytucji RP",
+      "Art. 4 ust. 1 ustawy o ogłaszaniu aktów normatywnych",
+    ],
   },
 ];
 
@@ -269,6 +392,29 @@ function StepBadge({ n }: { n: number }) {
   );
 }
 
+function LegalSources({ items }: { items: string[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div
+      className="mt-3 pt-2 font-mono text-[10px] text-muted-foreground leading-snug"
+      style={{ borderTop: "1px dashed var(--border)", letterSpacing: "0.02em" }}
+    >
+      <span
+        className="uppercase tracking-[0.12em] mr-2"
+        style={{ fontSize: 9, fontWeight: 600 }}
+      >
+        Podstawa prawna
+      </span>
+      {items.map((s, i) => (
+        <span key={i}>
+          {i > 0 && <span aria-hidden> · </span>}
+          {s}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 export function ProcessStagesExplainer() {
   return (
     <Dialog>
@@ -298,7 +444,9 @@ export function ProcessStagesExplainer() {
             >
               Jedenaście etapów, przez które przechodzi każdy projekt — od
               wpłynięcia do publikacji w Dzienniku Ustaw. Pasek nad ustawą
-              pokazuje, na którym etapie jest konkretna sprawa.
+              pokazuje, na którym etapie jest konkretna sprawa. Pod każdym
+              etapem podana jest <strong>podstawa prawna</strong> z Konstytucji
+              RP albo Regulaminu Sejmu.
             </DialogDescription>
           </DialogHeader>
         </div>
@@ -326,9 +474,6 @@ export function ProcessStagesExplainer() {
             className="list-none p-0 m-0 relative"
             style={
               {
-                // Vertical timeline line connecting step badges. Positioned
-                // to align with the centre of the step circles (left padding
-                // + half circle width = 14px from list-item left edge).
                 "--timeline-x": "14px",
               } as React.CSSProperties
             }
@@ -343,9 +488,8 @@ export function ProcessStagesExplainer() {
               }}
             />
 
-            {ROWS.map((row, idx) => {
+            {ROWS.map((row) => {
               const Icon = row.icon;
-              const isLast = idx === ROWS.length - 1;
               return (
                 <li
                   key={row.key}
@@ -379,7 +523,7 @@ export function ProcessStagesExplainer() {
                     <p className="font-sans text-[13px] text-muted-foreground italic m-0 mb-2">
                       {row.blurb}
                     </p>
-                    <p
+                    <div
                       className="font-serif text-secondary-foreground m-0"
                       style={{
                         fontSize: 14,
@@ -388,7 +532,8 @@ export function ProcessStagesExplainer() {
                       }}
                     >
                       {row.detail}
-                    </p>
+                    </div>
+                    <LegalSources items={row.sources} />
                   </div>
 
                   {row.branches.length > 0 ? (
@@ -439,14 +584,23 @@ export function ProcessStagesExplainer() {
               możliwe zakończenie procesu
             </span>
             <span className="ml-auto">
-              Źródło:{" "}
+              Źródła:{" "}
               <a
-                href="https://www.sejm.gov.pl/Sejm10.nsf/proces.xsp"
+                href="https://www.sejm.gov.pl/prawo/konst/polski/4.htm"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline underline-offset-2 hover:text-foreground"
               >
-                procedura legislacyjna Sejmu RP
+                Konstytucja RP
+              </a>
+              {" · "}
+              <a
+                href="https://www.sejm.gov.pl/prawo/regulamin/kon7.htm"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                Regulamin Sejmu
               </a>
             </span>
           </div>


### PR DESCRIPTION
## Summary

Cross-check explainera proces legislacyjnego z polskim prawem (Konstytucja art. 118-123, Regulamin Sejmu art. 32, 37, 41-50). **Pięć faktycznych błędów + cztery niekompletności**, plus bold + cytaty per etap.

## 🔴 Faktyczne błędy naprawione

| # | Co było | Co powinno być | Podstawa |
|---|---|---|---|
| 1 | "bezwzględna większość (50% + 1 obecnych)" | więcej ZA niż PRZECIW **i wstrzymujących razem** | Art. 121 ust. 3 |
| 2 | "Budżet i pilne ustawy mają skrócone terminy" (zlepione) | 30 dni zwykła / **20 dni budżet** (bez prawa odrzucenia w całości) / 14 dni pilne | Art. 121, 123, 223 |
| 3 | I czytanie na sali: "jak budżet czy zmiany konstytucji" (niepełne) | Pełna lista: konstytucja, budżet, podatki, wyborcze, ustrojowe, **kodeksy** | Art. 37 ust. 2 Reg. |
| 4 | Prezydent 21 dni (bez wzmianki o TK i trybie pilnym) | 21 dni standardowo, **7 dni pilne**, **7 dni po obaleniu weta**, termin **wstrzymany przy skierowaniu do TK** | Art. 122 + 123 |
| 5 | "Wnioskodawca może wycofać projekt" (tylko w komisji) | Wycofanie możliwe **do końca II czytania** | Art. 119 ust. 4 |

## 🟡 Uzupełnienia

- Etap 2 (I czytanie): "nie wcześniej niż **7 dni** od doręczenia druku" (art. 37 ust. 4 Reg.)
- Etap 5 (II czytanie): dodany terminal "Odrzucenie projektu" (można złożyć wniosek o odrzucenie w II czytaniu — art. 47 Reg.)
- Etap 7 (Głosowanie): doprecyzowano kworum "230 z 460"
- Etap 11 (Dz.U.): doprecyzowano że "ustawa może określać własny termin (krótszy lub dłuższy)" niż 14 dni

## ✨ UX

- **Bold** na każdej liczbie/terminie który obywatel powinien zapamiętać (progi, dni, kworum, większości)
- **"PODSTAWA PRAWNA: Art. X Konstytucji RP · Art. Y Regulaminu Sejmu"** pod każdym etapem (mały monospace, dashed border-top) — żeby sceptyczny czytelnik mógł zweryfikować każde stwierdzenie
- Stopka rozbita na dwa źródła: Konstytucja + Regulamin Sejmu

## Test plan

- [x] `pnpm tsc --noEmit` clean (z wyłączeniem .next/dev/types)
- [x] Dialog renderuje wszystkie 11 etapów + branche + cytaty
- [x] Bold widoczne, podstawa prawna pod każdym etapem
- [ ] Mobile (TODO przy review)

https://claude.ai/code/session_01QoTgxhBepPoffhyjvpZhhH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoTgxhBepPoffhyjvpZhhH)_