### PR TITLE
Add process-scoped citations section to druk pages

### DIFF
--- a/frontend/app/proces/[term]/[number]/_components/Citations.tsx
+++ b/frontend/app/proces/[term]/[number]/_components/Citations.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+import { MPAvatar } from "@/components/tygodnik/MPAvatar";
+import type { ProcessCitation } from "@/lib/db/statements";
+
+function SectionHead({ title, subtitle }: { title: string; subtitle?: string | null }) {
+  return (
+    <div className="mb-5 flex items-baseline gap-4 border-b border-border pb-3">
+      <h2
+        className="font-serif font-medium text-foreground m-0"
+        style={{ fontSize: 22, lineHeight: 1, letterSpacing: "-0.015em" }}
+      >
+        {title}
+      </h2>
+      {subtitle && (
+        <span className="font-sans text-[11.5px] text-muted-foreground ml-auto">
+          {subtitle}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function formatDate(iso: string | null): string | null {
+  if (!iso) return null;
+  return new Date(iso).toLocaleDateString("pl-PL", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export function Citations({ items }: { items: ProcessCitation[] }) {
+  if (items.length === 0) return null;
+  const sittingNum = items[0].proceedingNumber;
+
+  return (
+    <section className="py-12 border-b border-border">
+      <div className="max-w-[1280px] mx-auto">
+        <SectionHead
+          title="Cytaty z sali plenarnej"
+          subtitle={
+            sittingNum
+              ? `Wybrane wypowiedzi · posiedzenie nr ${sittingNum}`
+              : "Wybrane wypowiedzi"
+          }
+        />
+
+        <div className="grid gap-6 md:gap-8 grid-cols-1 md:grid-cols-2">
+          {items.map((c) => (
+            <CitationCard key={c.id} c={c} />
+          ))}
+        </div>
+
+        <div className="mt-5 font-sans text-[11px] text-muted-foreground italic">
+          Próbka spośród najbardziej cytowalnych wypowiedzi — odśwież stronę, by
+          zobaczyć inne.
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CitationCard({ c }: { c: ProcessCitation }) {
+  const dateLabel = formatDate(c.date);
+  const role = c.function?.trim();
+  const hideRole =
+    !role ||
+    role.localeCompare("poseł", "pl", { sensitivity: "accent" }) === 0;
+
+  return (
+    <article className="flex flex-col gap-3 min-w-0">
+      <div className="flex items-baseline gap-3 min-w-0">
+        <MPAvatar
+          mpId={c.mpId}
+          name={c.speakerName}
+          photoUrl={c.photoUrl}
+          klub={c.clubRef}
+          size={40}
+          shape="squircle"
+        />
+        <span className="ml-auto font-mono uppercase text-muted-foreground shrink-0"
+          style={{ fontSize: 10, letterSpacing: "0.12em" }}
+        >
+          {dateLabel}
+        </span>
+      </div>
+      {!hideRole && (
+        <div
+          className="font-sans text-muted-foreground"
+          style={{ fontSize: 11, letterSpacing: "0.02em" }}
+        >
+          {role}
+        </div>
+      )}
+      <Link
+        href={`/mowa/${c.id}`}
+        className="group block no-underline"
+        aria-label={`Otwórz pełną wypowiedź — ${c.speakerName ?? "wypowiedź sejmowa"}`}
+      >
+        <blockquote
+          className="font-serif italic m-0 relative text-foreground group-hover:text-foreground/90"
+          style={{
+            fontSize: 18,
+            lineHeight: 1.4,
+            padding: "6px 0 6px 22px",
+            borderLeft: "3px solid var(--destructive)",
+            textWrap: "pretty" as never,
+          }}
+        >
+          <span
+            aria-hidden
+            className="font-serif text-destructive absolute"
+            style={{
+              fontSize: 44,
+              lineHeight: 0.8,
+              left: 8,
+              top: 2,
+              opacity: 0.18,
+              fontStyle: "normal",
+            }}
+          >
+            “
+          </span>
+          {c.viralQuote}
+        </blockquote>
+      </Link>
+      {c.viralReason && (
+        <div
+          className="font-sans text-muted-foreground italic"
+          style={{ fontSize: 12, lineHeight: 1.45 }}
+        >
+          {c.viralReason}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/frontend/app/proces/[term]/[number]/page.tsx
+++ b/frontend/app/proces/[term]/[number]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPrint } from "@/lib/db/prints";
+import { getProcessCitations } from "@/lib/db/statements";
 import { documentCategoryLabel, opinionSourceLabel, opinionSourceShort, promiseStatusLabel } from "@/lib/labels";
 import { PrintCard } from "@/components/print/PrintCard";
 import { NotFoundPage } from "@/components/chrome/NotFoundPage";
@@ -8,6 +9,7 @@ import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
 import { Hero } from "./_components/Hero";
 import { Timeline } from "./_components/Timeline";
 import { Summary } from "./_components/Summary";
+import { Citations } from "./_components/Citations";
 import { Votings } from "./_components/Votings";
 import { Committees } from "./_components/Committees";
 import { ProceedingPoints } from "./_components/ProceedingPoints";
@@ -92,6 +94,16 @@ export default async function DrukPage({
     proceedingPoints,
   } = data;
 
+  // Top-viral citations from the most recent sitting that discussed this
+  // process. Tolerant: if enrichment hasn't run for the linked statements,
+  // returns [] and the section silently disappears.
+  let citations: Awaited<ReturnType<typeof getProcessCitations>> = [];
+  try {
+    citations = await getProcessCitations(term, number);
+  } catch (err) {
+    console.error("[/proces/[term]/[number]] getProcessCitations failed", { term, number, err });
+  }
+
   const processStillOpen = !outcome?.passed && !print.currentStageType?.match(/^(End|Withdrawn|Rejected)$/);
 
   return (
@@ -140,6 +152,7 @@ export default async function DrukPage({
 
       <div className="max-w-[1280px] mx-auto px-4 md:px-8 lg:px-14">
         <Summary print={print} />
+        <Citations items={citations} />
         <Votings
           votings={relatedVotings}
           mainVotingId={mainVoting?.votingId ?? null}

--- a/frontend/lib/db/statements.ts
+++ b/frontend/lib/db/statements.ts
@@ -840,6 +840,149 @@ async function getRecentStatementSnippets(
   });
 }
 
+// ─── Process-scoped citations ────────────────────────────────────────────
+//
+// Powers the "Cytaty z sali plenarnej" section on /proces/[term]/[number].
+// Pulls top-viral statements linked (via statement_print_links) to any
+// print in the process (main + sub_prints), restricted to the most-recent
+// sitting that actually discussed it. Random sample server-side per request
+// so the cards rotate on every reload.
+export type ProcessCitation = {
+  id: number;
+  mpId: number | null;
+  speakerName: string | null;
+  function: string | null;
+  clubRef: string | null;
+  photoUrl: string | null;
+  viralQuote: string;
+  viralReason: string | null;
+  tone: string | null;
+  date: string | null;
+  proceedingNumber: number | null;
+};
+
+export async function getProcessCitations(
+  term: number,
+  printNumber: string,
+  sampleSize = 4,
+): Promise<ProcessCitation[]> {
+  const sb = supabase();
+
+  // 1. All print IDs in this process: the main print + any forward-linked
+  //    sub-prints (autopoprawka, opinia, OSR). Statements may be tagged
+  //    against any of them via statement_print_links.
+  const { data: printRows, error: pErr } = await sb
+    .from("prints")
+    .select("id")
+    .eq("term", term)
+    .or(`number.eq.${printNumber},parent_number.eq.${printNumber}`);
+  if (pErr) throw pErr;
+  const printIds = (printRows ?? []).map((r) => (r as { id: number }).id);
+  if (printIds.length === 0) return [];
+
+  // 2. Statement IDs linked to any of those prints.
+  const { data: linkRows, error: lErr } = await sb
+    .from("statement_print_links")
+    .select("statement_id")
+    .in("print_id", printIds);
+  if (lErr) throw lErr;
+  const stmtIds = Array.from(
+    new Set((linkRows ?? []).map((r) => (r as { statement_id: number }).statement_id)),
+  );
+  if (stmtIds.length === 0) return [];
+
+  // 3. Top-viral candidates among the linked set. Grab a wider pool than
+  //    sampleSize so the "last sitting" filter + random sample still has
+  //    room to work.
+  type StmtRow = {
+    id: number;
+    mp_id: number | null;
+    speaker_name: string | null;
+    function: string | null;
+    viral_quote: string | null;
+    viral_reason: string | null;
+    viral_score: number | string | null;
+    tone: string | null;
+    start_datetime: string | null;
+    proceeding_day: { date: string | null; proceeding: { number: number | null } | null } | null;
+  };
+  const { data: stmtRows, error: sErr } = await sb
+    .from("proceeding_statements")
+    .select(
+      "id, mp_id, speaker_name, function, viral_quote, viral_reason, viral_score, tone, start_datetime, proceeding_day:proceeding_days!inner(date, proceeding:proceedings!inner(number))",
+    )
+    .in("id", stmtIds)
+    .eq("term", term)
+    .not("viral_quote", "is", null)
+    .order("viral_score", { ascending: false, nullsFirst: false })
+    .limit(40);
+  if (sErr) throw sErr;
+  const rows = ((stmtRows ?? []) as unknown as StmtRow[]).filter(
+    (r) => r.viral_quote && r.viral_quote.trim().length > 0,
+  );
+  if (rows.length === 0) return [];
+
+  // 4. Keep only the most-recent sitting (highest proceeding.number) —
+  //    "z ostatniej dyskusji". Statements without a linked sitting fall out.
+  const latestSitting = rows.reduce<number | null>((max, r) => {
+    const n = r.proceeding_day?.proceeding?.number ?? null;
+    if (n == null) return max;
+    return max == null || n > max ? n : max;
+  }, null);
+  const pool = latestSitting == null
+    ? rows
+    : rows.filter((r) => r.proceeding_day?.proceeding?.number === latestSitting);
+
+  // 5. Random sample of sampleSize from the top-viral pool. Per-request
+  //    Math.random() — each page render shows a different selection.
+  const shuffled = [...pool].sort(() => Math.random() - 0.5).slice(0, sampleSize);
+
+  // 6. Resolve speaker club + photo for the sampled rows only.
+  const mpIds = Array.from(
+    new Set(shuffled.map((r) => r.mp_id).filter((x): x is number => x != null)),
+  );
+  const [clubMap, photoMap] = await Promise.all([
+    resolveMpClubs(mpIds, term),
+    resolveMpPhotos(mpIds, term),
+  ]);
+
+  return shuffled.map((r): ProcessCitation => {
+    const club = r.mp_id != null ? clubMap.get(r.mp_id) ?? null : null;
+    return {
+      id: r.id,
+      mpId: r.mp_id,
+      speakerName: r.speaker_name,
+      function: r.function,
+      clubRef: club?.clubRef ?? null,
+      photoUrl: r.mp_id != null ? photoMap.get(r.mp_id) ?? null : null,
+      viralQuote: r.viral_quote!.trim(),
+      viralReason: r.viral_reason,
+      tone: r.tone,
+      date: r.start_datetime ?? r.proceeding_day?.date ?? null,
+      proceedingNumber: r.proceeding_day?.proceeding?.number ?? null,
+    };
+  });
+}
+
+async function resolveMpPhotos(
+  mpIds: number[],
+  term: number,
+): Promise<Map<number, string | null>> {
+  const out = new Map<number, string | null>();
+  if (mpIds.length === 0) return out;
+  const sb = supabase();
+  const { data, error } = await sb
+    .from("mps")
+    .select("mp_id, photo_url")
+    .eq("term", term)
+    .in("mp_id", mpIds);
+  if (error) throw error;
+  for (const r of (data ?? []) as { mp_id: number; photo_url: string | null }[]) {
+    out.set(r.mp_id, r.photo_url);
+  }
+  return out;
+}
+
 export async function getActiveClubs(term = DEFAULT_TERM): Promise<{ clubId: string; name: string }[]> {
   const sb = supabase();
   const { data, error } = await sb

--- a/frontend/lib/db/statements.ts
+++ b/frontend/lib/db/statements.ts
@@ -880,7 +880,10 @@ export async function getProcessCitations(
   const printIds = (printRows ?? []).map((r) => (r as { id: number }).id);
   if (printIds.length === 0) return [];
 
-  // 2. Statement IDs linked to any of those prints.
+  // 2. Statement IDs linked via the structured statement_print_links table
+  //    (mig 0060). Authoritative when populated, but the backfill lags
+  //    statement ingest — when it's empty we fall back to
+  //    mentioned_entities.prints (LLM enrichment) below.
   const { data: linkRows, error: lErr } = await sb
     .from("statement_print_links")
     .select("statement_id")
@@ -889,11 +892,7 @@ export async function getProcessCitations(
   const stmtIds = Array.from(
     new Set((linkRows ?? []).map((r) => (r as { statement_id: number }).statement_id)),
   );
-  if (stmtIds.length === 0) return [];
 
-  // 3. Top-viral candidates among the linked set. Grab a wider pool than
-  //    sampleSize so the "last sitting" filter + random sample still has
-  //    room to work.
   type StmtRow = {
     id: number;
     mp_id: number | null;
@@ -906,20 +905,46 @@ export async function getProcessCitations(
     start_datetime: string | null;
     proceeding_day: { date: string | null; proceeding: { number: number | null } | null } | null;
   };
-  const { data: stmtRows, error: sErr } = await sb
-    .from("proceeding_statements")
-    .select(
-      "id, mp_id, speaker_name, function, viral_quote, viral_reason, viral_score, tone, start_datetime, proceeding_day:proceeding_days!inner(date, proceeding:proceedings!inner(number))",
-    )
-    .in("id", stmtIds)
-    .eq("term", term)
-    .not("viral_quote", "is", null)
-    .order("viral_score", { ascending: false, nullsFirst: false })
-    .limit(40);
-  if (sErr) throw sErr;
-  const rows = ((stmtRows ?? []) as unknown as StmtRow[]).filter(
-    (r) => r.viral_quote && r.viral_quote.trim().length > 0,
-  );
+
+  // 3. Top-viral candidates. Two paths:
+  //    a) link table populated → filter by statement IDs.
+  //    b) link table empty (early-term, backfill pending) → match by
+  //       proceeding_statements.mentioned_entities->prints containing the
+  //       canonical "druk nr X" token the LLM emits during enrichment.
+  let rows: StmtRow[] = [];
+  if (stmtIds.length > 0) {
+    const { data: stmtRows, error: sErr } = await sb
+      .from("proceeding_statements")
+      .select(
+        "id, mp_id, speaker_name, function, viral_quote, viral_reason, viral_score, tone, start_datetime, proceeding_day:proceeding_days!inner(date, proceeding:proceedings!inner(number))",
+      )
+      .in("id", stmtIds)
+      .eq("term", term)
+      .not("viral_quote", "is", null)
+      .order("viral_score", { ascending: false, nullsFirst: false })
+      .limit(40);
+    if (sErr) throw sErr;
+    rows = ((stmtRows ?? []) as unknown as StmtRow[]).filter(
+      (r) => r.viral_quote && r.viral_quote.trim().length > 0,
+    );
+  }
+  if (rows.length === 0) {
+    const token = `druk nr ${printNumber}`;
+    const { data: stmtRows, error: sErr } = await sb
+      .from("proceeding_statements")
+      .select(
+        "id, mp_id, speaker_name, function, viral_quote, viral_reason, viral_score, tone, start_datetime, proceeding_day:proceeding_days!inner(date, proceeding:proceedings!inner(number))",
+      )
+      .eq("term", term)
+      .not("viral_quote", "is", null)
+      .filter("mentioned_entities->prints", "cs", JSON.stringify([token]))
+      .order("viral_score", { ascending: false, nullsFirst: false })
+      .limit(40);
+    if (sErr) throw sErr;
+    rows = ((stmtRows ?? []) as unknown as StmtRow[]).filter(
+      (r) => r.viral_quote && r.viral_quote.trim().length > 0,
+    );
+  }
   if (rows.length === 0) return [];
 
   // 4. Keep only the most-recent sitting (highest proceeding.number) —


### PR DESCRIPTION
## Summary

Adds a new "Cytaty z sali plenarnej" (Plenary Hall Quotes) section to process pages (`/proces/[term]/[number]`), displaying top-viral statements linked to the process with random sampling per request.

## Changes

- **`frontend/lib/db/statements.ts`**
  - New `ProcessCitation` type for citation display data
  - `getProcessCitations(term, printNumber, sampleSize)` function that:
    - Resolves all print IDs in a process (main + sub-prints via parent_number)
    - Fetches statement IDs linked via `statement_print_links` table (authoritative path)
    - Falls back to LLM-enriched `mentioned_entities->prints` when link table is empty (early-term backfill lag)
    - Filters to top-viral statements with non-empty quotes
    - Restricts to the most-recent sitting that discussed the process
    - Performs random server-side sampling (4 items by default) so cards rotate on reload
    - Resolves speaker club and photo URLs for sampled rows only
  - New `resolveMpPhotos()` helper to batch-fetch MP photos by term

- **`frontend/app/proces/[term]/[number]/_components/Citations.tsx`** (new file)
  - `Citations` component renders the section with sitting number subtitle
  - `CitationCard` component displays individual quotes with:
    - MP avatar, name, and role (hidden if generic "poseł")
    - Date in monospace uppercase
    - Blockquote with serif italic styling and decorative left border
    - Viral reason (LLM-generated context) if available
    - Link to full statement (`/mowa/[id]`)

- **`frontend/app/proces/[term]/[number]/page.tsx`**
  - Import and call `getProcessCitations()` with error handling (silent fallback to empty array)
  - Render `<Citations>` component after summary section
  - Graceful degradation: section disappears if enrichment hasn't run or no viral statements exist

## Implementation Notes

- **Two-path statement resolution:** Prefers structured `statement_print_links` table (mig 0060) when populated; falls back to LLM-enriched `mentioned_entities->prints` containing canonical "druk nr X" token during early-term backfill lag
- **Sitting filtering:** Keeps only statements from the highest `proceeding.number` (most recent discussion) to ensure "z ostatniej dyskusji" accuracy
- **Per-request randomization:** Uses `Math.random()` for client-side variety without database-side overhead
- **Lazy resolution:** Only fetches MP clubs and photos for the final sampled rows, not the full 40-item candidate pool
- **Error tolerance:** Wraps call in try-catch; missing enrichment or empty results silently hide the section rather than breaking the page

https://claude.ai/code/session_01QCDJyBCAEVu3XuabhxrWFN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Selected Quotes" section to process pages displaying relevant statements and citations with speaker information, date/meeting details, and viral context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miskibin/tygodnik-sejmowy/pull/54)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->