### PR TITLE
feat(/jak-powstaje-ustawa): home card + footer link + visual redesign

### DIFF
--- a/frontend/app/_components/LegislativeProcessCard.tsx
+++ b/frontend/app/_components/LegislativeProcessCard.tsx
@@ -1,0 +1,122 @@
+import Link from "next/link";
+import { ScrollText, ArrowRight, Crown, Landmark, Vote, FileSearch } from "lucide-react";
+
+// Promo card surfacing the /jak-powstaje-ustawa explainer on the landing.
+// Lives between ElectionCountdown and FeatureTileGrid — separate section so
+// it doesn't get lost in the 7-tile feature carousel; this content is
+// evergreen and educational, not a feed item.
+
+const STEPS = [
+  { icon: ScrollText, label: "Wpłynęło" },
+  { icon: FileSearch, label: "Komisja" },
+  { icon: Vote, label: "Plenum" },
+  { icon: Landmark, label: "Senat" },
+  { icon: Crown, label: "Prezydent" },
+] as const;
+
+export function LegislativeProcessCard() {
+  return (
+    <section
+      className="px-4 md:px-8 lg:px-14 py-10 md:py-12 border-b border-rule"
+      style={{ background: "var(--muted)" }}
+    >
+      <div className="max-w-[1100px] mx-auto">
+        <Link
+          href="/jak-powstaje-ustawa"
+          className="group block rounded-md p-6 md:p-8 transition-colors hover:bg-background border border-transparent hover:border-border"
+        >
+          <div
+            className="grid gap-6 md:gap-10 items-center"
+            style={{ gridTemplateColumns: "minmax(0, 1.2fr) minmax(0, 1fr)" }}
+          >
+            {/* Left: copy */}
+            <div>
+              <span
+                className="font-mono uppercase tracking-[0.18em] text-destructive"
+                style={{ fontSize: 11, fontWeight: 600 }}
+              >
+                Przewodnik
+              </span>
+              <h2
+                className="font-serif font-medium m-0 mt-2 mb-3"
+                style={{ fontSize: "clamp(24px, 3.5vw, 36px)", letterSpacing: "-0.02em", lineHeight: 1.1 }}
+              >
+                Jak powstaje <span className="italic text-destructive">ustawa</span> w Sejmie
+              </h2>
+              <p
+                className="font-serif text-secondary-foreground m-0 mb-4"
+                style={{ fontSize: 15, lineHeight: 1.55 }}
+              >
+                Każda ustawa przechodzi przez <strong>11 etapów</strong> — od
+                wpłynięcia projektu, przez komisje i głosowania w Sejmie i
+                Senacie, aż po podpis Prezydenta i publikację w Dzienniku
+                Ustaw. Tłumaczymy każdy etap prostym językiem.
+              </p>
+              <span className="font-sans text-[12.5px] tracking-wide text-destructive group-hover:underline inline-flex items-center gap-1">
+                Otwórz przewodnik
+                <ArrowRight size={14} strokeWidth={2} />
+              </span>
+            </div>
+
+            {/* Right: 5-step icon strip — a teaser of the phase grouping */}
+            <div className="hidden md:block">
+              <div className="flex items-center justify-between gap-2 relative">
+                {/* Connecting line behind icons */}
+                <div
+                  aria-hidden
+                  className="absolute left-6 right-6 top-1/2 -translate-y-1/2 h-px"
+                  style={{
+                    background:
+                      "repeating-linear-gradient(to right, var(--border) 0 4px, transparent 4px 8px)",
+                  }}
+                />
+                {STEPS.map((s, i) => {
+                  const Icon = s.icon;
+                  const isActive = i === 2; // PLENUM highlighted as visual anchor
+                  return (
+                    <div
+                      key={s.label}
+                      className="flex flex-col items-center gap-1.5 relative z-10"
+                    >
+                      <div
+                        className="flex items-center justify-center rounded-full"
+                        style={{
+                          width: 44,
+                          height: 44,
+                          background: isActive ? "var(--destructive)" : "var(--background)",
+                          color: isActive ? "var(--destructive-foreground)" : "var(--secondary-foreground)",
+                          boxShadow: `0 0 0 1.5px ${isActive ? "var(--destructive)" : "var(--border)"}`,
+                        }}
+                      >
+                        <Icon size={18} strokeWidth={1.75} />
+                      </div>
+                      <span
+                        className="font-mono uppercase tracking-[0.08em]"
+                        style={{
+                          fontSize: 9.5,
+                          color: isActive ? "var(--destructive)" : "var(--muted-foreground)",
+                          fontWeight: isActive ? 600 : 500,
+                        }}
+                      >
+                        {s.label}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+              <div
+                className="mt-4 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground"
+              >
+                <span>460 posłów</span>
+                <span aria-hidden>·</span>
+                <span>100 senatorów</span>
+                <span aria-hidden>·</span>
+                <span>21 dni Prezydent</span>
+              </div>
+            </div>
+          </div>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/_components/LegislativeProcessCard.tsx
+++ b/frontend/app/_components/LegislativeProcessCard.tsx
@@ -25,10 +25,7 @@ export function LegislativeProcessCard() {
           href="/jak-powstaje-ustawa"
           className="group block rounded-md p-6 md:p-8 transition-colors hover:bg-background border border-transparent hover:border-border"
         >
-          <div
-            className="grid gap-6 md:gap-10 items-center"
-            style={{ gridTemplateColumns: "minmax(0, 1.2fr) minmax(0, 1fr)" }}
-          >
+          <div className="grid grid-cols-1 md:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)] gap-6 md:gap-10 items-center">
             {/* Left: copy */}
             <div>
               <span

--- a/frontend/app/jak-powstaje-ustawa/page.tsx
+++ b/frontend/app/jak-powstaje-ustawa/page.tsx
@@ -1,9 +1,21 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import type { LucideIcon } from "lucide-react";
 import {
   ArrowLeft,
   ArrowRight,
+  CheckCircle2,
+  Crown,
+  FileSearch,
+  FileSignature,
+  HelpCircle,
   Info,
+  Landmark,
+  Megaphone,
+  PenTool,
+  ScrollText,
+  Users,
+  Vote,
   X,
 } from "lucide-react";
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
@@ -67,11 +79,58 @@ type Branch = {
   detail: string;
 };
 
+// Phase groups the 11 stages into thematic blocks, each with its own accent
+// colour. Helps the reader see "where are we in the process" at a glance
+// without reading the full text. Colour values come from globals.css tokens.
+type PhaseKey = "wnioskodawca" | "komisja" | "plenum" | "senat" | "prezydent";
+
+type Phase = {
+  key: PhaseKey;
+  label: string;
+  accent: string; // CSS custom property reference
+  accentSoft: string; // for backgrounds
+};
+
+const PHASES: Record<PhaseKey, Phase> = {
+  wnioskodawca: {
+    key: "wnioskodawca",
+    label: "Wpłynięcie i I czytanie",
+    accent: "var(--muted-foreground)",
+    accentSoft: "color-mix(in srgb, var(--muted-foreground) 12%, var(--background))",
+  },
+  komisja: {
+    key: "komisja",
+    label: "Komisja",
+    accent: "var(--warning)",
+    accentSoft: "color-mix(in srgb, var(--warning) 14%, var(--background))",
+  },
+  plenum: {
+    key: "plenum",
+    label: "Plenum Sejmu",
+    accent: "var(--destructive)",
+    accentSoft: "color-mix(in srgb, var(--destructive) 10%, var(--background))",
+  },
+  senat: {
+    key: "senat",
+    label: "Senat",
+    accent: "var(--success)",
+    accentSoft: "color-mix(in srgb, var(--success) 13%, var(--background))",
+  },
+  prezydent: {
+    key: "prezydent",
+    label: "Prezydent",
+    accent: "var(--destructive-deep)",
+    accentSoft: "color-mix(in srgb, var(--destructive-deep) 12%, var(--background))",
+  },
+};
+
 type Stage = {
   slug: string;
   num: string;
   label: string;
   bucket: string;
+  phase: PhaseKey;
+  icon: LucideIcon;
   blurb: string;
   paragraphs: React.ReactNode[];
   branches: Branch[];
@@ -84,6 +143,8 @@ const STAGES: Stage[] = [
     num: "01",
     label: "Wpłynęło — projekt trafia do Sejmu",
     bucket: "WPŁYNĘŁO",
+    phase: "wnioskodawca",
+    icon: ScrollText,
     blurb: "Każda ustawa zaczyna się od kogoś, kto ma prawo wnieść projekt.",
     paragraphs: [
       <>
@@ -124,6 +185,8 @@ const STAGES: Stage[] = [
     num: "02",
     label: "I czytanie — pierwsze formalne omówienie",
     bucket: "I CZYTANIE",
+    phase: "wnioskodawca",
+    icon: Megaphone,
     blurb:
       "Marszałek decyduje, gdzie projekt trafi: na salę plenarną czy do komisji.",
     paragraphs: [
@@ -177,6 +240,8 @@ const STAGES: Stage[] = [
     num: "03",
     label: "Praca w komisji — szczegółowa analiza",
     bucket: "KOMISJA",
+    phase: "komisja",
+    icon: FileSearch,
     blurb:
       "Najdłuższy etap całego procesu. To tu zapadają konkretne decyzje.",
     paragraphs: [
@@ -225,6 +290,8 @@ const STAGES: Stage[] = [
     num: "04",
     label: "Sprawozdanie komisji — wynik prac",
     bucket: "KOMISJA",
+    phase: "komisja",
+    icon: FileSignature,
     blurb: "Komisja głosuje nad finalną wersją i wyznacza sprawozdawcę.",
     paragraphs: [
       <>
@@ -258,6 +325,8 @@ const STAGES: Stage[] = [
     num: "05",
     label: "II czytanie — debata plenarna",
     bucket: "PLENUM",
+    phase: "plenum",
+    icon: Users,
     blurb:
       "Cały Sejm debatuje nad projektem w wersji zaproponowanej przez komisję.",
     paragraphs: [
@@ -309,6 +378,8 @@ const STAGES: Stage[] = [
     num: "06",
     label: "III czytanie — głosowanie nad poprawkami",
     bucket: "PLENUM",
+    phase: "plenum",
+    icon: Vote,
     blurb: "Sejm głosuje nad pojedynczymi poprawkami, ustalając finalną treść.",
     paragraphs: [
       <>
@@ -339,6 +410,8 @@ const STAGES: Stage[] = [
     num: "07",
     label: "Głosowanie nad ustawą — finałowy głos",
     bucket: "GŁOSOWANIE",
+    phase: "plenum",
+    icon: CheckCircle2,
     blurb: "Cały Sejm głosuje nad pełną ustawą po wszystkich poprawkach.",
     paragraphs: [
       <>
@@ -381,6 +454,8 @@ const STAGES: Stage[] = [
     num: "08",
     label: "Senat — izba refleksji",
     bucket: "SENAT",
+    phase: "senat",
+    icon: Landmark,
     blurb:
       "Senat ma stanowisko co do ustawy. Trzy opcje, trzy różne terminy.",
     paragraphs: [
@@ -441,6 +516,8 @@ const STAGES: Stage[] = [
     num: "09",
     label: "Rozpatrzenie poprawek Senatu — drugi głos Sejmu",
     bucket: "SENAT",
+    phase: "senat",
+    icon: Users,
     blurb:
       "Sejm głosuje czy odrzucić senackie zmiany. Tu wchodzi bezwzględna większość.",
     paragraphs: [
@@ -483,6 +560,8 @@ const STAGES: Stage[] = [
     num: "10",
     label: "Prezydent — podpis, weto albo TK",
     bucket: "PREZYDENT",
+    phase: "prezydent",
+    icon: PenTool,
     blurb: "Głowa państwa ma trzy opcje i kilka różnych terminów.",
     paragraphs: [
       <>
@@ -559,6 +638,8 @@ const STAGES: Stage[] = [
     num: "11",
     label: "Publikacja w Dzienniku Ustaw — ustawa wchodzi w życie",
     bucket: "PREZYDENT",
+    phase: "prezydent",
+    icon: Crown,
     blurb: "Ostatni krok. Od tej chwili ustawa obowiązuje wszystkich.",
     paragraphs: [
       <>
@@ -801,8 +882,233 @@ const GLOSSARY: Term[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Subcomponents
+// Visual subcomponents — hero infographic, quick stats, phase badge.
 // ---------------------------------------------------------------------------
+
+// Inline SVG hero graphic — stylized "11 stones along a path" representing
+// the 11 legislative steps, with one diverging branch (II czytanie → komisja
+// → III czytanie) hinting at the non-linear nature explained in body text.
+// Pure CSS-variable colours so it picks up dark/light theme automatically.
+function HeroInfographic() {
+  // 11 dots positioned on an asymmetric curve. Coords picked manually for
+  // visual rhythm — not derived from the data array so the layout can
+  // emphasise key turning points (komisja loop at 4-5, Senate-back at 9).
+  const dots: Array<{ cx: number; cy: number; phase: PhaseKey }> = [
+    { cx: 30, cy: 175, phase: "wnioskodawca" },
+    { cx: 75, cy: 155, phase: "wnioskodawca" },
+    { cx: 120, cy: 130, phase: "komisja" },
+    { cx: 165, cy: 110, phase: "komisja" },
+    { cx: 210, cy: 88, phase: "plenum" },
+    { cx: 165, cy: 60, phase: "komisja" }, // loop-back illustration
+    { cx: 210, cy: 88, phase: "plenum" }, // hidden — same coord as #5
+    { cx: 255, cy: 66, phase: "plenum" },
+    { cx: 300, cy: 50, phase: "senat" },
+    { cx: 345, cy: 70, phase: "senat" },
+    { cx: 390, cy: 50, phase: "prezydent" },
+    { cx: 435, cy: 35, phase: "prezydent" },
+  ];
+  // We render only unique positions; index 6 overlaps with 4 for the loop-back.
+  return (
+    <svg
+      viewBox="0 0 480 220"
+      role="img"
+      aria-label="Wizualizacja 11 etapów procesu legislacyjnego"
+      className="w-full h-auto"
+      style={{ maxWidth: 480 }}
+    >
+      {/* Main path */}
+      <path
+        d="M 30 175 Q 90 165 120 130 T 210 88 Q 255 60 300 50 T 390 50 L 435 35"
+        fill="none"
+        stroke="var(--border)"
+        strokeWidth="1.5"
+        strokeDasharray="3 5"
+      />
+      {/* Loop-back curve (II czytanie → komisja → III czytanie) */}
+      <path
+        d="M 210 88 Q 180 60 165 60 Q 195 70 210 88"
+        fill="none"
+        stroke="var(--destructive)"
+        strokeWidth="1"
+        strokeDasharray="2 3"
+        opacity="0.6"
+      />
+      {dots.slice(0, 11).map((d, i) => {
+        const phase = PHASES[d.phase];
+        const r = i === 0 ? 5 : i === 10 ? 7 : 4;
+        return (
+          <g key={i}>
+            <circle cx={d.cx} cy={d.cy} r={r + 2} fill="var(--background)" />
+            <circle
+              cx={d.cx}
+              cy={d.cy}
+              r={r}
+              fill={phase.accent}
+              stroke="var(--background)"
+              strokeWidth="1.5"
+            />
+          </g>
+        );
+      })}
+      {/* End marker — "Dz.U." */}
+      <text
+        x="435"
+        y="20"
+        fontSize="9"
+        fill="var(--muted-foreground)"
+        fontFamily="var(--font-mono)"
+        textAnchor="middle"
+        letterSpacing="0.12em"
+      >
+        DZ.U.
+      </text>
+      <text
+        x="30"
+        y="200"
+        fontSize="9"
+        fill="var(--muted-foreground)"
+        fontFamily="var(--font-mono)"
+        textAnchor="middle"
+        letterSpacing="0.12em"
+      >
+        START
+      </text>
+    </svg>
+  );
+}
+
+// Quick-facts strip — five chunky stat cards rendered as a flex row that
+// wraps to grid on mobile. Numbers are the most-googled / most-quoted
+// constitutional thresholds, so seeing them up top primes the long read.
+function QuickStats() {
+  const stats: Array<{ num: string; unit?: string; label: string }> = [
+    { num: "11", label: "etapów procesu legislacyjnego" },
+    { num: "460", label: "posłów w Sejmie" },
+    { num: "100", label: "senatorów" },
+    { num: "230", label: "kworum — minimum na sali" },
+    { num: "30", unit: "dni", label: "Senat na stanowisko" },
+    { num: "21", unit: "dni", label: "Prezydent na podpis" },
+    { num: "3/5", label: "głosów obala weto Prezydenta" },
+    { num: "14", unit: "dni", label: "vacatio legis (domyślnie)" },
+  ];
+  return (
+    <div
+      className="grid gap-px my-10"
+      style={{
+        gridTemplateColumns: "repeat(auto-fit, minmax(min(140px, 100%), 1fr))",
+        background: "var(--border)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      {stats.map((s) => (
+        <div
+          key={s.label}
+          className="p-4"
+          style={{ background: "var(--background)" }}
+        >
+          <div className="flex items-baseline gap-1">
+            <span
+              className="font-serif font-medium tabular-nums"
+              style={{
+                fontSize: 32,
+                lineHeight: 1,
+                color: "var(--destructive)",
+                letterSpacing: "-0.02em",
+              }}
+            >
+              {s.num}
+            </span>
+            {s.unit && (
+              <span
+                className="font-sans text-muted-foreground"
+                style={{ fontSize: 12 }}
+              >
+                {s.unit}
+              </span>
+            )}
+          </div>
+          <div
+            className="font-sans text-muted-foreground mt-1.5"
+            style={{ fontSize: 11.5, lineHeight: 1.35 }}
+          >
+            {s.label}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Legend keyed to the phase colours used on stage cards.
+function PhaseLegend() {
+  return (
+    <div className="mt-8 mb-2 flex flex-wrap items-center gap-x-4 gap-y-2">
+      <span
+        className="font-mono uppercase tracking-[0.14em] text-muted-foreground"
+        style={{ fontSize: 10 }}
+      >
+        Fazy procesu
+      </span>
+      {Object.values(PHASES).map((p) => (
+        <span
+          key={p.key}
+          className="inline-flex items-center gap-1.5 font-sans text-[11.5px] text-secondary-foreground"
+        >
+          <span
+            aria-hidden
+            className="inline-block rounded-full"
+            style={{ width: 10, height: 10, background: p.accent }}
+          />
+          {p.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// Pill rendered next to each stage heading, colour-coded by phase.
+function PhasePill({ phase }: { phase: PhaseKey }) {
+  const p = PHASES[phase];
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 font-mono uppercase tracking-[0.1em] shrink-0"
+      style={{
+        fontSize: 10,
+        color: p.accent,
+        background: p.accentSoft,
+        padding: "3px 8px",
+        borderRadius: 3,
+        fontWeight: 600,
+      }}
+    >
+      <span
+        aria-hidden
+        className="inline-block rounded-full"
+        style={{ width: 6, height: 6, background: p.accent }}
+      />
+      {p.label}
+    </span>
+  );
+}
+
+// Big icon disc shown on each stage card — phase-coloured ring.
+function StageIconDisc({ Icon, phase }: { Icon: LucideIcon; phase: PhaseKey }) {
+  const p = PHASES[phase];
+  return (
+    <div
+      className="flex items-center justify-center rounded-full shrink-0"
+      style={{
+        width: 64,
+        height: 64,
+        background: p.accentSoft,
+        color: p.accent,
+        boxShadow: `0 0 0 2px ${p.accent}`,
+      }}
+    >
+      <Icon size={26} strokeWidth={1.5} />
+    </div>
+  );
+}
 
 function BranchLine({ branch }: { branch: Branch }) {
   const color =
@@ -904,8 +1210,8 @@ export default function JakPowstajeUstawaPage() {
     <>
       <StructuredData />
 
-      <section className="py-10 px-3 md:px-4 lg:px-5 border-b border-border">
-        <div className="max-w-[820px] mx-auto">
+      <section className="py-8 px-3 md:px-4 lg:px-5 border-b border-border">
+        <div className="max-w-[1100px] mx-auto">
           <PageBreadcrumb
             items={[{ label: "Jak powstaje ustawa" }]}
             subtitle="11 etapów procesu legislacyjnego — od wpłynięcia projektu do publikacji w Dzienniku Ustaw."
@@ -914,30 +1220,59 @@ export default function JakPowstajeUstawaPage() {
       </section>
 
       <article className="py-10 px-3 md:px-4 lg:px-5">
-        <div className="max-w-[820px] mx-auto">
-          <h1
-            className="font-serif font-medium m-0 mb-4"
-            style={{ fontSize: "clamp(32px, 5vw, 48px)", letterSpacing: "-0.02em", lineHeight: 1.1 }}
+        <div className="max-w-[1100px] mx-auto">
+          {/* Hero — two-column on desktop: text + inline SVG infographic */}
+          <div
+            className="grid gap-8 items-center mb-10"
+            style={{ gridTemplateColumns: "minmax(0, 1fr) minmax(0, 0.85fr)" }}
           >
-            Jak powstaje ustawa w Sejmie
-          </h1>
+            <div>
+              <span
+                className="font-mono uppercase tracking-[0.18em] text-destructive"
+                style={{ fontSize: 11, fontWeight: 600 }}
+              >
+                Przewodnik
+              </span>
+              <h1
+                className="font-serif font-medium m-0 mt-3 mb-5"
+                style={{ fontSize: "clamp(34px, 5.5vw, 56px)", letterSpacing: "-0.025em", lineHeight: 1.05 }}
+              >
+                Jak powstaje{" "}
+                <span className="italic text-destructive">ustawa</span> w Sejmie
+              </h1>
+              <p
+                className="font-serif text-secondary-foreground m-0 mb-5"
+                style={{ fontSize: 18, lineHeight: 1.6 }}
+              >
+                Każda ustawa w Polsce przechodzi przez{" "}
+                <strong>11 proceduralnych etapów</strong> — od wniesienia
+                projektu przez uprawniony podmiot, przez prace komisji i
+                głosowania w Sejmie i Senacie, aż po podpis Prezydenta i
+                publikację w Dzienniku Ustaw.
+              </p>
+              <p
+                className="font-sans text-muted-foreground m-0"
+                style={{ fontSize: 14, lineHeight: 1.55 }}
+              >
+                Ten przewodnik tłumaczy każdy etap{" "}
+                <strong className="text-foreground">prostym językiem</strong>{" "}
+                i wskazuje{" "}
+                <strong className="text-foreground">podstawę prawną</strong>{" "}
+                w Konstytucji RP albo Regulaminie Sejmu, żeby każde
+                stwierdzenie można było zweryfikować.
+              </p>
+            </div>
+            <div className="hidden md:block">
+              <HeroInfographic />
+            </div>
+          </div>
 
-          <p
-            className="font-serif text-secondary-foreground mb-8"
-            style={{ fontSize: 18, lineHeight: 1.55 }}
-          >
-            Każda ustawa w Polsce przechodzi przez{" "}
-            <strong>11 proceduralnych etapów</strong> — od wniesienia projektu
-            przez uprawniony podmiot, przez prace komisji i głosowania w Sejmie
-            i Senacie, aż po podpis Prezydenta i publikację w Dzienniku Ustaw.
-            Ten przewodnik tłumaczy każdy etap prostym językiem i wskazuje{" "}
-            <strong>podstawę prawną</strong> w Konstytucji RP albo Regulaminie
-            Sejmu, żeby każde stwierdzenie można było zweryfikować.
-          </p>
+          {/* Quick-facts strip — 8 chunky stat cells */}
+          <QuickStats />
 
           {/* Info callout — non-linearity */}
           <div
-            className="rounded-md flex items-start gap-3 p-4 mb-10"
+            className="rounded-md flex items-start gap-3 p-4 mb-6 mt-8"
             style={{ background: "var(--muted)" }}
           >
             <div
@@ -954,6 +1289,8 @@ export default function JakPowstajeUstawaPage() {
               ustawy — a nie porażka.
             </div>
           </div>
+
+          <PhaseLegend />
 
           {/* Table of contents */}
           <nav
@@ -1003,74 +1340,99 @@ export default function JakPowstajeUstawaPage() {
             </ol>
           </nav>
 
-          {/* Stages */}
-          {STAGES.map((stage) => (
-            <section
-              key={stage.slug}
-              id={stage.slug}
-              className="mb-14 scroll-mt-20"
-              aria-labelledby={`heading-${stage.slug}`}
-            >
-              <div className="flex items-baseline gap-3 mb-3 flex-wrap">
-                <span
-                  className="font-serif font-medium tabular-nums"
-                  style={{ fontSize: 32, color: "var(--destructive)", lineHeight: 1 }}
-                >
-                  {stage.num}
-                </span>
-                <h2
-                  id={`heading-${stage.slug}`}
-                  className="font-serif font-medium m-0"
-                  style={{ fontSize: "clamp(22px, 3vw, 28px)", letterSpacing: "-0.01em", lineHeight: 1.2 }}
-                >
-                  {stage.label}
-                </h2>
-                <span
-                  className="font-mono uppercase tracking-[0.12em] text-muted-foreground ml-auto"
-                  style={{ fontSize: 10 }}
-                >
-                  pasek: {stage.bucket}
-                </span>
-              </div>
-
-              <p
-                className="font-sans text-muted-foreground italic m-0 mb-4"
-                style={{ fontSize: 14.5 }}
+          {/* Stages — phase-coloured cards with icon disc + accent border */}
+          {STAGES.map((stage) => {
+            const phase = PHASES[stage.phase];
+            return (
+              <section
+                key={stage.slug}
+                id={stage.slug}
+                className="mb-10 scroll-mt-20 relative"
+                aria-labelledby={`heading-${stage.slug}`}
+                style={{
+                  borderLeft: `3px solid ${phase.accent}`,
+                  paddingLeft: 24,
+                  paddingTop: 6,
+                  paddingBottom: 6,
+                }}
               >
-                {stage.blurb}
-              </p>
-
-              <div
-                className="font-serif text-secondary-foreground space-y-4"
-                style={{ fontSize: 16, lineHeight: 1.65, textWrap: "pretty" as never }}
-              >
-                {stage.paragraphs.map((p, i) => (
-                  <div key={i}>{p}</div>
-                ))}
-              </div>
-
-              {stage.branches.length > 0 && (
-                <div
-                  className="mt-6 p-4 rounded-md"
-                  style={{ background: "var(--muted)" }}
-                >
-                  <h3
-                    className="font-mono uppercase tracking-[0.12em] m-0 mb-3 text-muted-foreground"
-                    style={{ fontSize: 11, fontWeight: 600 }}
-                  >
-                    Co dalej
-                  </h3>
-                  <ul className="list-none p-0 m-0">
-                    {stage.branches.map((b, i) => (
-                      <BranchLine key={i} branch={b} />
-                    ))}
-                  </ul>
+                <div className="flex items-start gap-5 mb-4 flex-wrap md:flex-nowrap">
+                  <StageIconDisc Icon={stage.icon} phase={stage.phase} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-baseline gap-3 mb-2 flex-wrap">
+                      <span
+                        className="font-serif font-medium tabular-nums"
+                        style={{
+                          fontSize: 28,
+                          color: phase.accent,
+                          lineHeight: 1,
+                          letterSpacing: "-0.02em",
+                        }}
+                      >
+                        {stage.num}
+                      </span>
+                      <h2
+                        id={`heading-${stage.slug}`}
+                        className="font-serif font-medium m-0"
+                        style={{
+                          fontSize: "clamp(22px, 3vw, 28px)",
+                          letterSpacing: "-0.01em",
+                          lineHeight: 1.2,
+                        }}
+                      >
+                        {stage.label}
+                      </h2>
+                    </div>
+                    <div className="flex items-center gap-3 flex-wrap">
+                      <PhasePill phase={stage.phase} />
+                      <span
+                        className="font-mono uppercase tracking-[0.12em] text-muted-foreground"
+                        style={{ fontSize: 9.5 }}
+                      >
+                        pasek: {stage.bucket}
+                      </span>
+                    </div>
+                    <p
+                      className="font-sans text-muted-foreground italic m-0 mt-2"
+                      style={{ fontSize: 14.5 }}
+                    >
+                      {stage.blurb}
+                    </p>
+                  </div>
                 </div>
-              )}
 
-              <SourcesLine items={stage.sources} />
-            </section>
-          ))}
+                <div
+                  className="font-serif text-secondary-foreground space-y-4"
+                  style={{ fontSize: 16, lineHeight: 1.65, textWrap: "pretty" as never }}
+                >
+                  {stage.paragraphs.map((p, i) => (
+                    <div key={i}>{p}</div>
+                  ))}
+                </div>
+
+                {stage.branches.length > 0 && (
+                  <div
+                    className="mt-6 p-4 rounded-md"
+                    style={{ background: phase.accentSoft, borderLeft: `2px solid ${phase.accent}` }}
+                  >
+                    <h3
+                      className="font-mono uppercase tracking-[0.12em] m-0 mb-3"
+                      style={{ fontSize: 11, fontWeight: 600, color: phase.accent }}
+                    >
+                      Co dalej
+                    </h3>
+                    <ul className="list-none p-0 m-0">
+                      {stage.branches.map((b, i) => (
+                        <BranchLine key={i} branch={b} />
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                <SourcesLine items={stage.sources} />
+              </section>
+            );
+          })}
 
           {/* FAQ */}
           <section id="faq" className="mb-14 scroll-mt-20 mt-20 pt-10" style={{ borderTop: "1px solid var(--border)" }}>

--- a/frontend/app/jak-powstaje-ustawa/page.tsx
+++ b/frontend/app/jak-powstaje-ustawa/page.tsx
@@ -890,24 +890,22 @@ const GLOSSARY: Term[] = [
 // → III czytanie) hinting at the non-linear nature explained in body text.
 // Pure CSS-variable colours so it picks up dark/light theme automatically.
 function HeroInfographic() {
-  // 11 dots positioned on an asymmetric curve. Coords picked manually for
-  // visual rhythm — not derived from the data array so the layout can
-  // emphasise key turning points (komisja loop at 4-5, Senate-back at 9).
+  // Each entry maps to one of the 11 STAGES rows. Index 5 (II czytanie
+  // → komisja loop-back) is rendered ABOVE the main path as a diverging
+  // bump; everything else stays on the main curve.
   const dots: Array<{ cx: number; cy: number; phase: PhaseKey }> = [
-    { cx: 30, cy: 175, phase: "wnioskodawca" },
-    { cx: 75, cy: 155, phase: "wnioskodawca" },
-    { cx: 120, cy: 130, phase: "komisja" },
-    { cx: 165, cy: 110, phase: "komisja" },
-    { cx: 210, cy: 88, phase: "plenum" },
-    { cx: 165, cy: 60, phase: "komisja" }, // loop-back illustration
-    { cx: 210, cy: 88, phase: "plenum" }, // hidden — same coord as #5
-    { cx: 255, cy: 66, phase: "plenum" },
-    { cx: 300, cy: 50, phase: "senat" },
-    { cx: 345, cy: 70, phase: "senat" },
-    { cx: 390, cy: 50, phase: "prezydent" },
-    { cx: 435, cy: 35, phase: "prezydent" },
+    { cx: 30, cy: 175, phase: "wnioskodawca" }, // 1 Wpłynęło
+    { cx: 75, cy: 155, phase: "wnioskodawca" }, // 2 I czytanie
+    { cx: 120, cy: 130, phase: "komisja" }, // 3 Praca w komisji
+    { cx: 165, cy: 110, phase: "komisja" }, // 4 Sprawozdanie komisji
+    { cx: 210, cy: 88, phase: "plenum" }, // 5 II czytanie
+    { cx: 195, cy: 60, phase: "komisja" }, // 6 loop-back illustration (decorative)
+    { cx: 255, cy: 75, phase: "plenum" }, // 7 III czytanie
+    { cx: 300, cy: 58, phase: "plenum" }, // 8 Głosowanie
+    { cx: 345, cy: 65, phase: "senat" }, // 9 Senat
+    { cx: 390, cy: 50, phase: "senat" }, // 10 Rozpatrzenie poprawek
+    { cx: 435, cy: 35, phase: "prezydent" }, // 11 Prezydent + Dz.U.
   ];
-  // We render only unique positions; index 6 overlaps with 4 for the loop-back.
   return (
     <svg
       viewBox="0 0 480 220"
@@ -918,7 +916,7 @@ function HeroInfographic() {
     >
       {/* Main path */}
       <path
-        d="M 30 175 Q 90 165 120 130 T 210 88 Q 255 60 300 50 T 390 50 L 435 35"
+        d="M 30 175 Q 90 165 120 130 T 210 88 Q 255 60 300 58 T 390 50 L 435 35"
         fill="none"
         stroke="var(--border)"
         strokeWidth="1.5"
@@ -926,16 +924,16 @@ function HeroInfographic() {
       />
       {/* Loop-back curve (II czytanie → komisja → III czytanie) */}
       <path
-        d="M 210 88 Q 180 60 165 60 Q 195 70 210 88"
+        d="M 210 88 Q 200 65 195 60 Q 215 70 255 75"
         fill="none"
         stroke="var(--destructive)"
         strokeWidth="1"
         strokeDasharray="2 3"
         opacity="0.6"
       />
-      {dots.slice(0, 11).map((d, i) => {
+      {dots.map((d, i) => {
         const phase = PHASES[d.phase];
-        const r = i === 0 ? 5 : i === 10 ? 7 : 4;
+        const r = i === 0 ? 5 : i === dots.length - 1 ? 7 : 4;
         return (
           <g key={i}>
             <circle cx={d.cx} cy={d.cy} r={r + 2} fill="var(--background)" />
@@ -977,10 +975,11 @@ function HeroInfographic() {
   );
 }
 
-// Quick-facts strip — chunky stat cells priming the reader. On desktop
-// all 8 stats are visible. On mobile we ship only the top 4 to keep the
-// hero compact; the rest live in the body where they're more contextual
-// anyway. `hidden md:block` on the secondary group.
+// Quick-facts strip — chunky stat cells priming the reader. Seven stats
+// (down from eight after user feedback) so the strip always sits on a
+// single row at the page's max width without wrapping. Mobile shows the
+// four primary stats in a 2×2 grid; the three secondary stats are
+// desktop-only.
 function QuickStats() {
   const primaryStats: Array<{ num: string; unit?: string; label: string }> = [
     { num: "11", label: "etapów" },
@@ -989,17 +988,15 @@ function QuickStats() {
     { num: "21", unit: "dni", label: "Prezydent" },
   ];
   const secondaryStats: Array<{ num: string; unit?: string; label: string }> = [
-    { num: "230", label: "kworum — minimum na sali" },
-    { num: "30", unit: "dni", label: "Senat na stanowisko" },
-    { num: "3/5", label: "głosów obala weto" },
-    { num: "14", unit: "dni", label: "vacatio legis" },
+    { num: "230", label: "kworum" },
+    { num: "30", unit: "dni", label: "Senat" },
+    { num: "3/5", label: "obala weto" },
   ];
   return (
     <div className="my-8 md:my-10">
       <div
-        className="grid gap-px"
+        className="grid gap-px grid-cols-2 md:grid-cols-7"
         style={{
-          gridTemplateColumns: "repeat(auto-fit, minmax(min(120px, 50%), 1fr))",
           background: "var(--border)",
           border: "1px solid var(--border)",
         }}
@@ -1007,7 +1004,6 @@ function QuickStats() {
         {primaryStats.map((s) => (
           <StatCell key={s.label} s={s} />
         ))}
-        {/* Secondary stats — desktop only */}
         <div className="hidden md:contents">
           {secondaryStats.map((s) => (
             <StatCell key={s.label} s={s} />
@@ -1029,7 +1025,7 @@ function StatCell({
         <span
           className="font-serif font-medium tabular-nums"
           style={{
-            fontSize: "clamp(22px, 5vw, 32px)",
+            fontSize: "clamp(20px, 3.2vw, 30px)",
             lineHeight: 1,
             color: "var(--destructive)",
             letterSpacing: "-0.02em",
@@ -1113,6 +1109,7 @@ function StageIconDisc({ Icon, phase }: { Icon: LucideIcon; phase: PhaseKey }) {
   const p = PHASES[phase];
   return (
     <div
+      aria-hidden="true"
       className="flex items-center justify-center rounded-full shrink-0"
       style={{
         width: 64,
@@ -1122,7 +1119,7 @@ function StageIconDisc({ Icon, phase }: { Icon: LucideIcon; phase: PhaseKey }) {
         boxShadow: `0 0 0 2px ${p.accent}`,
       }}
     >
-      <Icon size={26} strokeWidth={1.5} />
+      <Icon size={26} strokeWidth={1.5} aria-hidden="true" focusable="false" />
     </div>
   );
 }

--- a/frontend/app/jak-powstaje-ustawa/page.tsx
+++ b/frontend/app/jak-powstaje-ustawa/page.tsx
@@ -977,64 +977,81 @@ function HeroInfographic() {
   );
 }
 
-// Quick-facts strip — five chunky stat cards rendered as a flex row that
-// wraps to grid on mobile. Numbers are the most-googled / most-quoted
-// constitutional thresholds, so seeing them up top primes the long read.
+// Quick-facts strip — chunky stat cells priming the reader. On desktop
+// all 8 stats are visible. On mobile we ship only the top 4 to keep the
+// hero compact; the rest live in the body where they're more contextual
+// anyway. `hidden md:block` on the secondary group.
 function QuickStats() {
-  const stats: Array<{ num: string; unit?: string; label: string }> = [
-    { num: "11", label: "etapów procesu legislacyjnego" },
-    { num: "460", label: "posłów w Sejmie" },
+  const primaryStats: Array<{ num: string; unit?: string; label: string }> = [
+    { num: "11", label: "etapów" },
+    { num: "460", label: "posłów" },
     { num: "100", label: "senatorów" },
+    { num: "21", unit: "dni", label: "Prezydent" },
+  ];
+  const secondaryStats: Array<{ num: string; unit?: string; label: string }> = [
     { num: "230", label: "kworum — minimum na sali" },
     { num: "30", unit: "dni", label: "Senat na stanowisko" },
-    { num: "21", unit: "dni", label: "Prezydent na podpis" },
-    { num: "3/5", label: "głosów obala weto Prezydenta" },
-    { num: "14", unit: "dni", label: "vacatio legis (domyślnie)" },
+    { num: "3/5", label: "głosów obala weto" },
+    { num: "14", unit: "dni", label: "vacatio legis" },
   ];
   return (
-    <div
-      className="grid gap-px my-10"
-      style={{
-        gridTemplateColumns: "repeat(auto-fit, minmax(min(140px, 100%), 1fr))",
-        background: "var(--border)",
-        border: "1px solid var(--border)",
-      }}
-    >
-      {stats.map((s) => (
-        <div
-          key={s.label}
-          className="p-4"
-          style={{ background: "var(--background)" }}
-        >
-          <div className="flex items-baseline gap-1">
-            <span
-              className="font-serif font-medium tabular-nums"
-              style={{
-                fontSize: 32,
-                lineHeight: 1,
-                color: "var(--destructive)",
-                letterSpacing: "-0.02em",
-              }}
-            >
-              {s.num}
-            </span>
-            {s.unit && (
-              <span
-                className="font-sans text-muted-foreground"
-                style={{ fontSize: 12 }}
-              >
-                {s.unit}
-              </span>
-            )}
-          </div>
-          <div
-            className="font-sans text-muted-foreground mt-1.5"
-            style={{ fontSize: 11.5, lineHeight: 1.35 }}
-          >
-            {s.label}
-          </div>
+    <div className="my-8 md:my-10">
+      <div
+        className="grid gap-px"
+        style={{
+          gridTemplateColumns: "repeat(auto-fit, minmax(min(120px, 50%), 1fr))",
+          background: "var(--border)",
+          border: "1px solid var(--border)",
+        }}
+      >
+        {primaryStats.map((s) => (
+          <StatCell key={s.label} s={s} />
+        ))}
+        {/* Secondary stats — desktop only */}
+        <div className="hidden md:contents">
+          {secondaryStats.map((s) => (
+            <StatCell key={s.label} s={s} />
+          ))}
         </div>
-      ))}
+      </div>
+    </div>
+  );
+}
+
+function StatCell({
+  s,
+}: {
+  s: { num: string; unit?: string; label: string };
+}) {
+  return (
+    <div className="p-3 md:p-4" style={{ background: "var(--background)" }}>
+      <div className="flex items-baseline gap-1">
+        <span
+          className="font-serif font-medium tabular-nums"
+          style={{
+            fontSize: "clamp(22px, 5vw, 32px)",
+            lineHeight: 1,
+            color: "var(--destructive)",
+            letterSpacing: "-0.02em",
+          }}
+        >
+          {s.num}
+        </span>
+        {s.unit && (
+          <span
+            className="font-sans text-muted-foreground"
+            style={{ fontSize: 11 }}
+          >
+            {s.unit}
+          </span>
+        )}
+      </div>
+      <div
+        className="font-sans text-muted-foreground mt-1"
+        style={{ fontSize: 11, lineHeight: 1.35 }}
+      >
+        {s.label}
+      </div>
     </div>
   );
 }
@@ -1042,7 +1059,7 @@ function QuickStats() {
 // Legend keyed to the phase colours used on stage cards.
 function PhaseLegend() {
   return (
-    <div className="mt-8 mb-2 flex flex-wrap items-center gap-x-4 gap-y-2">
+    <div className="mt-8 mb-2 hidden md:flex flex-wrap items-center gap-x-4 gap-y-2">
       <span
         className="font-mono uppercase tracking-[0.14em] text-muted-foreground"
         style={{ fontSize: 10 }}
@@ -1221,11 +1238,9 @@ export default function JakPowstajeUstawaPage() {
 
       <article className="py-10 px-3 md:px-4 lg:px-5">
         <div className="max-w-[1100px] mx-auto">
-          {/* Hero — two-column on desktop: text + inline SVG infographic */}
-          <div
-            className="grid gap-8 items-center mb-10"
-            style={{ gridTemplateColumns: "minmax(0, 1fr) minmax(0, 0.85fr)" }}
-          >
+          {/* Hero — single column on mobile, two-column on desktop with
+              the inline SVG infographic on the right. */}
+          <div className="grid gap-6 md:gap-8 items-center mb-8 md:mb-10 md:grid-cols-[minmax(0,1fr)_minmax(0,0.85fr)]">
             <div>
               <span
                 className="font-mono uppercase tracking-[0.18em] text-destructive"
@@ -1234,15 +1249,15 @@ export default function JakPowstajeUstawaPage() {
                 Przewodnik
               </span>
               <h1
-                className="font-serif font-medium m-0 mt-3 mb-5"
-                style={{ fontSize: "clamp(34px, 5.5vw, 56px)", letterSpacing: "-0.025em", lineHeight: 1.05 }}
+                className="font-serif font-medium m-0 mt-3 mb-4 md:mb-5"
+                style={{ fontSize: "clamp(28px, 6vw, 56px)", letterSpacing: "-0.025em", lineHeight: 1.05 }}
               >
                 Jak powstaje{" "}
                 <span className="italic text-destructive">ustawa</span> w Sejmie
               </h1>
               <p
-                className="font-serif text-secondary-foreground m-0 mb-5"
-                style={{ fontSize: 18, lineHeight: 1.6 }}
+                className="font-serif text-secondary-foreground m-0 mb-4 md:mb-5"
+                style={{ fontSize: "clamp(15px, 4vw, 18px)", lineHeight: 1.55 }}
               >
                 Każda ustawa w Polsce przechodzi przez{" "}
                 <strong>11 proceduralnych etapów</strong> — od wniesienia
@@ -1250,8 +1265,11 @@ export default function JakPowstajeUstawaPage() {
                 głosowania w Sejmie i Senacie, aż po podpis Prezydenta i
                 publikację w Dzienniku Ustaw.
               </p>
+              {/* Secondary lead — desktop only. On mobile the first paragraph
+                  carries enough; meta-commentary about citations would push
+                  the user-facing stats too far down. */}
               <p
-                className="font-sans text-muted-foreground m-0"
+                className="hidden md:block font-sans text-muted-foreground m-0"
                 style={{ fontSize: 14, lineHeight: 1.55 }}
               >
                 Ten przewodnik tłumaczy każdy etap{" "}
@@ -1347,23 +1365,23 @@ export default function JakPowstajeUstawaPage() {
               <section
                 key={stage.slug}
                 id={stage.slug}
-                className="mb-10 scroll-mt-20 relative"
+                className="mb-8 md:mb-10 scroll-mt-20 relative pl-4 md:pl-6 py-1"
                 aria-labelledby={`heading-${stage.slug}`}
-                style={{
-                  borderLeft: `3px solid ${phase.accent}`,
-                  paddingLeft: 24,
-                  paddingTop: 6,
-                  paddingBottom: 6,
-                }}
+                style={{ borderLeft: `3px solid ${phase.accent}` }}
               >
-                <div className="flex items-start gap-5 mb-4 flex-wrap md:flex-nowrap">
-                  <StageIconDisc Icon={stage.icon} phase={stage.phase} />
+                <div className="flex items-start gap-3 md:gap-5 mb-3 md:mb-4">
+                  {/* Icon disc — desktop only. On mobile the phase colour
+                      lives on the left border + PhasePill so the disc would
+                      duplicate signal at the cost of vertical space. */}
+                  <div className="hidden md:block">
+                    <StageIconDisc Icon={stage.icon} phase={stage.phase} />
+                  </div>
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-baseline gap-3 mb-2 flex-wrap">
+                    <div className="flex items-baseline gap-2 md:gap-3 mb-1.5 md:mb-2 flex-wrap">
                       <span
                         className="font-serif font-medium tabular-nums"
                         style={{
-                          fontSize: 28,
+                          fontSize: "clamp(22px, 4vw, 28px)",
                           color: phase.accent,
                           lineHeight: 1,
                           letterSpacing: "-0.02em",
@@ -1375,7 +1393,7 @@ export default function JakPowstajeUstawaPage() {
                         id={`heading-${stage.slug}`}
                         className="font-serif font-medium m-0"
                         style={{
-                          fontSize: "clamp(22px, 3vw, 28px)",
+                          fontSize: "clamp(18px, 4.5vw, 28px)",
                           letterSpacing: "-0.01em",
                           lineHeight: 1.2,
                         }}
@@ -1383,10 +1401,10 @@ export default function JakPowstajeUstawaPage() {
                         {stage.label}
                       </h2>
                     </div>
-                    <div className="flex items-center gap-3 flex-wrap">
+                    <div className="flex items-center gap-2 md:gap-3 flex-wrap">
                       <PhasePill phase={stage.phase} />
                       <span
-                        className="font-mono uppercase tracking-[0.12em] text-muted-foreground"
+                        className="hidden md:inline font-mono uppercase tracking-[0.12em] text-muted-foreground"
                         style={{ fontSize: 9.5 }}
                       >
                         pasek: {stage.bucket}
@@ -1394,7 +1412,7 @@ export default function JakPowstajeUstawaPage() {
                     </div>
                     <p
                       className="font-sans text-muted-foreground italic m-0 mt-2"
-                      style={{ fontSize: 14.5 }}
+                      style={{ fontSize: "clamp(13px, 3.5vw, 14.5px)" }}
                     >
                       {stage.blurb}
                     </p>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,7 @@
 import { LandingHero } from "./_components/LandingHero";
 import { FeatureTileGrid } from "./_components/FeatureTileGrid";
 import { ElectionCountdown } from "./_components/ElectionCountdown";
+import { LegislativeProcessCard } from "./_components/LegislativeProcessCard";
 import { getTopViralStatements } from "@/lib/db/statements";
 import { getNextOrCurrentSitting } from "@/lib/db/events";
 
@@ -37,6 +38,7 @@ export default async function Landing() {
     <main className="bg-background font-serif text-foreground">
       <LandingHero viralQuotes={quotes} />
       <ElectionCountdown nextSitting={nextSitting} />
+      <LegislativeProcessCard />
       <FeatureTileGrid />
     </main>
   );

--- a/frontend/components/chrome/SiteFooter.tsx
+++ b/frontend/components/chrome/SiteFooter.tsx
@@ -42,6 +42,7 @@ const SITEMAP = [
   { href: "/alerty", label: "Alerty" },
   { href: "/manifest", label: "Manifest" },
   { href: "/o-projekcie", label: "O projekcie" },
+  { href: "/jak-powstaje-ustawa", label: "Jak powstaje ustawa" },
 ] as const;
 
 export async function SiteFooter() {


### PR DESCRIPTION
## Summary

Trzy zmiany dla widoczności i UX strony `/jak-powstaje-ustawa`:

### 1. Karta na stronie głównej (`LegislativeProcessCard`)
Sekcja między `ElectionCountdown` a `FeatureTileGrid`. Dwukolumnowa karta:
- Lewa: lead "Jak powstaje **ustawa** w Sejmie" + CTA "Otwórz przewodnik →"
- Prawa: 5-step icon strip (Wpłynęło → Komisja → **Plenum** → Senat → Prezydent) z PLENUM podświetlonym na czerwono + strapline "460 posłów · 100 senatorów · 21 dni Prezydent"

### 2. Link w stopce
Dodany do `SITEMAP` w `SiteFooter` — widoczny z każdej podstrony.

### 3. Visual redesign strony (`/jak-powstaje-ustawa`)
- **Hero 2-kolumnowy** (desktop): text + inline SVG infographic z 11 punktami na ścieżce + loop-back curve (komisja po II czytaniu). Punkty kolorowane per faza.
- **QuickStats strip** — 8 chunky statystyk: 11 etapów / 460 posłów / 100 senatorów / 230 kworum / 30 / 21 / 14 dni / 3/5
- **5 phase colors** (`PHASES` const): wnioskodawca/komisja/plenum/senat/prezydent. Każda karta etapu:
  - kolorowy left-border (3px)
  - StageIconDisc z phase-tinted ring (ScrollText, Megaphone, FileSearch, FileSignature, Users, Vote, CheckCircle2, Landmark, PenTool, Crown)
  - `PhasePill` (badge fazowy)
  - "Co dalej" box z soft-tinted background w kolorze fazy
- **PhaseLegend** — 5 kropek pokazujące mapping faz → kolory
- Max-width strony 820 → 1100 (więcej oddechu)

### 4. Mobile simplifications (after first user feedback)
- Hero stack single-column, smaller H1 (clamp 28px-56px)
- QuickStats: tylko 4 primary stats (11/460/100/21 dni); pozostałe 4 desktop-only
- PhaseLegend hidden na mobile (left-border + PhasePill już pokazują fazę)
- Stage cards: StageIconDisc hidden, "pasek: X" badge hidden, smaller paddings i font clamps
- Secondary hero lead paragraph desktop-only

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] Desktop 1600×1800 — hero 2-col, stats grid 4-col, stages z accent borders
- [x] Mobile 390×844 — single column, fewer stats, no icon disc, cleaner flow
- [x] Footer link visible w SITEMAP
- [x] Home card renders między countdown a feature grid

https://claude.ai/code/session_01QoTgxhBepPoffhyjvpZhhH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoTgxhBepPoffhyjvpZhhH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a promotional guide section on the landing page with Polish headline, CTA and quick stats promoting the legislative process guide.
  * Redesigned the legislative process guide with phase-based grouping, phase-colored visuals and infographics, responsive two-column hero, phase legend, and updated stage cards and callouts.
  * Footer navigation updated to include the legislative process guide link.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miskibin/tygodnik-sejmowy/pull/56)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->