### PR TITLE
Add /posiedzenie/mockup route with hardcoded proceeding data & UI

### DIFF
--- a/frontend/app/posiedzenie/mockup/_components/AgendaList.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/AgendaList.tsx
@@ -111,7 +111,7 @@ function ToneBar({ tones }: { tones: Partial<Record<Tone, number>> }) {
 }
 
 function VoteMini({ v }: { v: VoteType }) {
-  const accent = verdictInk(v.result);
+  const accent = verdictInk(v.result, v.motionPolarity);
   return (
     <div
       className="block no-underline text-inherit"
@@ -225,7 +225,7 @@ function QuoteMini({ q }: { q: ViralQuote }) {
           textWrap: "pretty",
         }}
       >
-        „{q.text}"
+        „{q.text}”
       </p>
       <div className="flex items-center gap-2 flex-wrap">
         <MPAvatarPhoto name={q.speaker} size={28} />
@@ -424,10 +424,10 @@ function PunktCenter({ p }: { p: AgendaPoint }) {
           <StageBadge key={s} label={s} />
         ))}
         {p.prints.map((d) => (
-          <PrintRef key={d.number} term={d.term} number={d.number} />
+          <PrintRef key={`${d.term}-${d.number}`} term={d.term} number={d.number} />
         ))}
         {p.procesy.map((pr) => (
-          <ProcessRef key={pr.number} term={pr.term} number={pr.number} />
+          <ProcessRef key={`${pr.term}-${pr.number}`} term={pr.term} number={pr.number} />
         ))}
       </div>
 
@@ -476,7 +476,7 @@ function PunktCenter({ p }: { p: AgendaPoint }) {
             maxWidth: 720,
           }}
         >
-          „{p.title}"
+          „{p.title}”
         </p>
       </details>
 

--- a/frontend/app/posiedzenie/mockup/_components/AgendaList.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/AgendaList.tsx
@@ -1,0 +1,589 @@
+// "Porządek obrad" — the main agenda list. Filterable, chronological.
+// Each row: ord+time rail / title+summary+stats / vote OR quote OR planned.
+// On mobile the 3-column grid stacks; the rail collapses to a horizontal
+// "PKT N · HH:MM" strip.
+
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { MPAvatarPhoto } from "@/components/tygodnik/MPAvatar";
+import { ClubBadge } from "@/components/clubs/ClubBadge";
+import { TopicChips } from "@/components/tygodnik/atoms/TopicChips";
+import { ToneBadge } from "@/components/statement/ToneBadge";
+import { TOPICS } from "@/lib/topics";
+import {
+  MOCK,
+  type AgendaPoint,
+  type Vote as VoteType,
+  type ViralQuote,
+  type Tone,
+} from "../data";
+import { TONE_INK, TONE_LABEL, verdictInk } from "../tokens";
+import { Kicker, SectionHead } from "./SectionHead";
+
+type FilterId = "all" | "done" | "planned" | "vote" | "flagship";
+
+const FILTERS: { id: FilterId; label: (n: number) => string; pred: (p: AgendaPoint) => boolean }[] = [
+  { id: "all", label: (n) => `wszystkie · ${n}`, pred: () => true },
+  { id: "done", label: (n) => `już za nami · ${n}`, pred: (p) => !p.planned },
+  { id: "planned", label: (n) => `zaplanowane · ${n}`, pred: (p) => p.planned },
+  { id: "vote", label: (n) => `z głosowaniem · ${n}`, pred: (p) => !!p.vote },
+  { id: "flagship", label: (n) => `kluczowe · ${n}`, pred: (p) => p.importance === "flagship" },
+];
+
+function StageBadge({ label }: { label: string }) {
+  return (
+    <span
+      className="font-mono uppercase"
+      style={{
+        fontSize: 9.5,
+        color: "var(--background)",
+        background: "var(--foreground)",
+        padding: "3px 8px",
+        letterSpacing: "0.14em",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function PrintRef({ number, term }: { term: number; number: string }) {
+  return (
+    <Link
+      href={`/druk/${term}/${number}`}
+      className="font-mono uppercase no-underline hover:bg-muted transition-colors"
+      style={{
+        fontSize: 9.5,
+        color: "var(--secondary-foreground)",
+        padding: "3px 8px",
+        letterSpacing: "0.14em",
+        border: "1px solid var(--border)",
+      }}
+    >
+      druk {number}
+    </Link>
+  );
+}
+
+function ProcessRef({ number, term }: { term: number; number: string }) {
+  return (
+    <Link
+      href={`/proces/${term}/${number}`}
+      className="font-mono uppercase no-underline hover:bg-muted transition-colors"
+      style={{
+        fontSize: 9.5,
+        color: "var(--destructive-deep)",
+        padding: "3px 8px",
+        letterSpacing: "0.14em",
+        border: "1px solid var(--destructive-deep)",
+      }}
+    >
+      proces {number}
+    </Link>
+  );
+}
+
+function ToneBar({ tones }: { tones: Partial<Record<Tone, number>> }) {
+  const sum = Object.values(tones).reduce<number>((s, v) => s + (v ?? 0), 0);
+  if (sum === 0) return null;
+  return (
+    <div className="mt-4">
+      <div
+        className="flex"
+        style={{ height: 8, background: "var(--secondary)", border: "1px solid var(--border)" }}
+        aria-hidden
+      >
+        {Object.entries(tones).map(([k, v]) => (
+          <div
+            key={k}
+            style={{
+              width: `${((v ?? 0) / sum) * 100}%`,
+              background: TONE_INK[k as Tone],
+            }}
+            title={`${TONE_LABEL[k as Tone]}: ${v}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function VoteMini({ v }: { v: VoteType }) {
+  const accent = verdictInk(v.result);
+  return (
+    <div
+      className="block no-underline text-inherit"
+      style={{
+        padding: "14px 16px",
+        border: "1.5px solid var(--foreground)",
+        background: "var(--background)",
+      }}
+    >
+      <Kicker className="mb-1.5">głosowanie · {v.time}</Kicker>
+      <div
+        className="font-serif italic font-medium"
+        style={{
+          fontSize: 22,
+          color: accent,
+          letterSpacing: "-0.02em",
+          lineHeight: 1,
+          marginBottom: 4,
+        }}
+      >
+        {v.result}
+      </div>
+      {v.subtitle && (
+        <div
+          className="font-sans"
+          style={{
+            fontSize: 11,
+            color: "var(--muted-foreground)",
+            marginBottom: 8,
+          }}
+        >
+          {v.subtitle}
+        </div>
+      )}
+      <div
+        className="font-sans"
+        style={{ fontSize: 12, color: "var(--secondary-foreground)", marginBottom: 10 }}
+      >
+        większością <b>{v.za}–{v.przeciw}</b>, różnica {v.margin}
+      </div>
+
+      <div
+        className="flex"
+        style={{ height: 8, border: "1px solid var(--border)" }}
+        aria-hidden
+      >
+        <div style={{ width: `${(v.za / 460) * 100}%`, background: "var(--success)" }} />
+        <div style={{ width: `${(v.przeciw / 460) * 100}%`, background: "var(--destructive)" }} />
+        <div style={{ width: `${(v.wstrzym / 460) * 100}%`, background: "var(--warning)" }} />
+        <div style={{ width: `${(v.nieob / 460) * 100}%`, background: "var(--border)" }} />
+      </div>
+
+      {v.byClub && (
+        <div className="mt-3 grid gap-1.5" style={{ gridTemplateColumns: "repeat(4, 1fr)" }}>
+          {Object.entries(v.byClub).map(([club, cb]) => {
+            const total = (cb.za + cb.pr + cb.ws + Math.max(0, cb.nb)) || 1;
+            return (
+              <div key={club} title={`${club}: ZA ${cb.za}, PR ${cb.pr}, WS ${cb.ws}`}>
+                <div
+                  className="font-mono"
+                  style={{
+                    fontSize: 8.5,
+                    color: "var(--secondary-foreground)",
+                    fontWeight: 700,
+                    marginBottom: 2,
+                  }}
+                >
+                  {club.slice(0, 4)}
+                </div>
+                <div className="flex" style={{ height: 4 }} aria-hidden>
+                  <div style={{ width: `${(cb.za / total) * 100}%`, background: "var(--success)" }} />
+                  <div style={{ width: `${(cb.pr / total) * 100}%`, background: "var(--destructive)" }} />
+                  <div style={{ width: `${(cb.ws / total) * 100}%`, background: "var(--warning)" }} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div
+        className="mt-3 font-mono uppercase"
+        style={{
+          fontSize: 10,
+          color: "var(--destructive-deep)",
+          letterSpacing: "0.14em",
+        }}
+      >
+        całe głosowanie →
+      </div>
+    </div>
+  );
+}
+
+function QuoteMini({ q }: { q: ViralQuote }) {
+  return (
+    <div
+      style={{
+        padding: "14px 16px",
+        borderLeft: "3px solid var(--destructive-deep)",
+        background: "var(--secondary)",
+      }}
+    >
+      <Kicker className="mb-2">cytat punktu</Kicker>
+      <p
+        className="font-serif italic m-0 mb-2.5"
+        style={{
+          fontSize: 15,
+          lineHeight: 1.4,
+          color: "var(--foreground)",
+          textWrap: "pretty",
+        }}
+      >
+        „{q.text}"
+      </p>
+      <div className="flex items-center gap-2 flex-wrap">
+        <MPAvatarPhoto name={q.speaker} size={28} />
+        <div
+          className="font-sans"
+          style={{ fontSize: 11.5, color: "var(--secondary-foreground)" }}
+        >
+          <b style={{ color: "var(--foreground)" }}>{q.speaker}</b>
+          <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
+            <span style={{ color: "var(--muted-foreground)" }}>{q.function}</span>
+            {q.club && <ClubBadge klub={q.club} size="xs" />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PlannedMini({ p }: { p: AgendaPoint }) {
+  return (
+    <div
+      style={{
+        padding: "14px 16px",
+        border: "1px dashed var(--border)",
+        color: "var(--muted-foreground)",
+      }}
+    >
+      <Kicker className="mb-1.5">zaplanowane</Kicker>
+      <div
+        className="font-serif italic"
+        style={{ fontSize: 14.5, lineHeight: 1.4 }}
+      >
+        Punkt rozpocznie się ok.{" "}
+        <b style={{ color: "var(--foreground)", fontStyle: "normal" }}>{p.timeStart}</b>.
+        Wracaj po odświeżenie.
+      </div>
+    </div>
+  );
+}
+
+function PunktRow({ p }: { p: AgendaPoint }) {
+  const isFlag = p.importance === "flagship";
+  return (
+    <li
+      id={`punkt-${p.ord}`}
+      className="grid gap-5 md:gap-8 py-7 border-t"
+      style={{
+        gridTemplateColumns: "1fr",
+        borderColor: p.planned ? "var(--border)" : "var(--rule)",
+        opacity: p.planned ? 0.85 : 1,
+      }}
+    >
+      <div
+        className="hidden md:grid"
+        style={{
+          gridTemplateColumns: "84px 1fr 320px",
+          gap: 32,
+        }}
+      >
+        {/* Rail */}
+        <div>
+          <div
+            className="font-serif italic font-medium"
+            style={{
+              fontSize: 56,
+              lineHeight: 0.9,
+              letterSpacing: "-0.02em",
+              color: isFlag ? "var(--destructive-deep)" : "var(--foreground)",
+            }}
+          >
+            {p.ord}
+          </div>
+          <div
+            className="font-mono mt-2"
+            style={{
+              fontSize: 10,
+              color: "var(--muted-foreground)",
+              letterSpacing: "0.1em",
+              lineHeight: 1.5,
+            }}
+          >
+            {p.timeStart}
+            <br />
+            <span style={{ color: "var(--border)" }}>↓ {p.durMin}min</span>
+            <br />
+            {p.timeEnd}
+          </div>
+          {p.ongoing && (
+            <div
+              className="font-mono uppercase mt-3"
+              style={{
+                fontSize: 9.5,
+                color: "var(--destructive-deep)",
+                letterSpacing: "0.16em",
+              }}
+            >
+              ● trwa
+            </div>
+          )}
+          {p.planned && (
+            <div
+              className="font-mono uppercase mt-3"
+              style={{
+                fontSize: 9.5,
+                color: "var(--muted-foreground)",
+                letterSpacing: "0.16em",
+              }}
+            >
+              ○ planowany
+            </div>
+          )}
+        </div>
+
+        {/* Center */}
+        <PunktCenter p={p} />
+
+        {/* Right */}
+        <div>
+          {p.vote ? (
+            <VoteMini v={p.vote} />
+          ) : p.viralQuote ? (
+            <QuoteMini q={p.viralQuote} />
+          ) : p.planned ? (
+            <PlannedMini p={p} />
+          ) : null}
+        </div>
+      </div>
+
+      {/* Mobile stacked */}
+      <div className="md:hidden">
+        <div className="flex items-baseline gap-3 mb-3">
+          <span
+            className="font-serif italic font-medium"
+            style={{
+              fontSize: 40,
+              lineHeight: 0.9,
+              color: isFlag ? "var(--destructive-deep)" : "var(--foreground)",
+            }}
+          >
+            {p.ord}
+          </span>
+          <div
+            className="font-mono"
+            style={{
+              fontSize: 10,
+              color: "var(--muted-foreground)",
+              letterSpacing: "0.1em",
+              lineHeight: 1.5,
+            }}
+          >
+            {p.timeStart}—{p.timeEnd} · {p.durMin} min
+            {p.ongoing && (
+              <span
+                className="ml-2 uppercase"
+                style={{
+                  color: "var(--destructive-deep)",
+                  letterSpacing: "0.16em",
+                }}
+              >
+                ● trwa
+              </span>
+            )}
+            {p.planned && (
+              <span
+                className="ml-2 uppercase"
+                style={{
+                  color: "var(--muted-foreground)",
+                  letterSpacing: "0.16em",
+                }}
+              >
+                ○ planowany
+              </span>
+            )}
+          </div>
+        </div>
+        <PunktCenter p={p} />
+        <div className="mt-5">
+          {p.vote ? (
+            <VoteMini v={p.vote} />
+          ) : p.viralQuote ? (
+            <QuoteMini q={p.viralQuote} />
+          ) : p.planned ? (
+            <PlannedMini p={p} />
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function PunktCenter({ p }: { p: AgendaPoint }) {
+  return (
+    <div className="min-w-0">
+      <div className="flex gap-1.5 mb-2.5 flex-wrap">
+        {p.stages.map((s) => (
+          <StageBadge key={s} label={s} />
+        ))}
+        {p.prints.map((d) => (
+          <PrintRef key={d.number} term={d.term} number={d.number} />
+        ))}
+        {p.procesy.map((pr) => (
+          <ProcessRef key={pr.number} term={pr.term} number={pr.number} />
+        ))}
+      </div>
+
+      <h3
+        className="font-serif font-medium m-0 mb-2"
+        style={{
+          fontSize: 22,
+          lineHeight: 1.2,
+          letterSpacing: "-0.012em",
+          color: "var(--foreground)",
+          textWrap: "balance",
+        }}
+      >
+        {p.shortTitle}.
+      </h3>
+      <p
+        className="font-serif m-0 mb-3.5"
+        style={{
+          fontSize: 14.5,
+          lineHeight: 1.55,
+          color: "var(--secondary-foreground)",
+          textWrap: "pretty",
+        }}
+      >
+        {p.plainSummary}
+      </p>
+
+      <details className="mb-4">
+        <summary
+          className="cursor-pointer font-mono uppercase"
+          style={{
+            fontSize: 10,
+            color: "var(--muted-foreground)",
+            letterSpacing: "0.14em",
+            listStyle: "none",
+          }}
+        >
+          ▸ pełny urzędowy tytuł
+        </summary>
+        <p
+          className="font-serif italic mt-2 mb-0"
+          style={{
+            fontSize: 13,
+            color: "var(--muted-foreground)",
+            lineHeight: 1.5,
+            maxWidth: 720,
+          }}
+        >
+          „{p.title}"
+        </p>
+      </details>
+
+      {!p.planned && (
+        <div
+          className="flex items-center gap-x-5 gap-y-2 flex-wrap font-mono uppercase"
+          style={{
+            fontSize: 10.5,
+            color: "var(--muted-foreground)",
+            letterSpacing: "0.1em",
+          }}
+        >
+          <span>
+            <b style={{ color: "var(--foreground)", fontWeight: 700 }}>
+              {p.stats.wypowiedzi}
+            </b>{" "}
+            wypowiedzi
+          </span>
+          <span>
+            <b style={{ color: "var(--foreground)", fontWeight: 700 }}>
+              {p.stats.mowcy}
+            </b>{" "}
+            mówców
+          </span>
+          {p.stats.glosowania > 0 && (
+            <span>
+              <b style={{ color: "var(--foreground)", fontWeight: 700 }}>
+                {p.stats.glosowania}
+              </b>{" "}
+              głosowań
+            </span>
+          )}
+          {p.topics.length > 0 && (
+            <span className="ml-auto inline-flex">
+              <TopicChips topicIds={p.topics} size="sm" />
+            </span>
+          )}
+        </div>
+      )}
+
+      {!p.planned && <ToneBar tones={p.tones} />}
+    </div>
+  );
+}
+
+export function AgendaList() {
+  const [filter, setFilter] = useState<FilterId>("all");
+
+  const counts: Record<FilterId, number> = {
+    all: MOCK.punkty.length,
+    done: MOCK.punkty.filter((p) => !p.planned).length,
+    planned: MOCK.punkty.filter((p) => p.planned).length,
+    vote: MOCK.punkty.filter((p) => !!p.vote).length,
+    flagship: MOCK.punkty.filter((p) => p.importance === "flagship").length,
+  };
+
+  const visible = MOCK.punkty.filter(FILTERS.find((f) => f.id === filter)!.pred);
+
+  return (
+    <section className="border-b border-border">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+        <SectionHead
+          num={4}
+          title="Porządek obrad"
+          sub="Każdy punkt z osobna — chronologicznie, z cytatem dnia i tonacją dyskusji."
+          anchor="porzadek"
+        />
+
+        <div className="flex gap-2.5 mb-7 flex-wrap font-sans" style={{ fontSize: 12.5 }}>
+          <span
+            className="font-mono uppercase self-center mr-1"
+            style={{
+              fontSize: 10,
+              color: "var(--muted-foreground)",
+              letterSpacing: "0.16em",
+            }}
+          >
+            filtruj
+          </span>
+          {FILTERS.map((f) => {
+            const on = filter === f.id;
+            return (
+              <button
+                key={f.id}
+                type="button"
+                onClick={() => setFilter(f.id)}
+                className="cursor-pointer rounded-full transition-colors"
+                style={{
+                  padding: "6px 13px",
+                  border: `1px solid ${on ? "var(--foreground)" : "var(--border)"}`,
+                  background: on ? "var(--foreground)" : "transparent",
+                  color: on ? "var(--background)" : "var(--secondary-foreground)",
+                }}
+                aria-pressed={on}
+              >
+                {f.label(counts[f.id])}
+              </button>
+            );
+          })}
+        </div>
+
+        <ol className="list-none p-0 m-0">
+          {visible.map((p) => (
+            <PunktRow key={p.ord} p={p} />
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/DayHeadline.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/DayHeadline.tsx
@@ -7,6 +7,7 @@ import type { Day } from "../data";
 import { Kicker } from "./SectionHead";
 
 export function DayHeadline({ day }: { day: Day }) {
+  const year = day.date ? new Date(day.date).getFullYear() : "";
   return (
     <section
       className="border-b border-border"
@@ -29,7 +30,7 @@ export function DayHeadline({ day }: { day: Day }) {
             >
               {day.weekday}
               <br />
-              {day.short}.2026
+              {day.short}.{year}
               <br />
               {day.status === "live" && (
                 <span style={{ color: "var(--destructive-deep)" }}>

--- a/frontend/app/posiedzenie/mockup/_components/DayHeadline.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/DayHeadline.tsx
@@ -1,0 +1,93 @@
+// Newsroom-style 3-sentence summary of a single day. Sits on a warm
+// secondary surface (no inverted black panel) and uses the destructive
+// accent for the kicker rule, mirroring the editorial voice elsewhere
+// in the site (BriefList atoms, ViralQuote card).
+
+import type { Day } from "../data";
+import { Kicker } from "./SectionHead";
+
+export function DayHeadline({ day }: { day: Day }) {
+  return (
+    <section
+      className="border-b border-border"
+      style={{ background: "var(--secondary)" }}
+    >
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-10 md:py-12">
+        <div className="grid gap-10 md:gap-14 md:grid-cols-[auto_1fr] items-start">
+          <div className="min-w-[140px]">
+            <Kicker color="var(--destructive-deep)" className="mb-2.5">
+              nagłówek dnia
+            </Kicker>
+            <div
+              className="font-mono uppercase"
+              style={{
+                fontSize: 12,
+                color: "var(--muted-foreground)",
+                letterSpacing: "0.12em",
+                lineHeight: 1.8,
+              }}
+            >
+              {day.weekday}
+              <br />
+              {day.short}.2026
+              <br />
+              {day.status === "live" && (
+                <span style={{ color: "var(--destructive-deep)" }}>
+                  ● obrady trwają
+                </span>
+              )}
+              {day.status === "done" && (
+                <span style={{ color: "var(--muted-foreground)" }}>
+                  ○ obrady zakończone
+                </span>
+              )}
+              {day.status === "planned" && (
+                <span style={{ color: "var(--muted-foreground)" }}>
+                  ○ obrady zaplanowane
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <p
+              className="font-serif m-0"
+              style={{
+                fontSize: 28,
+                lineHeight: 1.25,
+                letterSpacing: "-0.012em",
+                color: "var(--foreground)",
+                textWrap: "balance",
+                fontWeight: 400,
+              }}
+            >
+              {day.headline}
+            </p>
+
+            <div
+              className="mt-5 flex gap-x-9 gap-y-2 flex-wrap font-sans text-secondary-foreground"
+              style={{ fontSize: 13 }}
+            >
+              <span>
+                <b style={{ color: "var(--success)" }}>
+                  {day.stats.glosowania} głosowań
+                </b>
+                {" "}rozstrzygających
+              </span>
+              <span>
+                <b style={{ color: "var(--foreground)" }}>{day.stats.punkty}</b>{" "}
+                punktów porządku obrad
+              </span>
+              <span>
+                <b style={{ color: "var(--foreground)" }}>
+                  {day.stats.wypowiedzi}
+                </b>{" "}
+                wypowiedzi z mównicy
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/DayTimeline.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/DayTimeline.tsx
@@ -40,6 +40,7 @@ const TONES_IN_LEGEND: Tone[] = [
 
 export function DayTimeline({ activeDay }: { activeDay: number }) {
   const day = MOCK.days[activeDay];
+  if (!day) return null;
   const points = MOCK.punkty.filter((p) => p.date === day.date);
   if (points.length === 0) {
     return null;
@@ -154,6 +155,20 @@ export function DayTimeline({ activeDay }: { activeDay: number }) {
             // approximate min pixel width at common viewports to decide whether to render title
             // (we don't know runtime width here; fall back to widthPct threshold)
             const narrow = widthPct < 4.2;
+            // Vote-marker offset inside the block. Guard against zero duration
+            // and clamp to the [0, 100] range so a stale time never paints
+            // the marker outside its parent.
+            const voteLeftPct = p.vote && p.durMin > 0
+              ? Math.max(
+                  0,
+                  Math.min(
+                    100,
+                    ((timeToMin(p.vote.time) - timeToMin(p.timeStart)) /
+                      p.durMin) *
+                      100,
+                  ),
+                )
+              : 0;
             return (
               <div
                 key={p.ord}
@@ -204,11 +219,7 @@ export function DayTimeline({ activeDay }: { activeDay: number }) {
                     className="absolute"
                     style={{
                       top: -10,
-                      left: `${
-                        ((timeToMin(p.vote.time) - timeToMin(p.timeStart)) /
-                          p.durMin) *
-                        100
-                      }%`,
+                      left: `${voteLeftPct}%`,
                       width: 2,
                       height: 12,
                       background: "var(--destructive-deep)",

--- a/frontend/app/posiedzenie/mockup/_components/DayTimeline.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/DayTimeline.tsx
@@ -1,0 +1,277 @@
+// Hourly horizontal timeline. Each punkt = a block; block height = number
+// of speakers; block fill colour = dominant tone (uses ToneBadge palette
+// via tokens.ts). Live cursor label sits BELOW the hour ruler in its own
+// row so it never overlaps hour ticks. Narrow blocks (<60px) hide the
+// title text — only "PKT N" remains visible, full title appears on hover.
+
+import { MOCK, type AgendaPoint, type Tone } from "../data";
+import { TONE_INK, TONE_LABEL } from "../tokens";
+import { Kicker, SectionHead } from "./SectionHead";
+
+function timeToMin(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function sumTones(t: Partial<Record<Tone, number>>): number {
+  return Object.values(t).reduce<number>((s, v) => s + (v ?? 0), 0);
+}
+
+function dominantTone(t: Partial<Record<Tone, number>>): Tone | null {
+  let best: Tone | null = null;
+  let bestN = 0;
+  for (const [k, v] of Object.entries(t)) {
+    if ((v ?? 0) > bestN) {
+      bestN = v ?? 0;
+      best = k as Tone;
+    }
+  }
+  return best;
+}
+
+const TONES_IN_LEGEND: Tone[] = [
+  "argumentowy",
+  "techniczny",
+  "emocjonalny",
+  "apel",
+  "konfrontacyjny",
+  "neutralny",
+];
+
+export function DayTimeline({ activeDay }: { activeDay: number }) {
+  const day = MOCK.days[activeDay];
+  const points = MOCK.punkty.filter((p) => p.date === day.date);
+  if (points.length === 0) {
+    return null;
+  }
+  // Pick a comfortable window covering all blocks + a little margin.
+  const startMin = 9 * 60;
+  const endMin = 22 * 60;
+  const span = endMin - startMin;
+
+  const liveMin = day.status === "live" ? timeToMin(MOCK.liveAt) - startMin : null;
+  const toPct = (t: string) => ((timeToMin(t) - startMin) / span) * 100;
+
+  const hours: number[] = [];
+  for (let h = 9; h <= 22; h++) hours.push(h);
+
+  return (
+    <section className="border-b border-border">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+        <SectionHead
+          num={3}
+          title="Oś dnia"
+          sub="Każdy punkt jako blok. Wysokość bloku — liczba mówców. Kolor — dominująca tonacja wypowiedzi."
+          anchor="os"
+        />
+
+        {/* Live-cursor label row — separate row to avoid overlapping hour ticks */}
+        {liveMin !== null && (
+          <div className="relative mb-2" style={{ height: 18 }}>
+            <span
+              className="absolute font-mono uppercase whitespace-nowrap"
+              style={{
+                left: `${(liveMin / span) * 100}%`,
+                transform: "translateX(-50%)",
+                fontSize: 10,
+                color: "var(--destructive-deep)",
+                letterSpacing: "0.14em",
+              }}
+            >
+              ▼ {MOCK.liveAt} na żywo
+            </span>
+          </div>
+        )}
+
+        {/* Hour ruler */}
+        <div className="relative mb-1" style={{ height: 18 }}>
+          {hours.map((h) => (
+            <span
+              key={h}
+              className="absolute font-mono"
+              style={{
+                left: `${((h * 60 - startMin) / span) * 100}%`,
+                transform: "translateX(-50%)",
+                fontSize: 10,
+                color: "var(--muted-foreground)",
+                letterSpacing: "0.08em",
+              }}
+            >
+              {String(h).padStart(2, "0")}:00
+            </span>
+          ))}
+        </div>
+
+        {/* Track */}
+        <div
+          className="relative"
+          style={{
+            height: 200,
+            background: "var(--secondary)",
+            border: "1px solid var(--border)",
+          }}
+        >
+          {hours.map((h) => (
+            <div
+              key={h}
+              className="absolute top-0 bottom-0"
+              style={{
+                left: `${((h * 60 - startMin) / span) * 100}%`,
+                width: 1,
+                background: "var(--border)",
+                opacity: 0.7,
+              }}
+              aria-hidden
+            />
+          ))}
+
+          {liveMin !== null && (
+            <div
+              className="absolute"
+              style={{
+                top: -6,
+                bottom: -6,
+                left: `${(liveMin / span) * 100}%`,
+                width: 2,
+                background: "var(--destructive)",
+                zIndex: 5,
+              }}
+              aria-hidden
+            />
+          )}
+
+          {points.map((p) => {
+            const left = toPct(p.timeStart);
+            const widthPct = (p.durMin / span) * 100;
+            const tones = sumTones(p.tones);
+            const dom = dominantTone(p.tones);
+            const fill = p.planned
+              ? "var(--muted)"
+              : dom
+                ? TONE_INK[dom]
+                : "var(--muted-foreground)";
+            const height = Math.max(38, Math.min(170, p.stats.mowcy * 5 + 28));
+            // approximate min pixel width at common viewports to decide whether to render title
+            // (we don't know runtime width here; fall back to widthPct threshold)
+            const narrow = widthPct < 4.2;
+            return (
+              <div
+                key={p.ord}
+                className="absolute overflow-hidden"
+                style={{
+                  bottom: 8,
+                  left: `${left}%`,
+                  width: `${widthPct}%`,
+                  height,
+                  background: fill,
+                  color: p.planned ? "var(--foreground)" : "var(--background)",
+                  padding: "6px 8px 5px",
+                  borderRight: "1px solid var(--background)",
+                  opacity: p.planned ? 0.45 : 0.94,
+                  cursor: "pointer",
+                }}
+                title={`Pkt ${p.ord} · ${p.shortTitle} · ${p.timeStart}–${p.timeEnd}${dom ? ` · ${TONE_LABEL[dom]}` : ""}`}
+              >
+                <div
+                  className="font-mono uppercase"
+                  style={{
+                    fontSize: 9,
+                    letterSpacing: "0.08em",
+                    opacity: 0.85,
+                  }}
+                >
+                  PKT {p.ord}
+                </div>
+                {!narrow && (
+                  <div
+                    className="font-sans"
+                    style={{
+                      fontWeight: 500,
+                      fontSize: 10,
+                      marginTop: 2,
+                      lineHeight: 1.18,
+                      overflow: "hidden",
+                      display: "-webkit-box",
+                      WebkitLineClamp: 3,
+                      WebkitBoxOrient: "vertical",
+                    }}
+                  >
+                    {p.shortTitle}
+                  </div>
+                )}
+                {p.vote && (
+                  <div
+                    className="absolute"
+                    style={{
+                      top: -10,
+                      left: `${
+                        ((timeToMin(p.vote.time) - timeToMin(p.timeStart)) /
+                          p.durMin) *
+                        100
+                      }%`,
+                      width: 2,
+                      height: 12,
+                      background: "var(--destructive-deep)",
+                      transform: "translateX(-50%)",
+                    }}
+                    title={`głosowanie ${p.vote.time}`}
+                    aria-hidden
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Legend */}
+        <div
+          className="mt-4 flex flex-wrap items-center justify-between gap-3 font-sans"
+          style={{ fontSize: 11.5, color: "var(--muted-foreground)" }}
+        >
+          <div className="flex flex-wrap gap-4">
+            {TONES_IN_LEGEND.map((t) => (
+              <span key={t} className="inline-flex items-center gap-1.5">
+                <span
+                  style={{
+                    width: 14,
+                    height: 10,
+                    background: TONE_INK[t],
+                    display: "inline-block",
+                  }}
+                  aria-hidden
+                />
+                {TONE_LABEL[t]}
+              </span>
+            ))}
+            <span className="inline-flex items-center gap-1.5">
+              <span
+                style={{
+                  width: 2,
+                  height: 12,
+                  background: "var(--destructive-deep)",
+                  display: "inline-block",
+                }}
+                aria-hidden
+              />
+              głosowanie
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span
+                style={{
+                  width: 14,
+                  height: 10,
+                  background: "var(--muted)",
+                  border: "1px solid var(--border)",
+                  display: "inline-block",
+                }}
+                aria-hidden
+              />
+              zaplanowane
+            </span>
+          </div>
+          <Kicker>najazd kursora pokaże tytuł i tonację</Kicker>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/Friction.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/Friction.tsx
@@ -1,0 +1,211 @@
+// "Iskry i renegaci" — three biggest verbal clashes + four MPs who voted
+// against their klub. Both sides use the same warm-paper palette and the
+// destructive accent as the friction-marker.
+
+import { MPAvatarPhoto } from "@/components/tygodnik/MPAvatar";
+import { ClubBadge } from "@/components/clubs/ClubBadge";
+import { MOCK, type Starcie, type Rebel } from "../data";
+import { Kicker, SectionHead } from "./SectionHead";
+
+function StarcieCard({ s }: { s: Starcie }) {
+  return (
+    <div
+      style={{
+        padding: "22px 24px",
+        background: "var(--secondary)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      <div className="flex items-center justify-between mb-3 gap-2 flex-wrap">
+        <span
+          className="font-mono uppercase"
+          style={{
+            fontSize: 10,
+            color: "var(--muted-foreground)",
+            letterSpacing: "0.14em",
+          }}
+        >
+          pkt {s.punktOrd} · {s.punktShort}
+        </span>
+        <span
+          className="font-mono uppercase"
+          style={{
+            fontSize: 10,
+            color: "var(--destructive-deep)",
+            letterSpacing: "0.14em",
+          }}
+        >
+          ↯ {s.exchanges} starcia
+        </span>
+      </div>
+
+      <div
+        className="grid items-center mb-4 gap-3"
+        style={{ gridTemplateColumns: "1fr auto 1fr" }}
+      >
+        <div className="text-right">
+          <div
+            className="font-serif font-medium"
+            style={{ fontSize: 17, color: "var(--foreground)" }}
+          >
+            {s.a}
+          </div>
+          <div className="mt-1 inline-block">
+            <ClubBadge klub={s.aClub} size="sm" withLabel />
+          </div>
+        </div>
+        <div
+          className="font-serif italic"
+          style={{
+            fontSize: 22,
+            color: "var(--destructive-deep)",
+            lineHeight: 1,
+          }}
+          aria-hidden
+        >
+          vs.
+        </div>
+        <div>
+          <div
+            className="font-serif font-medium"
+            style={{ fontSize: 17, color: "var(--foreground)" }}
+          >
+            {s.b}
+          </div>
+          <div className="mt-1 inline-block">
+            <ClubBadge klub={s.bClub} size="sm" withLabel />
+          </div>
+        </div>
+      </div>
+
+      <p
+        className="font-serif italic m-0"
+        style={{
+          fontSize: 14,
+          lineHeight: 1.5,
+          color: "var(--secondary-foreground)",
+          textWrap: "pretty",
+        }}
+      >
+        {s.snippet}
+      </p>
+    </div>
+  );
+}
+
+function RebelRow({ r, first }: { r: Rebel; first: boolean }) {
+  const actualLabel =
+    r.actual === "WS" ? "WSTRZ." : r.actual === "PR" ? "PRZECIW" : "ZA";
+  const actualBg =
+    r.actual === "ZA"
+      ? "var(--success)"
+      : r.actual === "PR"
+        ? "var(--destructive)"
+        : "var(--warning)";
+  return (
+    <div
+      className="py-4"
+      style={{
+        borderTop: first ? "2px solid var(--rule)" : "1px solid var(--border)",
+      }}
+    >
+      <div className="flex items-center gap-3.5 mb-2 flex-wrap">
+        <MPAvatarPhoto name={r.name} size={40} />
+        <div className="flex-1 min-w-0">
+          <div
+            className="font-serif font-medium"
+            style={{ fontSize: 17, color: "var(--foreground)", lineHeight: 1.1 }}
+          >
+            {r.name}
+          </div>
+          <div
+            className="font-sans mt-1 flex items-center gap-1.5 flex-wrap"
+            style={{ fontSize: 11.5, color: "var(--muted-foreground)" }}
+          >
+            <ClubBadge klub={r.club} size="xs" />
+            <span>· pkt {r.punktOrd} — {r.punktShort}</span>
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5 font-mono" style={{ fontSize: 10 }}>
+          <span
+            style={{
+              padding: "3px 7px",
+              background: "var(--muted)",
+              color: "var(--muted-foreground)",
+              textDecoration: "line-through",
+            }}
+          >
+            klub: {r.expectedClub}
+          </span>
+          <span style={{ color: "var(--destructive-deep)" }}>→</span>
+          <span
+            style={{
+              padding: "3px 7px",
+              background: actualBg,
+              color: "var(--background)",
+              fontWeight: 700,
+            }}
+          >
+            {actualLabel}
+          </span>
+        </div>
+      </div>
+      <p
+        className="font-serif italic m-0 pl-[54px]"
+        style={{
+          fontSize: 13.5,
+          color: "var(--secondary-foreground)",
+          lineHeight: 1.5,
+          textWrap: "pretty",
+        }}
+      >
+        {r.note}
+      </p>
+    </div>
+  );
+}
+
+export function Friction() {
+  return (
+    <section className="border-b border-border">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+        <SectionHead
+          num={8}
+          title="Iskry i renegaci"
+          sub="Gdzie sala zapalała się najmocniej — i kto zagłosował wbrew swojemu klubowi."
+          anchor="iskry"
+        />
+
+        <div className="grid gap-10 md:gap-14 md:grid-cols-[1.1fr_1fr]">
+          <div>
+            <Kicker
+              color="var(--destructive-deep)"
+              className="mb-3.5"
+            >
+              trzy największe starcia
+            </Kicker>
+            <div className="flex flex-col gap-4">
+              {MOCK.starcia.map((s, i) => (
+                <StarcieCard key={i} s={s} />
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <Kicker
+              color="var(--destructive-deep)"
+              className="mb-3.5"
+            >
+              głosowali wbrew klubowi
+            </Kicker>
+            <div>
+              {MOCK.renegaci.map((r, i) => (
+                <RebelRow key={i} r={r} first={i === 0} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/Hero.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/Hero.tsx
@@ -149,7 +149,10 @@ export function Hero({
           </h1>
 
           <div className="md:justify-self-end">
-            <Kicker className="mb-2">łącznie za 3 dni</Kicker>
+            <Kicker className="mb-2">
+              łącznie za {MOCK.days.length}{" "}
+              {MOCK.days.length === 1 ? "dzień" : "dni"}
+            </Kicker>
             <div className="flex gap-6 md:gap-8 justify-end items-baseline flex-wrap">
               <StatTile value={MOCK.totals.punkty} label="punktów" />
               <StatTile value={MOCK.totals.wypowiedzi} label="wypowiedzi" />

--- a/frontend/app/posiedzenie/mockup/_components/Hero.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/Hero.tsx
@@ -1,0 +1,179 @@
+// Hero: full sitting headline + 4 KPI tiles + day-tabs row.
+// Day-tab underline uses border-b on the active button only (no negative
+// margins) to avoid the alignment glitch from the inspiration.
+
+import { MOCK, type Day } from "../data";
+import { Kicker } from "./SectionHead";
+
+function StatTile({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="text-right">
+      <div
+        className="font-serif font-medium text-foreground"
+        style={{ fontSize: 36, lineHeight: 0.95, letterSpacing: "-0.02em" }}
+      >
+        {value}
+      </div>
+      <div className="font-sans text-[11px] text-muted-foreground mt-1">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function DayTab({
+  day,
+  active,
+  onSelect,
+}: {
+  day: Day;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="cursor-pointer text-left transition-colors flex-1 min-w-0"
+      style={{
+        padding: "16px 24px 18px 0",
+        borderBottom: active
+          ? "3px solid var(--destructive-deep)"
+          : "3px solid transparent",
+        color: active ? "var(--foreground)" : "var(--muted-foreground)",
+      }}
+      aria-pressed={active}
+    >
+      <div className="flex items-baseline gap-3 flex-wrap">
+        <span
+          className="font-serif font-medium"
+          style={{ fontSize: 26, letterSpacing: "-0.02em", lineHeight: 1 }}
+        >
+          Dzień {day.idx + 1}
+        </span>
+        {day.status === "live" && (
+          <span
+            className="font-mono uppercase inline-flex items-center gap-1.5"
+            style={{
+              fontSize: 10,
+              color: "var(--destructive-deep)",
+              letterSpacing: "0.14em",
+            }}
+          >
+            <span
+              className="inline-block rounded-full"
+              style={{ width: 6, height: 6, background: "var(--destructive)" }}
+              aria-hidden
+            />
+            trwa
+          </span>
+        )}
+        {day.status === "planned" && (
+          <span
+            className="font-mono uppercase"
+            style={{
+              fontSize: 10,
+              color: "var(--muted-foreground)",
+              letterSpacing: "0.14em",
+            }}
+          >
+            ○ zaplanowany
+          </span>
+        )}
+      </div>
+      <div
+        className="font-mono uppercase mt-1.5"
+        style={{ fontSize: 11, letterSpacing: "0.08em" }}
+      >
+        {day.weekday} · {day.short} · {day.open ?? "—"}—{day.close ?? "…"}
+      </div>
+      <div className="font-sans flex gap-4 mt-2" style={{ fontSize: 11.5 }}>
+        <span>
+          <b className={active ? "text-foreground" : "text-secondary-foreground"}>
+            {day.stats.punkty}
+          </b>{" "}
+          pkt
+        </span>
+        <span>
+          <b className={active ? "text-foreground" : "text-secondary-foreground"}>
+            {day.stats.glosowania}
+          </b>{" "}
+          głos.
+        </span>
+        <span>
+          <b className={active ? "text-foreground" : "text-secondary-foreground"}>
+            {day.stats.wypowiedzi}
+          </b>{" "}
+          wypow.
+        </span>
+      </div>
+    </button>
+  );
+}
+
+export function Hero({
+  activeDay,
+  setActiveDay,
+}: {
+  activeDay: number;
+  setActiveDay: (i: number) => void;
+}) {
+  return (
+    <section className="border-b border-border">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-12 md:py-16">
+        <Kicker className="mb-4">
+          X kadencja Sejmu &nbsp;·&nbsp; {MOCK.dates.length}-dniowe posiedzenie
+        </Kicker>
+
+        <div className="grid gap-x-14 gap-y-10 md:grid-cols-[1.5fr_1fr] items-end">
+          <h1
+            className="font-serif font-medium m-0"
+            style={{
+              fontSize: "clamp(2.5rem, 6vw, 4rem)",
+              lineHeight: 1,
+              letterSpacing: "-0.026em",
+              color: "var(--foreground)",
+              textWrap: "balance",
+            }}
+          >
+            <span
+              className="italic"
+              style={{ color: "var(--destructive-deep)" }}
+            >
+              {MOCK.number}.
+            </span>{" "}
+            posiedzenie
+            <br />
+            Sejmu
+            <span style={{ color: "var(--muted-foreground)" }}>.</span>
+          </h1>
+
+          <div className="md:justify-self-end">
+            <Kicker className="mb-2">łącznie za 3 dni</Kicker>
+            <div className="flex gap-6 md:gap-8 justify-end items-baseline flex-wrap">
+              <StatTile value={MOCK.totals.punkty} label="punktów" />
+              <StatTile value={MOCK.totals.wypowiedzi} label="wypowiedzi" />
+              <StatTile value={MOCK.totals.glosowania} label="głosowań" />
+              <StatTile value={MOCK.totals.mowcy} label="mówców" />
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="mt-10 flex gap-6 md:gap-10 overflow-x-auto"
+          style={{ borderBottom: "2px solid var(--rule)" }}
+          role="tablist"
+        >
+          {MOCK.days.map((d) => (
+            <DayTab
+              key={d.idx}
+              day={d}
+              active={d.idx === activeDay}
+              onSelect={() => setActiveDay(d.idx)}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/Hero.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/Hero.tsx
@@ -162,14 +162,13 @@ export function Hero({
         <div
           className="mt-10 flex gap-6 md:gap-10 overflow-x-auto"
           style={{ borderBottom: "2px solid var(--rule)" }}
-          role="tablist"
         >
-          {MOCK.days.map((d) => (
+          {MOCK.days.map((d, i) => (
             <DayTab
               key={d.idx}
               day={d}
-              active={d.idx === activeDay}
-              onSelect={() => setActiveDay(d.idx)}
+              active={i === activeDay}
+              onSelect={() => setActiveDay(i)}
             />
           ))}
         </div>

--- a/frontend/app/posiedzenie/mockup/_components/MomentOfDay.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/MomentOfDay.tsx
@@ -1,0 +1,225 @@
+// "Moment dnia" — the highest-ranked viral quote of the day. Replaces the
+// inspiration's pure-black aside with a warm secondary panel + destructive
+// accent, and drops every visible reference to "viral_score". The reader
+// gets the quote, the speaker, the agenda-point context, and a short
+// editorial note about why it landed.
+
+import { MPAvatarPhoto } from "@/components/tygodnik/MPAvatar";
+import { ClubBadge } from "@/components/clubs/ClubBadge";
+import { MOCK } from "../data";
+import { Kicker, SectionHead } from "./SectionHead";
+import { verdictInk } from "../tokens";
+
+export function MomentOfDay() {
+  const top = MOCK.topQuotes[0];
+  const punkt = MOCK.punkty.find((p) => p.ord === top.punktOrd);
+
+  return (
+    <section className="border-b border-border">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+        <SectionHead
+          num={1}
+          title="Moment dnia"
+          sub="Najmocniejszy cytat z dziewiętnastego posiedzenia — wybrany przez redaktora-AI z 612 wypowiedzi."
+          anchor="moment"
+        />
+
+        <div className="grid gap-12 md:grid-cols-[1.4fr_1fr]">
+          <div>
+            <div
+              className="font-serif italic"
+              style={{
+                fontSize: 110,
+                lineHeight: 0.7,
+                color: "var(--destructive-deep)",
+                marginBottom: -4,
+              }}
+              aria-hidden
+            >
+              „
+            </div>
+            <blockquote
+              className="font-serif m-0"
+              style={{
+                fontSize: 30,
+                lineHeight: 1.28,
+                letterSpacing: "-0.012em",
+                color: "var(--foreground)",
+                fontWeight: 400,
+                textWrap: "pretty",
+              }}
+            >
+              {top.text}
+            </blockquote>
+
+            <div
+              className="mt-7 flex items-center gap-4 pt-5"
+              style={{ borderTop: "1px solid var(--border)" }}
+            >
+              <MPAvatarPhoto name={top.speaker} size={48} />
+              <div className="min-w-0">
+                <div
+                  className="font-serif font-medium"
+                  style={{ fontSize: 18, color: "var(--foreground)" }}
+                >
+                  {top.speaker}
+                </div>
+                <div
+                  className="font-sans flex items-center gap-2 mt-0.5 flex-wrap"
+                  style={{ fontSize: 12, color: "var(--muted-foreground)" }}
+                >
+                  <span>{top.function}</span>
+                  <span>·</span>
+                  <ClubBadge klub={top.club} size="sm" withLabel={false} />
+                </div>
+              </div>
+              <div className="ml-auto text-right">
+                <Kicker className="mb-1.5">cytat dnia</Kicker>
+                <div
+                  className="font-serif italic font-medium"
+                  style={{
+                    fontSize: 26,
+                    color: "var(--destructive-deep)",
+                    lineHeight: 1,
+                  }}
+                >
+                  №1
+                </div>
+              </div>
+            </div>
+
+            <div
+              className="mt-5 p-4 pl-4"
+              style={{
+                background: "var(--secondary)",
+                borderLeft: "3px solid var(--destructive-deep)",
+              }}
+            >
+              <Kicker
+                color="var(--destructive-deep)"
+                className="mb-1"
+              >
+                czemu właśnie ten
+              </Kicker>
+              <p
+                className="font-sans m-0 italic"
+                style={{
+                  fontSize: 13,
+                  lineHeight: 1.55,
+                  color: "var(--secondary-foreground)",
+                }}
+              >
+                {top.reason}
+              </p>
+            </div>
+          </div>
+
+          {/* Agenda-point context aside — warm beige, NOT inverted black */}
+          {punkt && (
+            <aside
+              className="p-7 md:p-8"
+              style={{
+                background: "var(--secondary)",
+                borderTop: "3px solid var(--destructive-deep)",
+              }}
+            >
+              <Kicker className="mb-3">w którym punkcie</Kicker>
+              <div className="flex items-baseline gap-4 mb-3">
+                <span
+                  className="font-serif italic font-medium"
+                  style={{
+                    fontSize: 60,
+                    lineHeight: 0.9,
+                    color: "var(--destructive-deep)",
+                  }}
+                >
+                  {punkt.ord}
+                </span>
+                <div
+                  className="font-mono uppercase"
+                  style={{
+                    fontSize: 10.5,
+                    color: "var(--muted-foreground)",
+                    letterSpacing: "0.14em",
+                    lineHeight: 1.5,
+                  }}
+                >
+                  {punkt.timeStart}—{punkt.timeEnd}
+                  <br />
+                  {punkt.durMin} min
+                </div>
+              </div>
+              <h3
+                className="font-serif font-medium m-0 mb-2.5"
+                style={{
+                  fontSize: 21,
+                  lineHeight: 1.22,
+                  color: "var(--foreground)",
+                  textWrap: "balance",
+                }}
+              >
+                {punkt.shortTitle}.
+              </h3>
+              <p
+                className="font-serif m-0"
+                style={{
+                  fontSize: 14.5,
+                  lineHeight: 1.55,
+                  color: "var(--secondary-foreground)",
+                  textWrap: "pretty",
+                }}
+              >
+                {punkt.plainSummary}
+              </p>
+
+              {punkt.vote && (
+                <div
+                  className="mt-5 pt-4"
+                  style={{ borderTop: "1px solid var(--border)" }}
+                >
+                  <Kicker className="mb-1.5">wynik głosowania</Kicker>
+                  <div className="flex items-baseline gap-4 flex-wrap">
+                    <span
+                      className="font-serif italic font-medium"
+                      style={{
+                        fontSize: 24,
+                        color: verdictInk(punkt.vote.result),
+                        lineHeight: 1,
+                      }}
+                    >
+                      {punkt.vote.result}
+                    </span>
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 11.5,
+                        color: "var(--muted-foreground)",
+                        letterSpacing: "0.1em",
+                      }}
+                    >
+                      {punkt.vote.za}–{punkt.vote.przeciw} · różnica{" "}
+                      {punkt.vote.margin}
+                    </span>
+                  </div>
+                </div>
+              )}
+
+              <a
+                href="#porzadek"
+                className="mt-5 inline-flex items-center gap-1.5 hover:opacity-70 transition-opacity"
+                style={{
+                  fontSize: 12.5,
+                  color: "var(--destructive-deep)",
+                  borderBottom: "1px solid var(--destructive-deep)",
+                  paddingBottom: 2,
+                }}
+              >
+                cała wypowiedź + stenogram →
+              </a>
+            </aside>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/MomentOfDay.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/MomentOfDay.tsx
@@ -11,8 +11,10 @@ import { Kicker, SectionHead } from "./SectionHead";
 import { verdictInk } from "../tokens";
 
 export function MomentOfDay() {
-  const top = MOCK.topQuotes[0];
-  const punkt = MOCK.punkty.find((p) => p.ord === top.punktOrd);
+  const top =
+    MOCK.topQuotes.find((q) => q.rank === 1) ?? MOCK.topQuotes[0];
+  if (!top) return null;
+  const punkt = MOCK.punkty.find((p) => p.ord === top.punktOrd) ?? null;
 
   return (
     <section className="border-b border-border">
@@ -183,7 +185,7 @@ export function MomentOfDay() {
                       className="font-serif italic font-medium"
                       style={{
                         fontSize: 24,
-                        color: verdictInk(punkt.vote.result),
+                        color: verdictInk(punkt.vote.result, punkt.vote.motionPolarity),
                         lineHeight: 1,
                       }}
                     >

--- a/frontend/app/posiedzenie/mockup/_components/SectionHead.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/SectionHead.tsx
@@ -1,0 +1,98 @@
+// Roman-numeral section markers used across the proceeding-points narrative.
+// The italic serif numeral + serif h2 + optional sans subtitle echoes the
+// styling already used inside ProceedingPoints.tsx and BriefList atoms.
+
+import type { ReactNode } from "react";
+
+const ROMAN = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"];
+
+export function SectionHead({
+  num,
+  title,
+  sub,
+  anchor,
+  tone = "default",
+}: {
+  num: number;
+  title: string;
+  sub?: ReactNode;
+  anchor?: string;
+  /** "inverted" swaps colours for sections that sit on muted/secondary surfaces. */
+  tone?: "default" | "muted" | "inverted";
+}) {
+  const numColor =
+    tone === "inverted" ? "var(--highlight)" : "var(--destructive-deep)";
+  const titleColor = tone === "inverted" ? "var(--background)" : "var(--foreground)";
+  const subColor =
+    tone === "inverted" ? "var(--border)" : "var(--muted-foreground)";
+  const ruleColor =
+    tone === "inverted" ? "var(--muted-foreground)" : "var(--rule)";
+
+  return (
+    <div
+      id={anchor}
+      className="flex items-baseline gap-5 pb-4 mb-7 border-b-2"
+      style={{ borderColor: ruleColor, scrollMarginTop: 80 }}
+    >
+      <span
+        className="font-serif italic font-medium shrink-0"
+        style={{
+          fontSize: 36,
+          lineHeight: 1,
+          color: numColor,
+          minWidth: 32,
+        }}
+        aria-hidden
+      >
+        {ROMAN[num - 1] ?? num}
+      </span>
+      <h2
+        className="font-serif font-medium m-0"
+        style={{
+          fontSize: 28,
+          lineHeight: 1.05,
+          letterSpacing: "-0.018em",
+          color: titleColor,
+        }}
+      >
+        {title}.
+      </h2>
+      {sub && (
+        <span
+          className="font-sans ml-auto text-right hidden md:block"
+          style={{
+            fontSize: 12.5,
+            lineHeight: 1.4,
+            color: subColor,
+            maxWidth: 460,
+          }}
+        >
+          {sub}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function Kicker({
+  children,
+  color = "var(--muted-foreground)",
+  size = 10,
+  letterSpacing = "0.16em",
+  className,
+}: {
+  children: ReactNode;
+  color?: string;
+  size?: number;
+  letterSpacing?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`font-mono uppercase ${className ?? ""}`}
+      style={{ fontSize: size, color, letterSpacing }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/Sources.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/Sources.tsx
@@ -1,0 +1,101 @@
+// Editorial footer — primary sources, how-we-read note, share row.
+// Pure typography, no decorative surfaces.
+
+import { Kicker } from "./SectionHead";
+import { MOCK } from "../data";
+
+export function Sources() {
+  return (
+    <section
+      className="border-t border-border"
+      style={{ background: "var(--background)" }}
+    >
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-12 md:py-14">
+        <div className="grid gap-10 md:gap-12 md:grid-cols-3">
+          <div>
+            <Kicker className="mb-3.5">źródła pierwotne</Kicker>
+            <ul
+              className="list-none p-0 m-0 font-sans"
+              style={{ fontSize: 13, lineHeight: 1.85, color: "var(--secondary-foreground)" }}
+            >
+              <li>↗ Porządek obrad — sejm.gov.pl</li>
+              <li>↗ Stenogramy dnia (PDF, ok. 14:00 i ~22:00)</li>
+              <li>↗ Wyniki głosowań — sejm.gov.pl</li>
+              <li>↗ Transmisja archiwalna — Sejm TV</li>
+              <li>↗ Druki sejmowe 763, 812, 841, 856…</li>
+            </ul>
+          </div>
+          <div>
+            <Kicker className="mb-3.5">jak czytamy te dane</Kicker>
+            <p
+              className="font-serif m-0"
+              style={{
+                fontSize: 14,
+                lineHeight: 1.55,
+                color: "var(--secondary-foreground)",
+                textWrap: "pretty",
+              }}
+            >
+              Każdą wypowiedź przepuszczamy przez model językowy, który nadaje jej tonację, adresata i kilka tagów tematycznych. Sumy klubowe i renegaci liczone są programatycznie z listy imiennej Sejmu. Nic nie zmyślamy — co najwyżej streszczamy.
+            </p>
+          </div>
+          <div>
+            <Kicker className="mb-3.5">udostępnij dzień</Kicker>
+            <div
+              className="font-mono mb-3 break-all"
+              style={{
+                fontSize: 11,
+                padding: "10px 12px",
+                background: "var(--secondary)",
+                color: "var(--secondary-foreground)",
+                border: "1px solid var(--border)",
+              }}
+            >
+              tygodniksejmowy.pl/posiedzenie/10/{MOCK.number}
+            </div>
+            <div className="flex gap-2 flex-wrap">
+              {["kopiuj link", "pdf dnia", "newsletter", "rss"].map((b) => (
+                <button
+                  key={b}
+                  type="button"
+                  className="cursor-pointer rounded-full hover:bg-muted transition-colors"
+                  style={{
+                    padding: "6px 12px",
+                    border: "1px solid var(--border)",
+                    fontSize: 12,
+                    color: "var(--secondary-foreground)",
+                    background: "transparent",
+                  }}
+                >
+                  {b}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div
+          className="mt-10 pt-5 flex justify-between flex-wrap gap-3 items-baseline"
+          style={{ borderTop: "1px solid var(--border)" }}
+        >
+          <span
+            className="font-serif italic"
+            style={{ fontSize: 13, color: "var(--muted-foreground)" }}
+          >
+            Tygodnik Sejmowy porządkuje dane z sejm.gov.pl — nie zastępuje ich. Stenogram PDF jest źródłem prawa.
+          </span>
+          <span
+            className="font-mono uppercase"
+            style={{
+              fontSize: 10,
+              color: "var(--muted-foreground)",
+              letterSpacing: "0.12em",
+            }}
+          >
+            Posiedzenie {MOCK.number} · ostatnia aktualizacja {MOCK.dates[1].slice(8)}.05.2026, {MOCK.liveAt}
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/Sources.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/Sources.tsx
@@ -5,6 +5,10 @@ import { Kicker } from "./SectionHead";
 import { MOCK } from "../data";
 
 export function Sources() {
+  // 2026-05-14 → 14.05.2026 — derived rather than hardcoded.
+  const lastUpdateDate = MOCK.dates[1]
+    ? MOCK.dates[1].split("-").reverse().join(".")
+    : "—";
   return (
     <section
       className="border-t border-border"
@@ -92,7 +96,7 @@ export function Sources() {
               letterSpacing: "0.12em",
             }}
           >
-            Posiedzenie {MOCK.number} · ostatnia aktualizacja {MOCK.dates[1].slice(8)}.05.2026, {MOCK.liveAt}
+            Posiedzenie {MOCK.number} · ostatnia aktualizacja {lastUpdateDate}, {MOCK.liveAt}
           </span>
         </div>
       </div>

--- a/frontend/app/posiedzenie/mockup/_components/Tomorrow.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/Tomorrow.tsx
@@ -1,0 +1,144 @@
+// "Jutro w Sejmie" — next-day preview. Drops the inspiration's full-bleed
+// black panel for a muted warm-paper surface with destructive accents.
+
+import { TOPICS, type TopicId } from "@/lib/topics";
+import { MOCK, type PlannedCard } from "../data";
+import { Kicker, SectionHead } from "./SectionHead";
+
+function PlanCardTile({ p }: { p: PlannedCard }) {
+  return (
+    <div
+      style={{
+        background: "var(--background)",
+        padding: "22px 24px",
+        borderTop: p.flag
+          ? "3px solid var(--destructive-deep)"
+          : "1px solid var(--border)",
+        borderRight: "1px solid var(--border)",
+        borderBottom: "1px solid var(--border)",
+        borderLeft: p.flag
+          ? "3px solid var(--destructive-deep)"
+          : "1px solid var(--border)",
+      }}
+    >
+      <div className="flex items-baseline gap-3 mb-2.5">
+        <span
+          className="font-serif italic font-medium"
+          style={{
+            fontSize: 30,
+            color: "var(--destructive-deep)",
+            lineHeight: 0.9,
+          }}
+        >
+          {p.ord}.
+        </span>
+        <Kicker>punkt</Kicker>
+      </div>
+      <h3
+        className="font-serif font-medium m-0 mb-2"
+        style={{
+          fontSize: 19,
+          lineHeight: 1.25,
+          color: "var(--foreground)",
+          textWrap: "balance",
+        }}
+      >
+        {p.title}.
+      </h3>
+      <p
+        className="font-serif italic m-0"
+        style={{
+          fontSize: 13,
+          color: "var(--muted-foreground)",
+          lineHeight: 1.45,
+        }}
+      >
+        {p.subtitle}
+      </p>
+      {p.topic && (
+        <div className="mt-3.5">
+          <span
+            className="font-sans inline-flex items-center gap-1.5 rounded-full"
+            style={{
+              fontSize: 11,
+              color: "var(--secondary-foreground)",
+              padding: "3px 10px",
+              background: "var(--secondary)",
+              border: "1px solid var(--border)",
+            }}
+          >
+            <span style={{ color: TOPICS[p.topic as TopicId].color }} aria-hidden>
+              {TOPICS[p.topic as TopicId].icon}
+            </span>
+            {TOPICS[p.topic as TopicId].label.toLowerCase()}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function Tomorrow() {
+  const planned = MOCK.jutro;
+  return (
+    <section className="border-b border-border" style={{ background: "var(--muted)" }}>
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+        <SectionHead
+          num={9}
+          title="Jutro w Sejmie"
+          sub={`${planned.weekday} · 15.05.2026 · od 09:00`}
+          anchor="jutro"
+        />
+
+        <p
+          className="font-serif m-0 mb-9"
+          style={{
+            fontSize: 22,
+            lineHeight: 1.35,
+            color: "var(--foreground)",
+            maxWidth: 880,
+            textWrap: "balance",
+          }}
+        >
+          {planned.headline}
+        </p>
+
+        <div className="grid gap-4 md:gap-5 grid-cols-1 md:grid-cols-3">
+          {planned.plannedPoints.map((p) => (
+            <PlanCardTile key={p.ord} p={p} />
+          ))}
+        </div>
+
+        <div
+          className="mt-10 pt-6 flex justify-between items-baseline flex-wrap gap-3"
+          style={{ borderTop: "1px solid var(--border)" }}
+        >
+          <span
+            className="font-serif italic"
+            style={{
+              fontSize: 14,
+              color: "var(--muted-foreground)",
+              maxWidth: 720,
+            }}
+          >
+            Po piątku 19. posiedzenie zostanie zamknięte. Najbliższe — 20. posiedzenie — planowane w dn. 27–29 maja.
+          </span>
+          <button
+            type="button"
+            className="cursor-pointer hover:opacity-80 transition-opacity"
+            style={{
+              padding: "9px 18px",
+              background: "var(--destructive-deep)",
+              color: "var(--background)",
+              fontSize: 13,
+              fontWeight: 500,
+              border: "none",
+            }}
+          >
+            ✦ obserwuj posiedzenie 20
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/Tomorrow.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/Tomorrow.tsx
@@ -1,11 +1,13 @@
 // "Jutro w Sejmie" — next-day preview. Drops the inspiration's full-bleed
 // black panel for a muted warm-paper surface with destructive accents.
 
-import { TOPICS, type TopicId } from "@/lib/topics";
+import { TOPICS } from "@/lib/topics";
 import { MOCK, type PlannedCard } from "../data";
 import { Kicker, SectionHead } from "./SectionHead";
 
 function PlanCardTile({ p }: { p: PlannedCard }) {
+  // Resolve once so an unknown topic key doesn't crash the render path.
+  const topic = p.topic ? TOPICS[p.topic] : null;
   return (
     <div
       style={{
@@ -55,7 +57,7 @@ function PlanCardTile({ p }: { p: PlannedCard }) {
       >
         {p.subtitle}
       </p>
-      {p.topic && (
+      {topic && (
         <div className="mt-3.5">
           <span
             className="font-sans inline-flex items-center gap-1.5 rounded-full"
@@ -67,10 +69,10 @@ function PlanCardTile({ p }: { p: PlannedCard }) {
               border: "1px solid var(--border)",
             }}
           >
-            <span style={{ color: TOPICS[p.topic as TopicId].color }} aria-hidden>
-              {TOPICS[p.topic as TopicId].icon}
+            <span style={{ color: topic.color }} aria-hidden>
+              {topic.icon}
             </span>
-            {TOPICS[p.topic as TopicId].label.toLowerCase()}
+            {topic.label.toLowerCase()}
           </span>
         </div>
       )}
@@ -80,13 +82,16 @@ function PlanCardTile({ p }: { p: PlannedCard }) {
 
 export function Tomorrow() {
   const planned = MOCK.jutro;
+  const plannedDate = planned.date
+    ? planned.date.split("-").reverse().join(".")
+    : "—";
   return (
     <section className="border-b border-border" style={{ background: "var(--muted)" }}>
       <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
         <SectionHead
           num={9}
           title="Jutro w Sejmie"
-          sub={`${planned.weekday} · 15.05.2026 · od 09:00`}
+          sub={`${planned.weekday} · ${plannedDate} · od 09:00`}
           anchor="jutro"
         />
 

--- a/frontend/app/posiedzenie/mockup/_components/TopQuotes.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/TopQuotes.tsx
@@ -52,7 +52,7 @@ function QuoteRow({ q }: { q: TopQuote }) {
                 fontWeight: 400,
               }}
             >
-              „{q.text}"
+              „{q.text}”
             </p>
             <div className="mt-4 flex items-center gap-3 flex-wrap">
               <MPAvatarPhoto name={q.speaker} size={36} />

--- a/frontend/app/posiedzenie/mockup/_components/TopQuotes.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/TopQuotes.tsx
@@ -1,0 +1,143 @@
+// Ranking of the 5 most-shareable quotes. Rank position replaces the
+// numeric score from the inspiration ("№1 cytat dnia" instead of
+// "viral 0.87"). The reason explainer lives in the right column.
+
+import { MPAvatarPhoto } from "@/components/tygodnik/MPAvatar";
+import { ClubBadge } from "@/components/clubs/ClubBadge";
+import { ToneBadge } from "@/components/statement/ToneBadge";
+import { MOCK, type TopQuote } from "../data";
+import { Kicker, SectionHead } from "./SectionHead";
+
+function QuoteRow({ q }: { q: TopQuote }) {
+  const first = q.rank === 1;
+  return (
+    <li
+      className="grid gap-7 md:gap-10 py-7"
+      style={{
+        gridTemplateColumns: "1fr",
+        borderTop: first ? "2px solid var(--rule)" : "1px solid var(--border)",
+      }}
+    >
+      <div
+        className="grid items-start"
+        style={{
+          gridTemplateColumns: "90px 1fr",
+          gap: 32,
+        }}
+      >
+        <div>
+          <div
+            className="font-serif italic font-medium"
+            style={{
+              fontSize: 64,
+              lineHeight: 0.9,
+              color: first ? "var(--destructive-deep)" : "var(--foreground)",
+            }}
+          >
+            {q.rank}
+          </div>
+          <Kicker className="mt-1">cytat punktu</Kicker>
+        </div>
+
+        <div className="grid gap-7 md:gap-10 md:grid-cols-[1fr_280px]">
+          <div>
+            <p
+              className="font-serif m-0"
+              style={{
+                fontSize: first ? 25 : 21,
+                lineHeight: 1.32,
+                color: "var(--foreground)",
+                textWrap: "pretty",
+                letterSpacing: "-0.008em",
+                fontWeight: 400,
+              }}
+            >
+              „{q.text}"
+            </p>
+            <div className="mt-4 flex items-center gap-3 flex-wrap">
+              <MPAvatarPhoto name={q.speaker} size={36} />
+              <div
+                className="font-sans"
+                style={{ fontSize: 13 }}
+              >
+                <span style={{ color: "var(--foreground)", fontWeight: 600 }}>
+                  {q.speaker}
+                </span>
+                <span style={{ color: "var(--muted-foreground)" }}> · {q.function} · </span>
+                <ClubBadge klub={q.club} size="sm" withLabel />
+              </div>
+            </div>
+          </div>
+
+          <div
+            className="md:pl-5 md:border-l"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <Kicker className="mb-1.5">w punkcie</Kicker>
+            <div
+              className="font-serif mb-3.5"
+              style={{
+                fontSize: 15.5,
+                lineHeight: 1.3,
+                color: "var(--secondary-foreground)",
+              }}
+            >
+              <b
+                className="font-mono"
+                style={{ color: "var(--foreground)", fontSize: 12 }}
+              >
+                PKT {q.punktOrd}
+              </b>{" "}
+              <span
+                className="font-mono"
+                style={{ fontSize: 10, color: "var(--muted-foreground)" }}
+              >
+                {q.punktTime}
+              </span>
+              <br />
+              {q.punktShort}.
+            </div>
+            <Kicker className="mb-1.5">tonacja</Kicker>
+            <div className="mb-3">
+              <ToneBadge tone={q.tone} />
+            </div>
+            <div
+              className="font-serif italic pt-3"
+              style={{
+                fontSize: 12.5,
+                color: "var(--muted-foreground)",
+                lineHeight: 1.45,
+                borderTop: "1px dotted var(--border)",
+              }}
+            >
+              {q.reason}
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export function TopQuotes() {
+  return (
+    <section
+      className="border-b border-border"
+      style={{ background: "var(--secondary)" }}
+    >
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+        <SectionHead
+          num={5}
+          title="Pięć cytatów dnia"
+          sub="Krótkie, mocne, cytowalne wypowiedzi. Subiektywny ranking redaktora-AI."
+          anchor="cytaty"
+        />
+        <ol className="list-none p-0 m-0">
+          {MOCK.topQuotes.map((q) => (
+            <QuoteRow key={q.rank} q={q} />
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/TopSpeakers.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/TopSpeakers.tsx
@@ -10,7 +10,8 @@ import { MOCK } from "../data";
 import { Kicker, SectionHead } from "./SectionHead";
 
 export function TopSpeakers() {
-  const maxMin = Math.max(...MOCK.topSpeakers.map((s) => s.minutes));
+  // Guard against an all-zero dataset; the bars use this as a denominator.
+  const maxMin = Math.max(1, ...MOCK.topSpeakers.map((s) => s.minutes));
 
   return (
     <section className="border-b border-border">
@@ -132,7 +133,7 @@ export function TopSpeakers() {
                 textWrap: "pretty",
               }}
             >
-              „{s.bestQuote}"
+              „{s.bestQuote}”
             </div>
           </div>
         ))}
@@ -213,7 +214,7 @@ export function TopSpeakers() {
                   lineHeight: 1.45,
                 }}
               >
-                „{s.bestQuote}"
+                „{s.bestQuote}”
               </p>
             </div>
           ))}

--- a/frontend/app/posiedzenie/mockup/_components/TopSpeakers.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/TopSpeakers.tsx
@@ -1,0 +1,224 @@
+// "Kto najdłużej mówił" — ranking of top speakers by minutes on the
+// rostrum, paired with their dominant tone and best quote (replaces the
+// inspiration's "viral ø 0.71" decimal — we surface an actual quote
+// excerpt instead, which carries more editorial signal anyway).
+
+import { MPAvatarPhoto } from "@/components/tygodnik/MPAvatar";
+import { ClubBadge } from "@/components/clubs/ClubBadge";
+import { ToneBadge } from "@/components/statement/ToneBadge";
+import { MOCK } from "../data";
+import { Kicker, SectionHead } from "./SectionHead";
+
+export function TopSpeakers() {
+  const maxMin = Math.max(...MOCK.topSpeakers.map((s) => s.minutes));
+
+  return (
+    <section className="border-b border-border">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+        <SectionHead
+          num={7}
+          title="Kto najdłużej mówił"
+          sub="Top 8 mówców dnia w minutach na mównicy. Dominująca tonacja zdradza, jakim językiem walczyli o uwagę."
+          anchor="mowcy"
+        />
+
+        <div
+          className="hidden md:grid items-center pb-2.5 mb-2 font-mono uppercase"
+          style={{
+            gridTemplateColumns: "40px minmax(220px, 1fr) minmax(240px, 1.2fr) 80px 160px minmax(220px, 1.4fr)",
+            gap: 16,
+            fontSize: 9.5,
+            color: "var(--muted-foreground)",
+            letterSpacing: "0.14em",
+            borderBottom: "1px solid var(--rule)",
+          }}
+        >
+          <span>#</span>
+          <span>Poseł</span>
+          <span>Minuty na mównicy</span>
+          <span className="text-right">Wyp.</span>
+          <span>Dominująca tonacja</span>
+          <span>Najlepszy fragment</span>
+        </div>
+
+        {MOCK.topSpeakers.map((s, i) => (
+          <div
+            key={i}
+            className="hidden md:grid items-center py-4"
+            style={{
+              gridTemplateColumns: "40px minmax(220px, 1fr) minmax(240px, 1.2fr) 80px 160px minmax(220px, 1.4fr)",
+              gap: 16,
+              borderBottom: "1px solid var(--border)",
+            }}
+          >
+            <div
+              className="font-serif italic font-medium"
+              style={{
+                fontSize: 24,
+                color:
+                  i === 0
+                    ? "var(--destructive-deep)"
+                    : "var(--foreground)",
+                lineHeight: 1,
+              }}
+            >
+              {i + 1}
+            </div>
+
+            <div className="flex items-center gap-3 min-w-0">
+              <MPAvatarPhoto name={s.name} size={36} />
+              <div className="min-w-0">
+                <div
+                  className="font-serif font-medium truncate"
+                  style={{
+                    fontSize: 16,
+                    color: "var(--foreground)",
+                    lineHeight: 1.1,
+                  }}
+                >
+                  {s.name}
+                </div>
+                <div
+                  className="font-sans flex items-center gap-1.5 mt-1 flex-wrap"
+                  style={{ fontSize: 11, color: "var(--muted-foreground)" }}
+                >
+                  <span>{s.function}</span>
+                  <ClubBadge klub={s.club} size="xs" />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <div
+                style={{
+                  width: `${(s.minutes / maxMin) * 100}%`,
+                  height: 8,
+                  background: "var(--foreground)",
+                  minWidth: 4,
+                }}
+                aria-hidden
+              />
+              <span
+                className="font-mono font-bold"
+                style={{ fontSize: 12, color: "var(--foreground)" }}
+              >
+                {s.minutes}
+              </span>
+              <span
+                className="font-sans"
+                style={{ fontSize: 11, color: "var(--muted-foreground)" }}
+              >
+                min
+              </span>
+            </div>
+
+            <div
+              className="text-right font-mono"
+              style={{ fontSize: 13, color: "var(--secondary-foreground)" }}
+            >
+              {s.wypowiedzi}
+            </div>
+
+            <div>
+              <ToneBadge tone={s.dominantTone} />
+            </div>
+
+            <div
+              className="font-serif italic"
+              style={{
+                fontSize: 13,
+                color: "var(--secondary-foreground)",
+                lineHeight: 1.45,
+                textWrap: "pretty",
+              }}
+            >
+              „{s.bestQuote}"
+            </div>
+          </div>
+        ))}
+
+        {/* Mobile: stacked card list */}
+        <div className="md:hidden flex flex-col">
+          {MOCK.topSpeakers.map((s, i) => (
+            <div
+              key={i}
+              className="py-4"
+              style={{
+                borderBottom: "1px solid var(--border)",
+              }}
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <span
+                  className="font-serif italic font-medium"
+                  style={{
+                    fontSize: 24,
+                    color: i === 0
+                      ? "var(--destructive-deep)"
+                      : "var(--foreground)",
+                    lineHeight: 1,
+                    minWidth: 24,
+                  }}
+                >
+                  {i + 1}
+                </span>
+                <MPAvatarPhoto name={s.name} size={36} />
+                <div className="min-w-0 flex-1">
+                  <div
+                    className="font-serif font-medium"
+                    style={{
+                      fontSize: 16,
+                      color: "var(--foreground)",
+                      lineHeight: 1.1,
+                    }}
+                  >
+                    {s.name}
+                  </div>
+                  <div
+                    className="font-sans flex items-center gap-1.5 mt-1 flex-wrap"
+                    style={{ fontSize: 11, color: "var(--muted-foreground)" }}
+                  >
+                    <span>{s.function}</span>
+                    <ClubBadge klub={s.club} size="xs" />
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div
+                    className="font-mono font-bold"
+                    style={{ fontSize: 16, color: "var(--foreground)" }}
+                  >
+                    {s.minutes}
+                  </div>
+                  <Kicker>min · {s.wypowiedzi} wyp.</Kicker>
+                </div>
+              </div>
+              <div className="mt-2 mb-2 flex">
+                <div
+                  style={{
+                    width: `${(s.minutes / maxMin) * 100}%`,
+                    height: 6,
+                    background: "var(--foreground)",
+                    minWidth: 4,
+                  }}
+                  aria-hidden
+                />
+              </div>
+              <div className="flex items-baseline gap-2 mb-2">
+                <ToneBadge tone={s.dominantTone} />
+              </div>
+              <p
+                className="font-serif italic m-0"
+                style={{
+                  fontSize: 13,
+                  color: "var(--secondary-foreground)",
+                  lineHeight: 1.45,
+                }}
+              >
+                „{s.bestQuote}"
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/WhatPassed.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/WhatPassed.tsx
@@ -11,7 +11,7 @@ import { KLUB_COLORS, KLUB_LABELS } from "@/lib/atlas/constants";
 function DecisionCard({ p }: { p: AgendaPoint }) {
   if (!p.vote) return null;
   const v = p.vote;
-  const accent = verdictInk(v.result);
+  const accent = verdictInk(v.result, v.motionPolarity);
 
   return (
     <a
@@ -149,9 +149,11 @@ function VoteBar({ v }: { v: Vote }) {
 
 export function WhatPassed({ activeDay }: { activeDay: number }) {
   const dayDate = MOCK.days[activeDay]?.date;
-  const decisive = MOCK.punkty.filter(
-    (p) => p.vote && (!dayDate || p.date === dayDate),
-  );
+  // Bounds-check: out-of-range activeDay used to fall through to "all days"
+  // because of the `!dayDate ||` short-circuit. Require the day to exist.
+  const decisive = dayDate
+    ? MOCK.punkty.filter((p) => !!p.vote && p.date === dayDate)
+    : [];
   if (decisive.length === 0) {
     return (
       <section

--- a/frontend/app/posiedzenie/mockup/_components/WhatPassed.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/WhatPassed.tsx
@@ -1,0 +1,206 @@
+// "Co Sejm dziś zrobił" — only the punkty with a decisive vote.
+// 3-column grid of decision cards. No hard sticker shadow (it was
+// clipping outside the container on the inspiration); subtle border +
+// hover translate is enough.
+
+import { MOCK, type AgendaPoint, type Club, type Vote } from "../data";
+import { Kicker, SectionHead } from "./SectionHead";
+import { verdictInk } from "../tokens";
+import { KLUB_COLORS, KLUB_LABELS } from "@/lib/atlas/constants";
+
+function DecisionCard({ p }: { p: AgendaPoint }) {
+  if (!p.vote) return null;
+  const v = p.vote;
+  const accent = verdictInk(v.result);
+
+  return (
+    <a
+      href={`#punkt-${p.ord}`}
+      className="block no-underline text-inherit hover:-translate-y-0.5 transition-transform"
+      style={{
+        background: "var(--background)",
+        border: "1px solid var(--border)",
+        padding: "22px 24px 20px",
+      }}
+    >
+      <div className="flex items-baseline justify-between mb-2.5 gap-2 flex-wrap">
+        <span
+          className="font-mono uppercase"
+          style={{
+            fontSize: 10,
+            color: "var(--muted-foreground)",
+            letterSpacing: "0.14em",
+          }}
+        >
+          pkt {p.ord} · {p.timeStart}–{p.timeEnd}
+        </span>
+        <span
+          className="font-mono uppercase"
+          style={{
+            fontSize: 10,
+            color: accent,
+            letterSpacing: "0.14em",
+            fontWeight: 700,
+          }}
+        >
+          ● {v.time}
+        </span>
+      </div>
+
+      <div
+        className="font-serif italic font-medium"
+        style={{
+          fontSize: 26,
+          color: accent,
+          letterSpacing: "-0.02em",
+          lineHeight: 1,
+          marginBottom: 8,
+        }}
+      >
+        {v.result}
+      </div>
+      {v.subtitle && (
+        <div
+          className="font-mono uppercase mb-3"
+          style={{
+            fontSize: 10,
+            color: "var(--muted-foreground)",
+            letterSpacing: "0.1em",
+          }}
+        >
+          {v.subtitle}
+        </div>
+      )}
+
+      <h3
+        className="font-serif font-medium m-0 mt-2 mb-2"
+        style={{
+          fontSize: 19,
+          lineHeight: 1.22,
+          color: "var(--foreground)",
+          textWrap: "balance",
+        }}
+      >
+        {p.shortTitle}.
+      </h3>
+      <p
+        className="font-serif m-0 mb-4"
+        style={{
+          fontSize: 13.5,
+          lineHeight: 1.5,
+          color: "var(--secondary-foreground)",
+          textWrap: "pretty",
+        }}
+      >
+        {v.plainNote ?? p.plainSummary}
+      </p>
+
+      <VoteBar v={v} />
+    </a>
+  );
+}
+
+function VoteBar({ v }: { v: Vote }) {
+  return (
+    <>
+      <div
+        className="flex"
+        style={{ height: 16, border: "1px solid var(--border)" }}
+        aria-hidden
+      >
+        <div style={{ width: `${(v.za / 460) * 100}%`, background: "var(--success)" }} />
+        <div style={{ width: `${(v.przeciw / 460) * 100}%`, background: "var(--destructive)" }} />
+        <div
+          style={{
+            width: `${(v.wstrzym / 460) * 100}%`,
+            background: "var(--warning)",
+            opacity: 0.85,
+          }}
+        />
+        <div
+          style={{
+            width: `${(v.nieob / 460) * 100}%`,
+            background: "var(--border)",
+          }}
+        />
+      </div>
+      <div
+        className="mt-1.5 flex justify-between font-mono"
+        style={{
+          fontSize: 10,
+          color: "var(--muted-foreground)",
+          letterSpacing: "0.08em",
+        }}
+      >
+        <span>
+          <b style={{ color: "var(--success)" }}>ZA {v.za}</b>
+        </span>
+        <span>
+          <b style={{ color: "var(--destructive)" }}>PRZ {v.przeciw}</b>
+        </span>
+        <span>
+          <b style={{ color: "var(--warning)" }}>WS {v.wstrzym}</b>
+        </span>
+        <span>NB {v.nieob}</span>
+      </div>
+    </>
+  );
+}
+
+export function WhatPassed({ activeDay }: { activeDay: number }) {
+  const dayDate = MOCK.days[activeDay]?.date;
+  const decisive = MOCK.punkty.filter(
+    (p) => p.vote && (!dayDate || p.date === dayDate),
+  );
+  if (decisive.length === 0) {
+    return (
+      <section
+        className="border-b border-border"
+        style={{ background: "var(--highlight)", opacity: 0.95 }}
+      >
+        <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-12">
+          <SectionHead
+            num={2}
+            title="Co Sejm dziś zrobił"
+            sub="Tu wpadną tylko punkty z rozstrzygającym głosowaniem. Dla tego dnia jeszcze żadne się nie zamknęło."
+            anchor="decyzje"
+          />
+          <p
+            className="font-serif italic"
+            style={{
+              fontSize: 17,
+              color: "var(--secondary-foreground)",
+              textWrap: "pretty",
+            }}
+          >
+            Sejm nie podjął jeszcze decyzji w żadnym z punktów tego dnia.
+            Wszystkie sprawy są w fazie czytań lub informacji — odpowiednie
+            karty pojawią się tutaj automatycznie po pierwszych głosowaniach.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="border-b border-border"
+      style={{ background: "var(--highlight)" }}
+    >
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+        <SectionHead
+          num={2}
+          title="Co Sejm dziś zrobił"
+          sub="Punkty, w których zapadł rozstrzygający głos. Reszta to dyskusja — to są decyzje."
+          anchor="decyzje"
+        />
+
+        <div className="grid gap-4 md:gap-5 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+          {decisive.map((p) => (
+            <DecisionCard key={p.ord} p={p} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/_components/YourTopics.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/YourTopics.tsx
@@ -22,13 +22,27 @@ function topicsAggregate(): Record<TopicId, AgendaPoint[]> {
   return out;
 }
 
+const PUNKT_PLURAL = new Intl.PluralRules("pl-PL");
+function punktLabel(count: number): string {
+  switch (PUNKT_PLURAL.select(count)) {
+    case "one":
+      return "punkt";
+    case "few":
+      return "punkty";
+    default:
+      return "punktów";
+  }
+}
+
 export function YourTopics() {
   const agg = topicsAggregate();
-  const firstWithContent = (Object.keys(TOPICS) as TopicId[]).find(
-    (t) => agg[t].length > 0,
-  )!;
+  const topicIds = Object.keys(TOPICS) as TopicId[];
+  // Force-unwrap would crash on an all-empty taxonomy. Fall back to the
+  // first topic key so `selected` is always a valid TopicId.
+  const firstWithContent =
+    topicIds.find((t) => agg[t].length > 0) ?? topicIds[0];
   const [selected, setSelected] = useState<TopicId>(firstWithContent);
-  const current = agg[selected];
+  const current = agg[selected] ?? [];
 
   return (
     <section className="border-b border-border">
@@ -150,7 +164,7 @@ export function YourTopics() {
                   letterSpacing: "0.12em",
                 }}
               >
-                {current.length} {current.length === 1 ? "punkt" : "punktów"} dziś
+                {current.length} {punktLabel(current.length)} dziś
               </span>
             </div>
 
@@ -229,7 +243,7 @@ export function YourTopics() {
                       {p.vote && (
                         <span
                           style={{
-                            color: verdictInk(p.vote.result),
+                            color: verdictInk(p.vote.result, p.vote.motionPolarity),
                             fontWeight: 700,
                           }}
                         >

--- a/frontend/app/posiedzenie/mockup/_components/YourTopics.tsx
+++ b/frontend/app/posiedzenie/mockup/_components/YourTopics.tsx
@@ -1,0 +1,266 @@
+// "Twoje sprawy" — topic rail (11 categories from lib/topics.ts) on the
+// left; selected topic's punkty on the right. Personalisation entry point.
+// Not sticky — that caused empty-tail layouts in the inspiration.
+
+"use client";
+
+import { useState } from "react";
+import { TOPICS, type TopicId } from "@/lib/topics";
+import { MOCK, type AgendaPoint } from "../data";
+import { Kicker, SectionHead } from "./SectionHead";
+import { verdictInk } from "../tokens";
+
+function topicsAggregate(): Record<TopicId, AgendaPoint[]> {
+  const out: Record<TopicId, AgendaPoint[]> = Object.fromEntries(
+    (Object.keys(TOPICS) as TopicId[]).map((t) => [t, []]),
+  ) as Record<TopicId, AgendaPoint[]>;
+  for (const p of MOCK.punkty) {
+    for (const t of p.topics) {
+      out[t]?.push(p);
+    }
+  }
+  return out;
+}
+
+export function YourTopics() {
+  const agg = topicsAggregate();
+  const firstWithContent = (Object.keys(TOPICS) as TopicId[]).find(
+    (t) => agg[t].length > 0,
+  )!;
+  const [selected, setSelected] = useState<TopicId>(firstWithContent);
+  const current = agg[selected];
+
+  return (
+    <section className="border-b border-border">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+        <SectionHead
+          num={6}
+          title="Twoje sprawy"
+          sub="11 kategorii tematycznych. Kliknij — zobacz, których punktów dotyczy i co się tam działo."
+          anchor="sprawy"
+        />
+
+        <div className="grid gap-8 md:gap-12 md:grid-cols-[300px_1fr]">
+          {/* Topic rail */}
+          <div>
+            <div className="flex flex-col">
+              {(Object.keys(TOPICS) as TopicId[]).map((id) => {
+                const meta = TOPICS[id];
+                const punkty = agg[id];
+                const on = id === selected;
+                const has = punkty.length > 0;
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    disabled={!has}
+                    onClick={() => setSelected(id)}
+                    className="flex items-baseline justify-between transition-colors text-left"
+                    style={{
+                      cursor: has ? "pointer" : "default",
+                      padding: "13px 14px",
+                      borderTop: "1px solid var(--border)",
+                      borderLeft: on
+                        ? "3px solid var(--destructive-deep)"
+                        : "3px solid transparent",
+                      background: on ? "var(--background)" : "transparent",
+                      color: !has
+                        ? "var(--border)"
+                        : on
+                          ? "var(--foreground)"
+                          : "var(--secondary-foreground)",
+                    }}
+                    aria-pressed={on}
+                  >
+                    <span className="flex items-center gap-2.5">
+                      <span
+                        className="font-serif"
+                        style={{
+                          fontSize: 18,
+                          color: on
+                            ? "var(--destructive-deep)"
+                            : "var(--muted-foreground)",
+                        }}
+                        aria-hidden
+                      >
+                        {meta.icon}
+                      </span>
+                      <span className="font-sans" style={{ fontSize: 14 }}>
+                        {meta.label}
+                      </span>
+                    </span>
+                    <span
+                      className="font-mono"
+                      style={{
+                        fontSize: 11,
+                        color: !has
+                          ? "var(--border)"
+                          : "var(--muted-foreground)",
+                        letterSpacing: "0.1em",
+                      }}
+                    >
+                      {has ? `${punkty.length}` : "—"}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+            <div
+              className="mt-3 pt-3 font-sans italic"
+              style={{
+                borderTop: "1px solid var(--border)",
+                fontSize: 12,
+                color: "var(--muted-foreground)",
+                lineHeight: 1.45,
+              }}
+            >
+              Tematy tagujemy automatycznie z wypowiedzi (taksonomia 11-elementowa). Punkt może dotyczyć kilku spraw naraz.
+            </div>
+          </div>
+
+          {/* Content */}
+          <div style={{ minHeight: 360 }}>
+            <div className="flex items-baseline gap-4 mb-5 flex-wrap">
+              <span
+                className="font-serif"
+                style={{
+                  fontSize: 56,
+                  lineHeight: 0.9,
+                  color: "var(--destructive-deep)",
+                }}
+                aria-hidden
+              >
+                {TOPICS[selected].icon}
+              </span>
+              <h3
+                className="font-serif font-medium m-0"
+                style={{
+                  fontSize: 32,
+                  letterSpacing: "-0.018em",
+                  color: "var(--foreground)",
+                }}
+              >
+                {TOPICS[selected].label}.
+              </h3>
+              <span
+                className="font-mono uppercase ml-auto"
+                style={{
+                  fontSize: 11,
+                  color: "var(--muted-foreground)",
+                  letterSpacing: "0.12em",
+                }}
+              >
+                {current.length} {current.length === 1 ? "punkt" : "punktów"} dziś
+              </span>
+            </div>
+
+            <div className="flex flex-col gap-4">
+              {current.map((p) => (
+                <div
+                  key={p.ord}
+                  className="grid gap-4 md:gap-5"
+                  style={{
+                    gridTemplateColumns: "60px 1fr",
+                    padding: "18px 20px",
+                    background: "var(--secondary)",
+                    border: "1px solid var(--border)",
+                  }}
+                >
+                  <div>
+                    <div
+                      className="font-serif italic font-medium"
+                      style={{
+                        fontSize: 34,
+                        lineHeight: 0.9,
+                        color: "var(--foreground)",
+                      }}
+                    >
+                      {p.ord}
+                    </div>
+                    <div
+                      className="font-mono mt-1.5"
+                      style={{
+                        fontSize: 9.5,
+                        color: "var(--muted-foreground)",
+                        letterSpacing: "0.1em",
+                      }}
+                    >
+                      {p.timeStart}
+                    </div>
+                  </div>
+                  <div>
+                    <h4
+                      className="font-serif font-medium m-0 mb-1.5"
+                      style={{
+                        fontSize: 18,
+                        lineHeight: 1.22,
+                        color: "var(--foreground)",
+                        textWrap: "balance",
+                      }}
+                    >
+                      {p.shortTitle}.
+                    </h4>
+                    <p
+                      className="font-serif m-0 mb-2.5"
+                      style={{
+                        fontSize: 13.5,
+                        lineHeight: 1.5,
+                        color: "var(--secondary-foreground)",
+                      }}
+                    >
+                      {p.plainSummary}
+                    </p>
+                    <div
+                      className="flex items-center gap-x-4 gap-y-1 flex-wrap font-mono uppercase"
+                      style={{
+                        fontSize: 10,
+                        color: "var(--muted-foreground)",
+                        letterSpacing: "0.1em",
+                      }}
+                    >
+                      {p.stages.map((e) => (
+                        <span
+                          key={e}
+                          style={{ color: "var(--foreground)", fontWeight: 600 }}
+                        >
+                          {e}
+                        </span>
+                      ))}
+                      {p.vote && (
+                        <span
+                          style={{
+                            color: verdictInk(p.vote.result),
+                            fontWeight: 700,
+                          }}
+                        >
+                          ● {p.vote.result}
+                        </span>
+                      )}
+                      <span
+                        className="ml-auto"
+                        style={{ color: "var(--secondary-foreground)" }}
+                      >
+                        {p.stats.wypowiedzi} wypow. · {p.stats.mowcy} mówców
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+              {current.length === 0 && (
+                <p
+                  className="font-serif italic"
+                  style={{
+                    fontSize: 14,
+                    color: "var(--muted-foreground)",
+                  }}
+                >
+                  Brak punktów dotyczących tej sprawy w tym posiedzeniu.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/data.ts
+++ b/frontend/app/posiedzenie/mockup/data.ts
@@ -518,7 +518,7 @@ export const MOCK: ProceedingMock = {
       timeEnd: "10:00",
       durMin: 60,
       title:
-        "Pierwsze czytanie rządowego projektu ustawy o e-doręczeniach administracyjnych — ciąg dalszy",
+        "Trzecie czytanie rządowego projektu ustawy o e-doręczeniach administracyjnych — ciąg dalszy",
       shortTitle: "E-doręczenia administracyjne — III czytanie",
       plainSummary:
         "Cyfryzacja korespondencji urzędowej. Po negatywnej opinii Senatu rząd wprowadza autopoprawkę wydłużającą okres przejściowy do 18 mies.",

--- a/frontend/app/posiedzenie/mockup/data.ts
+++ b/frontend/app/posiedzenie/mockup/data.ts
@@ -1,58 +1,147 @@
-// Mock data for the proceeding-points view mockup.
-// Shape mirrors what a real loader would return from agenda_items joined with
-// agenda_item_processes, agenda_item_prints, proceeding_statements + enrichment.
+// Mockup data for /posiedzenie/mockup. Mirrors the shape a real loader
+// would produce by joining proceedings + proceeding_days + agenda_items +
+// agenda_item_processes + agenda_item_prints + proceeding_statements
+// (with utterance enrichment from migration 0061) + votings (with the
+// "Pkt. N ..." title heuristic from migration 0092).
+//
+// No DB access — all values hardcoded so designer & user can iterate on
+// layout without infra in the way.
 
-export type StageBadge =
-  | "I czytanie"
-  | "II czytanie"
-  | "III czytanie"
-  | "Głosowanie"
-  | "Sprawozdanie komisji"
-  | "Pierwsze czytanie"
-  | "Informacja"
-  | "Pytania w sprawach bieżących"
-  | "Wniosek formalny";
+import type { TopicId } from "@/lib/topics";
 
-export type ProcessRef = {
-  term: number;
-  number: string;
-  shortTitle: string;
-  topicTag?: string;
-};
+export type Club =
+  | "KO"
+  | "PiS"
+  | "Lewica"
+  | "PSL-TD"
+  | "Konfederacja"
+  | "Polska2050"
+  | "Razem"
+  | "niez.";
 
-export type PrintRef = {
-  term: number;
-  number: string;
-};
+export type Tone =
+  | "konfrontacyjny"
+  | "techniczny"
+  | "argumentowy"
+  | "emocjonalny"
+  | "apel"
+  | "neutralny";
 
 export type ViralQuote = {
-  statementId: number;
-  speakerName: string;
-  clubRef: string | null;
+  text: string;
+  speaker: string;
+  mpId?: number | null;
+  photoUrl?: string | null;
+  club: Club | null;
   function: string | null;
-  quote: string;
+  tone: Tone;
+  reason: string;
+};
+
+export type Vote = {
+  time: string;
+  votingNumber: number;
+  result: "PRZYJĘTA" | "ODRZUCONA" | "WNIOSEK PRZYJĘTY" | "WNIOSEK ODRZUCONY";
+  subtitle?: string | null;
+  za: number;
+  przeciw: number;
+  wstrzym: number;
+  nieob: number;
+  margin: number;
+  motionPolarity?: "pass" | "reject" | "amendment" | "minority" | "procedural" | null;
+  byClub?: Partial<Record<Club, { za: number; pr: number; ws: number; nb: number }>>;
+  plainNote?: string | null;
 };
 
 export type AgendaPoint = {
-  agendaItemId: number;
+  ord: number;
+  date: string;
+  timeStart: string;
+  timeEnd: string;
+  durMin: number;
+  title: string;
+  shortTitle: string;
+  plainSummary: string;
+  stages: string[];
+  prints: { term: number; number: string }[];
+  procesy: { term: number; number: string }[];
+  stats: { wypowiedzi: number; mowcy: number; glosowania: number };
+  tones: Partial<Record<Tone, number>>;
+  topics: TopicId[];
+  importance: "flagship" | "normal";
+  ongoing: boolean;
+  planned: boolean;
+  viralQuote: ViralQuote | null;
+  vote: Vote | null;
+};
+
+export type Day = {
+  idx: number;
+  date: string;
+  weekday: string;
+  short: string;
+  status: "done" | "live" | "planned";
+  open: string | null;
+  close: string | null;
+  headline: string;
+  stats: { punkty: number; wypowiedzi: number; glosowania: number };
+};
+
+export type TopQuote = {
+  rank: number;
+  text: string;
+  speaker: string;
+  mpId?: number | null;
+  photoUrl?: string | null;
+  club: Club;
+  function: string;
+  tone: Tone;
+  reason: string;
+  punktOrd: number;
+  punktShort: string;
+  punktTime: string;
+};
+
+export type TopSpeaker = {
+  name: string;
+  mpId?: number | null;
+  photoUrl?: string | null;
+  club: Club;
+  function: string;
+  minutes: number;
+  wypowiedzi: number;
+  dominantTone: Tone;
+  bestQuote: string;
+};
+
+export type Starcie = {
+  a: string;
+  aClub: Club;
+  b: string;
+  bClub: Club;
+  punktOrd: number;
+  punktShort: string;
+  exchanges: number;
+  snippet: string;
+};
+
+export type Rebel = {
+  name: string;
+  mpId?: number | null;
+  club: Club;
+  expectedClub: Club;
+  actual: "ZA" | "PR" | "WS";
+  punktOrd: number;
+  punktShort: string;
+  note: string;
+};
+
+export type PlannedCard = {
   ord: number;
   title: string;
-  /** ISO date when this point was discussed (some span multiple days). */
-  date: string;
-  /** Best-effort start time on that day. */
-  startTime: string | null;
-  /** Duration in minutes (sum of statement durations). */
-  durationMin: number | null;
-  stages: StageBadge[];
-  processes: ProcessRef[];
-  prints: PrintRef[];
-  statementCount: number;
-  votingCount: number;
-  uniqueSpeakers: number;
-  viralQuote: ViralQuote | null;
-  /** Optional one-line LLM summary (proceeding_statements_enrichment-style). */
-  summary: string | null;
-  topicTags: string[];
+  subtitle: string;
+  topic: TopicId | null;
+  flag?: boolean;
 };
 
 export type ProceedingMock = {
@@ -61,264 +150,688 @@ export type ProceedingMock = {
   title: string;
   dates: string[];
   current: boolean;
-  totalStatements: number;
-  totalVotings: number;
-  totalSpeakers: number;
-  totalPoints: number;
-  points: AgendaPoint[];
+  liveAt: string;
+  totals: { punkty: number; wypowiedzi: number; glosowania: number; mowcy: number };
+  days: Day[];
+  punkty: AgendaPoint[];
+  topQuotes: TopQuote[];
+  topSpeakers: TopSpeaker[];
+  starcia: Starcie[];
+  renegaci: Rebel[];
+  jutro: { date: string; weekday: string; headline: string; plannedPoints: PlannedCard[] };
 };
 
-export const MOCK_SITTING: ProceedingMock = {
+// ─────────────────────────────────────────────────────────────────────────────
+// Polish typographic quotes throughout: opening „ (U+201E) and closing " (U+201D).
+// Plain ASCII " is reserved for string delimiters only.
+
+export const MOCK: ProceedingMock = {
   term: 10,
   number: 19,
-  title:
-    "19. posiedzenie Sejmu Rzeczypospolitej Polskiej X kadencji",
+  title: "19. posiedzenie Sejmu Rzeczypospolitej Polskiej X kadencji",
   dates: ["2026-05-13", "2026-05-14", "2026-05-15"],
   current: true,
-  totalStatements: 612,
-  totalVotings: 47,
-  totalSpeakers: 218,
-  totalPoints: 24,
-  points: [
+  liveAt: "16:42",
+  totals: { punkty: 24, wypowiedzi: 612, glosowania: 47, mowcy: 218 },
+
+  days: [
     {
-      agendaItemId: 1,
+      idx: 0,
+      date: "2026-05-13",
+      weekday: "środa",
+      short: "13 maja",
+      status: "done",
+      open: "10:00",
+      close: "21:48",
+      headline:
+        "Sejm przyjął w II czytaniu projekt podnoszący kwotę wolną do 60 tys. zł — rekordowo długa debata podatkowa zakończona poprawkami rządowymi.",
+      stats: { punkty: 8, wypowiedzi: 224, glosowania: 18 },
+    },
+    {
+      idx: 1,
+      date: "2026-05-14",
+      weekday: "czwartek",
+      short: "14 maja",
+      status: "live",
+      open: "09:00",
+      close: null,
+      headline:
+        "Trzecie czytanie PIT — ustawa przeszła stosunkiem 248–198. Wniosek o odwołanie Marszałka odrzucony.",
+      stats: { punkty: 11, wypowiedzi: 296, glosowania: 23 },
+    },
+    {
+      idx: 2,
+      date: "2026-05-15",
+      weekday: "piątek",
+      short: "15 maja",
+      status: "planned",
+      open: "09:00",
+      close: null,
+      headline:
+        "Zaplanowany blok głosowań końcowych — m.in. e-doręczenia (III czytanie) i pakiet onkologiczny.",
+      stats: { punkty: 5, wypowiedzi: 92, glosowania: 6 },
+    },
+  ],
+
+  punkty: [
+    {
       ord: 1,
+      date: "2026-05-14",
+      timeStart: "09:02",
+      timeEnd: "11:06",
+      durMin: 124,
       title:
         "Sprawozdanie Komisji Finansów Publicznych o rządowym projekcie ustawy o zmianie ustawy o podatku dochodowym od osób fizycznych oraz niektórych innych ustaw",
-      date: "2026-05-13",
-      startTime: "10:08",
-      durationMin: 142,
-      stages: ["II czytanie", "Sprawozdanie komisji", "Głosowanie"],
-      processes: [
-        {
-          term: 10,
-          number: "841",
-          shortTitle: "Zmiany w PIT — kwota wolna 60 tys. zł",
-          topicTag: "podatki",
-        },
-      ],
+      shortTitle: "Trzecie czytanie ustawy PIT — kwota wolna 60 tys. zł",
+      plainSummary:
+        "Końcowe głosowanie nad pakietem podnoszącym kwotę wolną do 60 tys. zł oraz wprowadzającym ulgę dla rodzin 2+. Pełny rozłam koalicja–opozycja; trzech posłów PiS zagłosowało wbrew klubowi.",
+      stages: ["III czytanie", "Głosowanie"],
       prints: [
         { term: 10, number: "841" },
         { term: 10, number: "892" },
         { term: 10, number: "892-A" },
       ],
-      statementCount: 84,
-      votingCount: 6,
-      uniqueSpeakers: 41,
-      summary:
-        "II czytanie projektu podnoszącego kwotę wolną do 60 tys. zł i wprowadzającego ulgę dla rodzin 2+; przyjęto poprawki rządowe, odrzucono wniosek opozycji o pełną indeksację.",
-      topicTags: ["podatki", "budżet", "rodzina"],
+      procesy: [{ term: 10, number: "841" }],
+      stats: { wypowiedzi: 41, mowcy: 28, glosowania: 12 },
+      tones: { konfrontacyjny: 18, emocjonalny: 7, argumentowy: 9, techniczny: 5, neutralny: 2 },
+      topics: ["biznes-podatki", "edukacja-rodzina"],
+      importance: "flagship",
+      ongoing: false,
+      planned: false,
       viralQuote: {
-        statementId: 412901,
-        speakerName: "Krzysztof Bosak",
-        clubRef: "Konfederacja",
+        text: "Zwiększacie kwotę wolną o sześć złotych dziennie i nazywacie to ulgą dla rodzin. To nie ulga — to alibi.",
+        speaker: "Krzysztof Bosak",
+        club: "Konfederacja",
         function: "poseł",
-        quote:
-          "Zwiększacie kwotę wolną o sześć złotych dziennie i nazywacie to ulgą dla rodzin. To nie ulga — to alibi.",
+        tone: "konfrontacyjny",
+        reason:
+          "Mocna metafora („sześć złotych dziennie”) sprowadza abstrakcyjną liczbę 60 tys. do codziennego doświadczenia. „Alibi” zamiast „ulga” odwraca framing przeciwnika.",
       },
-    },
-    {
-      agendaItemId: 2,
-      ord: 2,
-      title:
-        "Pierwsze czytanie rządowego projektu ustawy o ochronie sygnalistów oraz o zmianie niektórych ustaw",
-      date: "2026-05-13",
-      startTime: "13:42",
-      durationMin: 96,
-      stages: ["I czytanie"],
-      processes: [
-        {
-          term: 10,
-          number: "905",
-          shortTitle: "Ochrona sygnalistów — implementacja dyrektywy UE",
-          topicTag: "praworządność",
+      vote: {
+        time: "10:54",
+        votingNumber: 84,
+        result: "PRZYJĘTA",
+        za: 248,
+        przeciw: 198,
+        wstrzym: 12,
+        nieob: 2,
+        margin: 50,
+        motionPolarity: "pass",
+        byClub: {
+          KO: { za: 142, pr: 0, ws: 1, nb: 0 },
+          Lewica: { za: 26, pr: 0, ws: 0, nb: 0 },
+          "PSL-TD": { za: 32, pr: 0, ws: 0, nb: 0 },
+          Polska2050: { za: 32, pr: 0, ws: 0, nb: 0 },
+          PiS: { za: 3, pr: 167, ws: 8, nb: 1 },
+          Konfederacja: { za: 0, pr: 14, ws: 3, nb: 0 },
+          Razem: { za: 8, pr: 0, ws: 0, nb: 0 },
+          "niez.": { za: 5, pr: 17, ws: 0, nb: 1 },
         },
-      ],
-      prints: [{ term: 10, number: "905" }],
-      statementCount: 38,
-      votingCount: 1,
-      uniqueSpeakers: 22,
-      summary:
-        "Projekt implementuje dyrektywę 2019/1937. Spór dotyczył zakresu podmiotowego (sektor prywatny od 50 pracowników) i roli RPO jako organu rozpatrującego zgłoszenia zewnętrzne.",
-      topicTags: ["praca", "praworządność", "UE"],
-      viralQuote: {
-        statementId: 412944,
-        speakerName: "Agnieszka Dziemianowicz-Bąk",
-        clubRef: "Lewica",
-        function: "Minister Rodziny, Pracy i Polityki Społecznej",
-        quote:
-          "Sygnalista to nie donosiciel. To człowiek, który widzi nieprawidłowość i nie chce udawać, że jej nie ma.",
+        plainNote:
+          "Większością 50 głosów. Trzech posłów PiS (Suski, Mularczyk, Czartoryski) złamało dyscyplinę i zagłosowało ZA.",
       },
     },
     {
-      agendaItemId: 3,
-      ord: 3,
+      ord: 2,
+      date: "2026-05-14",
+      timeStart: "11:15",
+      timeEnd: "12:50",
+      durMin: 95,
       title:
-        "Informacja Ministra Spraw Zagranicznych na temat polityki zagranicznej RP w 2026 roku",
-      date: "2026-05-13",
-      startTime: "16:15",
-      durationMin: 178,
-      stages: ["Informacja"],
-      processes: [],
-      prints: [],
-      statementCount: 67,
-      votingCount: 0,
-      uniqueSpeakers: 67,
-      summary:
-        "Coroczne exposé szefa MSZ. Główne osie: relacje z USA po wyborze administracji, bezpieczeństwo wschodniej flanki, członkostwo Ukrainy w UE, polityka migracyjna.",
-      topicTags: ["polityka zagraniczna", "bezpieczeństwo", "UE"],
+        "Sprawozdanie Komisji Regulaminowej, Spraw Poselskich i Immunitetowych w sprawie wniosku o odwołanie Marszałka Sejmu",
+      shortTitle: "Wniosek o odwołanie Marszałka — odrzucony",
+      plainSummary:
+        "Wniosek klubu PiS o odwołanie Marszałka odrzucony: 162 ZA, 281 PRZECIW. Zarzut: jednostronne stosowanie regulaminu w sprawie immunitetów.",
+      stages: ["Wniosek formalny", "Głosowanie"],
+      prints: [{ term: 10, number: "918" }],
+      procesy: [],
+      stats: { wypowiedzi: 22, mowcy: 18, glosowania: 1 },
+      tones: { konfrontacyjny: 14, emocjonalny: 5, neutralny: 3 },
+      topics: ["sady-prawa"],
+      importance: "flagship",
+      ongoing: false,
+      planned: false,
       viralQuote: {
-        statementId: 413102,
-        speakerName: "Radosław Sikorski",
-        clubRef: null,
-        function: "Minister Spraw Zagranicznych",
-        quote:
-          "Polska nie będzie peryferiami Europy. Polska jest tą Europą, która stawia jej granice — także moralne.",
+        text: "Pan marszałek prowadzi obrady jak prezes spółki z o.o. — tylko z większościowym pakietem. Sejm to nie spółka.",
+        speaker: "Mariusz Błaszczak",
+        club: "PiS",
+        function: "przewodniczący klubu",
+        tone: "konfrontacyjny",
+        reason:
+          "Porównanie Marszałka do prezesa spółki to wprost zarzut o instrumentalizację. Krótka pointa, mocna typografia mentalna — idealna na cytat.",
+      },
+      vote: {
+        time: "12:42",
+        votingNumber: 85,
+        result: "WNIOSEK ODRZUCONY",
+        za: 162,
+        przeciw: 281,
+        wstrzym: 4,
+        nieob: 13,
+        margin: 119,
+        motionPolarity: "procedural",
+        byClub: {
+          PiS: { za: 162, pr: 0, ws: 1, nb: 7 },
+          Konfederacja: { za: 0, pr: 14, ws: 3, nb: 0 },
+          KO: { za: 0, pr: 142, ws: 0, nb: 1 },
+          Lewica: { za: 0, pr: 26, ws: 0, nb: 0 },
+          "PSL-TD": { za: 0, pr: 32, ws: 0, nb: 0 },
+          Polska2050: { za: 0, pr: 32, ws: 0, nb: 0 },
+          Razem: { za: 0, pr: 8, ws: 0, nb: 0 },
+          "niez.": { za: 0, pr: 27, ws: 0, nb: 0 },
+        },
       },
     },
     {
-      agendaItemId: 4,
+      ord: 3,
+      date: "2026-05-14",
+      timeStart: "13:00",
+      timeEnd: "14:00",
+      durMin: 60,
+      title: "Pytania w sprawach bieżących",
+      shortTitle: "Pytania w sprawach bieżących",
+      plainSummary:
+        "15 pytań od opozycji i koalicji. Dominujące tematy: ceny energii (4 pytania), CPK (3), sytuacja w służbie zdrowia (3).",
+      stages: ["Pytania w sprawach bieżących"],
+      prints: [],
+      procesy: [],
+      stats: { wypowiedzi: 30, mowcy: 30, glosowania: 0 },
+      tones: { argumentowy: 10, konfrontacyjny: 8, neutralny: 12 },
+      topics: ["zdrowie", "transport"],
+      importance: "normal",
+      ongoing: false,
+      planned: false,
+      viralQuote: null,
+      vote: null,
+    },
+    {
       ord: 4,
+      date: "2026-05-14",
+      timeStart: "14:30",
+      timeEnd: "17:37",
+      durMin: 187,
       title:
         "Sprawozdanie Komisji Zdrowia o poselskim projekcie ustawy o zmianie ustawy o świadczeniach opieki zdrowotnej finansowanych ze środków publicznych",
-      date: "2026-05-14",
-      startTime: "09:02",
-      durationMin: 124,
+      shortTitle: "Bezpłatne leki dla seniorów 75+ — rozszerzenie listy",
+      plainSummary:
+        "Projekt rozszerza listę 75+ o 312 nowych pozycji. Przyjęto z poprawką Senatu obniżającą wiek do 70 lat dla osób z chorobami przewlekłymi.",
       stages: ["II czytanie", "Sprawozdanie komisji", "Głosowanie"],
-      processes: [
-        {
-          term: 10,
-          number: "763",
-          shortTitle: "Bezpłatne leki dla seniorów 75+ — rozszerzenie listy",
-          topicTag: "zdrowie",
-        },
-      ],
       prints: [
         { term: 10, number: "763" },
         { term: 10, number: "871" },
       ],
-      statementCount: 51,
-      votingCount: 4,
-      uniqueSpeakers: 29,
-      summary:
-        "Projekt rozszerza listę 75+ o 312 nowych pozycji. Przyjęto z poprawką Senatu obniżającą wiek do 70 lat dla osób z chorobami przewlekłymi.",
-      topicTags: ["zdrowie", "seniorzy"],
+      procesy: [{ term: 10, number: "763" }],
+      stats: { wypowiedzi: 51, mowcy: 29, glosowania: 4 },
+      tones: { argumentowy: 24, emocjonalny: 11, neutralny: 8, techniczny: 6, apel: 2 },
+      topics: ["zdrowie", "emerytury"],
+      importance: "flagship",
+      ongoing: true,
+      planned: false,
       viralQuote: {
-        statementId: 413288,
-        speakerName: "Marek Sawicki",
-        clubRef: "PSL-TD",
+        text: "Lek za złotówkę to nie jałmużna. To umowa pokoleniowa, którą państwo wreszcie zaczyna spłacać.",
+        speaker: "Marek Sawicki",
+        club: "PSL-TD",
         function: "poseł",
-        quote:
-          "Lek za złotówkę to nie jałmużna. To umowa pokoleniowa, którą państwo wreszcie zaczyna spłacać.",
+        tone: "argumentowy",
+        reason:
+          "Rzadkie cytowanie z PSL — partia nieprzyzwyczajona do mocnych pointów. Słowo „spłacać” przesuwa narrację z „dawania” na „oddawania należnego”.",
+      },
+      vote: {
+        time: "16:30",
+        votingNumber: 88,
+        result: "PRZYJĘTA",
+        za: 412,
+        przeciw: 24,
+        wstrzym: 18,
+        nieob: 6,
+        margin: 388,
+        motionPolarity: "pass",
+        plainNote:
+          "Konsensus parlamentarny — wszystkie kluby ZA poza częścią Konfederacji.",
       },
     },
     {
-      agendaItemId: 5,
       ord: 5,
-      title:
-        "Pytania w sprawach bieżących",
       date: "2026-05-14",
-      startTime: "12:00",
-      durationMin: 60,
-      stages: ["Pytania w sprawach bieżących"],
-      processes: [],
+      timeStart: "17:40",
+      timeEnd: "18:30",
+      durMin: 50,
+      title:
+        "Informacja Ministra Infrastruktury o stanie realizacji Centralnego Portu Komunikacyjnego",
+      shortTitle: "Informacja MI o stanie CPK",
+      plainSummary:
+        "Aktualizacja harmonogramu: pierwsza fala wywłaszczeń przesunięta na II połowę 2027. Brak rozstrzygnięcia w sprawie finansowania linii dużych prędkości.",
+      stages: ["Informacja"],
       prints: [],
-      statementCount: 30,
-      votingCount: 0,
-      uniqueSpeakers: 30,
-      summary:
-        "15 pytań od opozycji i koalicji. Dominujące tematy: ceny energii (4 pytania), CPK (3), sytuacja w służbie zdrowia (3).",
-      topicTags: ["energia", "infrastruktura", "zdrowie"],
-      viralQuote: null,
+      procesy: [],
+      stats: { wypowiedzi: 28, mowcy: 22, glosowania: 0 },
+      tones: { techniczny: 14, argumentowy: 8, konfrontacyjny: 4, neutralny: 2 },
+      topics: ["transport", "biznes-podatki"],
+      importance: "normal",
+      ongoing: false,
+      planned: false,
+      viralQuote: {
+        text: "Trzy lata mówicie „za chwilę”. W tym tempie pierwszego pociągu doczeka się moja wnuczka — i to tylko jeśli zostanie inżynierem.",
+        speaker: "Anna Maria Siarkowska",
+        club: "PiS",
+        function: "posłanka",
+        tone: "emocjonalny",
+        reason:
+          "Personalizacja zarzutu („moja wnuczka”) plus suchy żart polityczny — łatwo udostępniać.",
+      },
+      vote: null,
     },
     {
-      agendaItemId: 6,
       ord: 6,
+      date: "2026-05-14",
+      timeStart: "18:35",
+      timeEnd: "20:18",
+      durMin: 103,
       title:
         "Sprawozdanie Komisji Infrastruktury oraz Komisji Samorządu Terytorialnego i Polityki Regionalnej o rządowym projekcie ustawy o zmianie ustawy — Prawo budowlane oraz niektórych innych ustaw",
-      date: "2026-05-14",
-      startTime: "14:30",
-      durationMin: 187,
+      shortTitle: "Reforma planowania przestrzennego — etap II",
+      plainSummary:
+        "Cyfrowy rejestr planów, skrócenie procedur środowiskowych, ograniczenie zabudowy rozproszonej. Wniosek o odroczenie III czytania.",
       stages: ["II czytanie", "Sprawozdanie komisji"],
-      processes: [
-        {
-          term: 10,
-          number: "812",
-          shortTitle: "Reforma planowania przestrzennego — etap II",
-          topicTag: "budownictwo",
-        },
-      ],
       prints: [
         { term: 10, number: "812" },
         { term: 10, number: "812-A" },
         { term: 10, number: "812-B" },
       ],
-      statementCount: 73,
-      votingCount: 0,
-      uniqueSpeakers: 38,
-      summary:
-        "Kontynuacja reformy: cyfrowy rejestr planów, skrócenie procedur środowiskowych, ograniczenie zabudowy rozproszonej. Wniosek o odroczenie III czytania.",
-      topicTags: ["mieszkalnictwo", "samorząd", "ekologia"],
+      procesy: [{ term: 10, number: "812" }],
+      stats: { wypowiedzi: 38, mowcy: 24, glosowania: 0 },
+      tones: { argumentowy: 16, techniczny: 11, konfrontacyjny: 7, neutralny: 4 },
+      topics: ["mieszkanie-media", "srodowisko-klimat"],
+      importance: "normal",
+      ongoing: false,
+      planned: false,
       viralQuote: {
-        statementId: 413541,
-        speakerName: "Dorota Niedziela",
-        clubRef: "KO",
+        text: "Plan miejscowy to nie biurokracja. To umowa między mieszkańcami a deweloperem — i ona nie może już być pisana ołówkiem.",
+        speaker: "Dorota Niedziela",
+        club: "KO",
         function: "sprawozdawca",
-        quote:
-          "Plan miejscowy to nie biurokracja. To umowa między mieszkańcami a deweloperem — i ona nie może już być pisana ołówkiem.",
+        tone: "argumentowy",
+        reason:
+          "Eleganckie odwrócenie populizmu („biurokracja”) w stronę praw obywatelskich. „Pisana ołówkiem” — wizualna, pamięciowa metafora.",
       },
+      vote: null,
     },
     {
-      agendaItemId: 7,
       ord: 7,
+      date: "2026-05-14",
+      timeStart: "20:25",
+      timeEnd: "21:18",
+      durMin: 53,
       title:
-        "Trzecie czytanie rządowego projektu ustawy o zmianie ustawy o podatku dochodowym od osób fizycznych oraz niektórych innych ustaw",
-      date: "2026-05-15",
-      startTime: "10:00",
-      durationMin: 22,
-      stages: ["III czytanie", "Głosowanie"],
-      processes: [
-        {
-          term: 10,
-          number: "841",
-          shortTitle: "Zmiany w PIT — kwota wolna 60 tys. zł",
-          topicTag: "podatki",
-        },
-      ],
-      prints: [{ term: 10, number: "841" }],
-      statementCount: 8,
-      votingCount: 12,
-      uniqueSpeakers: 6,
-      summary:
-        "Ustawa przyjęta: 248 ZA, 198 PRZECIW, 12 WSTRZ. Pełny rozłam koalicja–opozycja; trzech posłów PiS zagłosowało ZA.",
-      topicTags: ["podatki"],
+        "Sprawozdanie Komisji Spraw Zagranicznych o stanowisku Sejmu wobec polityki UE",
+      shortTitle: "Stanowisko Sejmu wobec polityki UE",
+      plainSummary:
+        "Stanowisko poparte przez koalicję — odrzucone poprawki PiS dot. mechanizmu warunkowości. Konfederacja: przeciw całemu stanowisku.",
+      stages: ["II czytanie", "Głosowanie"],
+      prints: [{ term: 10, number: "901" }],
+      procesy: [{ term: 10, number: "901" }],
+      stats: { wypowiedzi: 22, mowcy: 16, glosowania: 6 },
+      tones: { konfrontacyjny: 9, argumentowy: 7, neutralny: 4, techniczny: 2 },
+      topics: ["sady-prawa", "bezpieczenstwo-obrona"],
+      importance: "normal",
+      ongoing: false,
+      planned: false,
       viralQuote: null,
+      vote: {
+        time: "21:10",
+        votingNumber: 91,
+        result: "PRZYJĘTA",
+        za: 294,
+        przeciw: 132,
+        wstrzym: 28,
+        nieob: 6,
+        margin: 162,
+        motionPolarity: "pass",
+      },
     },
     {
-      agendaItemId: 8,
       ord: 8,
-      title:
-        "Wniosek o odwołanie Marszałka Sejmu",
+      date: "2026-05-14",
+      timeStart: "21:25",
+      timeEnd: "21:48",
+      durMin: 23,
+      title: "Punkt porządku obrad — komunikaty Marszałka Sejmu",
+      shortTitle: "Komunikaty Marszałka i zakończenie dnia",
+      plainSummary:
+        "Komunikaty proceduralne i ogłoszenie planu jutrzejszego dnia. 5 zaplanowanych głosowań końcowych.",
+      stages: ["Informacja"],
+      prints: [],
+      procesy: [],
+      stats: { wypowiedzi: 4, mowcy: 4, glosowania: 0 },
+      tones: { neutralny: 4 },
+      topics: [],
+      importance: "normal",
+      ongoing: false,
+      planned: false,
+      viralQuote: null,
+      vote: null,
+    },
+    {
+      ord: 9,
       date: "2026-05-15",
-      startTime: "11:45",
-      durationMin: 95,
-      stages: ["Wniosek formalny", "Głosowanie"],
-      processes: [],
-      prints: [{ term: 10, number: "918" }],
-      statementCount: 22,
-      votingCount: 1,
-      uniqueSpeakers: 18,
-      summary:
-        "Wniosek złożony przez klub PiS odrzucony: 162 ZA, 281 PRZECIW. Główny zarzut: jednostronne stosowanie regulaminu w sprawie immunitetów.",
-      topicTags: ["regulamin", "władze Sejmu"],
-      viralQuote: {
-        statementId: 413892,
-        speakerName: "Mariusz Błaszczak",
-        clubRef: "PiS",
-        function: "przewodniczący klubu",
-        quote:
-          "Pan marszałek prowadzi obrady jak prezes spółki z o.o. — tylko z większościowym pakietem. Sejm to nie spółka.",
-      },
+      timeStart: "09:00",
+      timeEnd: "10:00",
+      durMin: 60,
+      title:
+        "Pierwsze czytanie rządowego projektu ustawy o e-doręczeniach administracyjnych — ciąg dalszy",
+      shortTitle: "E-doręczenia administracyjne — III czytanie",
+      plainSummary:
+        "Cyfryzacja korespondencji urzędowej. Po negatywnej opinii Senatu rząd wprowadza autopoprawkę wydłużającą okres przejściowy do 18 mies.",
+      stages: ["III czytanie", "Głosowanie"],
+      prints: [{ term: 10, number: "856" }],
+      procesy: [{ term: 10, number: "856" }],
+      stats: { wypowiedzi: 0, mowcy: 0, glosowania: 0 },
+      tones: {},
+      topics: ["biznes-podatki"],
+      importance: "normal",
+      ongoing: false,
+      planned: true,
+      viralQuote: null,
+      vote: null,
+    },
+    {
+      ord: 10,
+      date: "2026-05-15",
+      timeStart: "10:15",
+      timeEnd: "11:30",
+      durMin: 75,
+      title:
+        "Informacja Ministra Zdrowia o realizacji programu wczesnego wykrywania nowotworów u dzieci",
+      shortTitle: "Informacja MZ o programie onkologicznym dzieci",
+      plainSummary:
+        "Coroczny raport. Zwiększona kwota refundacji terapii CAR-T; rozszerzenie programu badań przesiewowych do 16 województw.",
+      stages: ["Informacja"],
+      prints: [],
+      procesy: [],
+      stats: { wypowiedzi: 0, mowcy: 0, glosowania: 0 },
+      tones: {},
+      topics: ["zdrowie", "edukacja-rodzina"],
+      importance: "normal",
+      ongoing: false,
+      planned: true,
+      viralQuote: null,
+      vote: null,
+    },
+    {
+      ord: 11,
+      date: "2026-05-15",
+      timeStart: "12:00",
+      timeEnd: "13:30",
+      durMin: 90,
+      title: "Blok głosowań końcowych — punkty 4, 6, 9, 12",
+      shortTitle: "Blok głosowań końcowych",
+      plainSummary:
+        "Zaplanowano łącznie 14 głosowań końcowych: pakiet onkologiczny, e-doręczenia, prawo budowlane, sprawa Marszałka — wszystkie do rozstrzygnięcia.",
+      stages: ["Głosowanie"],
+      prints: [],
+      procesy: [],
+      stats: { wypowiedzi: 0, mowcy: 0, glosowania: 0 },
+      tones: {},
+      topics: [],
+      importance: "flagship",
+      ongoing: false,
+      planned: true,
+      viralQuote: null,
+      vote: null,
     },
   ],
+
+  topQuotes: [
+    {
+      rank: 1,
+      text: "Zwiększacie kwotę wolną o sześć złotych dziennie i nazywacie to ulgą dla rodzin. To nie ulga — to alibi.",
+      speaker: "Krzysztof Bosak",
+      club: "Konfederacja",
+      function: "poseł",
+      tone: "konfrontacyjny",
+      reason:
+        "Mocna metafora („sześć złotych dziennie”) sprowadza abstrakcyjną liczbę 60 tys. do codziennego doświadczenia. „Alibi” zamiast „ulga” odwraca framing przeciwnika.",
+      punktOrd: 1,
+      punktShort: "Trzecie czytanie ustawy PIT",
+      punktTime: "10:48",
+    },
+    {
+      rank: 2,
+      text: "Pan marszałek prowadzi obrady jak prezes spółki z o.o. — tylko z większościowym pakietem. Sejm to nie spółka.",
+      speaker: "Mariusz Błaszczak",
+      club: "PiS",
+      function: "przewodniczący klubu",
+      tone: "konfrontacyjny",
+      reason:
+        "Porównanie Marszałka do prezesa spółki to wprost zarzut o instrumentalizację. Krótka pointa, mocna typografia mentalna — idealna na cytat.",
+      punktOrd: 2,
+      punktShort: "Wniosek o odwołanie Marszałka",
+      punktTime: "11:42",
+    },
+    {
+      rank: 3,
+      text: "Lek za złotówkę to nie jałmużna. To umowa pokoleniowa, którą państwo wreszcie zaczyna spłacać.",
+      speaker: "Marek Sawicki",
+      club: "PSL-TD",
+      function: "poseł",
+      tone: "argumentowy",
+      reason:
+        "Rzadkie cytowanie z PSL — partia nieprzyzwyczajona do mocnych pointów. Słowo „spłacać” przesuwa narrację z „dawania” na „oddawania należnego”.",
+      punktOrd: 4,
+      punktShort: "Bezpłatne leki 75+",
+      punktTime: "15:12",
+    },
+    {
+      rank: 4,
+      text: "Plan miejscowy to nie biurokracja. To umowa między mieszkańcami a deweloperem — i ona nie może już być pisana ołówkiem.",
+      speaker: "Dorota Niedziela",
+      club: "KO",
+      function: "sprawozdawca",
+      tone: "argumentowy",
+      reason:
+        "Eleganckie odwrócenie populizmu („biurokracja”) w stronę praw obywatelskich. „Pisana ołówkiem” — wizualna, pamięciowa metafora.",
+      punktOrd: 6,
+      punktShort: "Reforma planowania przestrzennego",
+      punktTime: "19:23",
+    },
+    {
+      rank: 5,
+      text: "Trzy lata mówicie „za chwilę”. W tym tempie pierwszego pociągu doczeka się moja wnuczka — i to tylko jeśli zostanie inżynierem.",
+      speaker: "Anna Maria Siarkowska",
+      club: "PiS",
+      function: "posłanka",
+      tone: "emocjonalny",
+      reason:
+        "Personalizacja zarzutu („moja wnuczka”) plus suchy żart polityczny — łatwo udostępniać.",
+      punktOrd: 5,
+      punktShort: "Informacja MI o stanie CPK",
+      punktTime: "18:02",
+    },
+  ],
+
+  topSpeakers: [
+    {
+      name: "Andrzej Domański",
+      club: "KO",
+      function: "Minister Finansów",
+      minutes: 78,
+      wypowiedzi: 9,
+      dominantTone: "techniczny",
+      bestQuote:
+        "Skala redystrybucji w tym pakiecie jest największa od czasu wprowadzenia 500+. Liczby są publiczne — każdy może sprawdzić.",
+    },
+    {
+      name: "Krzysztof Bosak",
+      club: "Konfederacja",
+      function: "poseł",
+      minutes: 64,
+      wypowiedzi: 14,
+      dominantTone: "konfrontacyjny",
+      bestQuote:
+        "Zwiększacie kwotę wolną o sześć złotych dziennie i nazywacie to ulgą dla rodzin. To nie ulga — to alibi.",
+    },
+    {
+      name: "Mariusz Błaszczak",
+      club: "PiS",
+      function: "przewodniczący klubu",
+      minutes: 52,
+      wypowiedzi: 11,
+      dominantTone: "konfrontacyjny",
+      bestQuote:
+        "Pan marszałek prowadzi obrady jak prezes spółki z o.o. — tylko z większościowym pakietem.",
+    },
+    {
+      name: "Anna Maria Siarkowska",
+      club: "PiS",
+      function: "posłanka",
+      minutes: 38,
+      wypowiedzi: 7,
+      dominantTone: "emocjonalny",
+      bestQuote:
+        "Trzy lata mówicie „za chwilę”. W tym tempie pierwszego pociągu doczeka się moja wnuczka.",
+    },
+    {
+      name: "Dorota Niedziela",
+      club: "KO",
+      function: "sprawozdawca",
+      minutes: 34,
+      wypowiedzi: 5,
+      dominantTone: "argumentowy",
+      bestQuote:
+        "Plan miejscowy to nie biurokracja. To umowa między mieszkańcami a deweloperem.",
+    },
+    {
+      name: "Marek Sawicki",
+      club: "PSL-TD",
+      function: "poseł",
+      minutes: 29,
+      wypowiedzi: 6,
+      dominantTone: "argumentowy",
+      bestQuote:
+        "Lek za złotówkę to nie jałmużna. To umowa pokoleniowa, którą państwo wreszcie zaczyna spłacać.",
+    },
+    {
+      name: "Magdalena Biejat",
+      club: "Lewica",
+      function: "wicemarszałek Sejmu",
+      minutes: 24,
+      wypowiedzi: 4,
+      dominantTone: "argumentowy",
+      bestQuote:
+        "Jeśli mówimy „rodzina”, musimy mówić też o opiece — bo bez niej praca jest złudzeniem.",
+    },
+    {
+      name: "Włodzimierz Czarzasty",
+      club: "Lewica",
+      function: "Marszałek Sejmu",
+      minutes: 21,
+      wypowiedzi: 8,
+      dominantTone: "neutralny",
+      bestQuote:
+        "Proszę nie przerywać. Pan poseł skończy myśl i wtedy będzie czas na repliki.",
+    },
+  ],
+
+  starcia: [
+    {
+      a: "Bosak",
+      aClub: "Konfederacja",
+      b: "Domański",
+      bClub: "KO",
+      punktOrd: 1,
+      punktShort: "Trzecie czytanie ustawy PIT",
+      exchanges: 6,
+      snippet:
+        "Bosak: „Liczby są fałszywe, bo zakłada się stałą inflację 2,5%.” Domański: „Pan poseł czyta jeden slajd, a w drugim jest waloryzacja kwartalna.”",
+    },
+    {
+      a: "Błaszczak",
+      aClub: "PiS",
+      b: "Czarzasty",
+      bClub: "Lewica",
+      punktOrd: 2,
+      punktShort: "Wniosek o odwołanie Marszałka",
+      exchanges: 4,
+      snippet:
+        "Błaszczak: „Pan marszałek nie udziela głosu posłom opozycji.” Czarzasty: „Udzielam głosu kolejno z listy, panie pośle — proszę się z nią zapoznać.”",
+    },
+    {
+      a: "Siarkowska",
+      aClub: "PiS",
+      b: "Klimczak",
+      bClub: "Polska2050",
+      punktOrd: 5,
+      punktShort: "Informacja MI o CPK",
+      exchanges: 3,
+      snippet:
+        "Siarkowska: „Trzy lata i ani jednej łopaty.” Klimczak: „Pani posłanka mówi o łopatach — my mówimy o procedurach środowiskowych, których wasi nie chcieli zacząć.”",
+    },
+  ],
+
+  renegaci: [
+    {
+      name: "Marek Suski",
+      club: "PiS",
+      expectedClub: "PiS",
+      actual: "ZA",
+      punktOrd: 1,
+      punktShort: "PIT — kwota wolna 60 tys.",
+      note: "Trzeci raz w tej kadencji wyłamuje się klubowi w głosowaniu podatkowym. Powołuje się na okręg radomski.",
+    },
+    {
+      name: "Arkadiusz Mularczyk",
+      club: "PiS",
+      expectedClub: "PiS",
+      actual: "ZA",
+      punktOrd: 1,
+      punktShort: "PIT — kwota wolna 60 tys.",
+      note: "Były wiceminister sprawiedliwości — pierwszy raz głosuje za projektem koalicji.",
+    },
+    {
+      name: "Zbigniew Hoffmann",
+      club: "Konfederacja",
+      expectedClub: "Konfederacja",
+      actual: "WS",
+      punktOrd: 4,
+      punktShort: "Bezpłatne leki 75+",
+      note: "Klub Konfederacji ZA, Hoffmann WSTRZ. — sygnalizuje sceptycyzm wobec dalszej rozbudowy programów osłonowych.",
+    },
+    {
+      name: "Joanna Mucha",
+      club: "Polska2050",
+      expectedClub: "Polska2050",
+      actual: "PR",
+      punktOrd: 7,
+      punktShort: "Stanowisko Sejmu wobec polityki UE",
+      note: "Klub ZA, Mucha PRZECIW — uzasadnia dystansem wobec mechanizmu warunkowości w obecnej formie.",
+    },
+  ],
+
+  jutro: {
+    date: "2026-05-15",
+    weekday: "piątek",
+    headline:
+      "Piątek otworzy trzecie czytanie e-doręczeń i blok 14 głosowań końcowych. Z dziewiętnastego posiedzenia zostają już tylko decyzje.",
+    plannedPoints: [
+      {
+        ord: 9,
+        title: "E-doręczenia — III czytanie",
+        subtitle: "rządowy projekt o cyfryzacji korespondencji urzędowej",
+        topic: "biznes-podatki",
+      },
+      {
+        ord: 10,
+        title: "Informacja Ministra Zdrowia",
+        subtitle: "o realizacji programu wczesnego wykrywania nowotworów u dzieci",
+        topic: "zdrowie",
+      },
+      {
+        ord: 11,
+        title: "Blok głosowań końcowych",
+        subtitle: "zaplanowano łącznie 14 głosowań, m.in. pakiet onkologiczny",
+        topic: null,
+        flag: true,
+      },
+    ],
+  },
 };

--- a/frontend/app/posiedzenie/mockup/data.ts
+++ b/frontend/app/posiedzenie/mockup/data.ts
@@ -1,0 +1,324 @@
+// Mock data for the proceeding-points view mockup.
+// Shape mirrors what a real loader would return from agenda_items joined with
+// agenda_item_processes, agenda_item_prints, proceeding_statements + enrichment.
+
+export type StageBadge =
+  | "I czytanie"
+  | "II czytanie"
+  | "III czytanie"
+  | "Głosowanie"
+  | "Sprawozdanie komisji"
+  | "Pierwsze czytanie"
+  | "Informacja"
+  | "Pytania w sprawach bieżących"
+  | "Wniosek formalny";
+
+export type ProcessRef = {
+  term: number;
+  number: string;
+  shortTitle: string;
+  topicTag?: string;
+};
+
+export type PrintRef = {
+  term: number;
+  number: string;
+};
+
+export type ViralQuote = {
+  statementId: number;
+  speakerName: string;
+  clubRef: string | null;
+  function: string | null;
+  quote: string;
+};
+
+export type AgendaPoint = {
+  agendaItemId: number;
+  ord: number;
+  title: string;
+  /** ISO date when this point was discussed (some span multiple days). */
+  date: string;
+  /** Best-effort start time on that day. */
+  startTime: string | null;
+  /** Duration in minutes (sum of statement durations). */
+  durationMin: number | null;
+  stages: StageBadge[];
+  processes: ProcessRef[];
+  prints: PrintRef[];
+  statementCount: number;
+  votingCount: number;
+  uniqueSpeakers: number;
+  viralQuote: ViralQuote | null;
+  /** Optional one-line LLM summary (proceeding_statements_enrichment-style). */
+  summary: string | null;
+  topicTags: string[];
+};
+
+export type ProceedingMock = {
+  term: number;
+  number: number;
+  title: string;
+  dates: string[];
+  current: boolean;
+  totalStatements: number;
+  totalVotings: number;
+  totalSpeakers: number;
+  totalPoints: number;
+  points: AgendaPoint[];
+};
+
+export const MOCK_SITTING: ProceedingMock = {
+  term: 10,
+  number: 19,
+  title:
+    "19. posiedzenie Sejmu Rzeczypospolitej Polskiej X kadencji",
+  dates: ["2026-05-13", "2026-05-14", "2026-05-15"],
+  current: true,
+  totalStatements: 612,
+  totalVotings: 47,
+  totalSpeakers: 218,
+  totalPoints: 24,
+  points: [
+    {
+      agendaItemId: 1,
+      ord: 1,
+      title:
+        "Sprawozdanie Komisji Finansów Publicznych o rządowym projekcie ustawy o zmianie ustawy o podatku dochodowym od osób fizycznych oraz niektórych innych ustaw",
+      date: "2026-05-13",
+      startTime: "10:08",
+      durationMin: 142,
+      stages: ["II czytanie", "Sprawozdanie komisji", "Głosowanie"],
+      processes: [
+        {
+          term: 10,
+          number: "841",
+          shortTitle: "Zmiany w PIT — kwota wolna 60 tys. zł",
+          topicTag: "podatki",
+        },
+      ],
+      prints: [
+        { term: 10, number: "841" },
+        { term: 10, number: "892" },
+        { term: 10, number: "892-A" },
+      ],
+      statementCount: 84,
+      votingCount: 6,
+      uniqueSpeakers: 41,
+      summary:
+        "II czytanie projektu podnoszącego kwotę wolną do 60 tys. zł i wprowadzającego ulgę dla rodzin 2+; przyjęto poprawki rządowe, odrzucono wniosek opozycji o pełną indeksację.",
+      topicTags: ["podatki", "budżet", "rodzina"],
+      viralQuote: {
+        statementId: 412901,
+        speakerName: "Krzysztof Bosak",
+        clubRef: "Konfederacja",
+        function: "poseł",
+        quote:
+          "Zwiększacie kwotę wolną o sześć złotych dziennie i nazywacie to ulgą dla rodzin. To nie ulga — to alibi.",
+      },
+    },
+    {
+      agendaItemId: 2,
+      ord: 2,
+      title:
+        "Pierwsze czytanie rządowego projektu ustawy o ochronie sygnalistów oraz o zmianie niektórych ustaw",
+      date: "2026-05-13",
+      startTime: "13:42",
+      durationMin: 96,
+      stages: ["I czytanie"],
+      processes: [
+        {
+          term: 10,
+          number: "905",
+          shortTitle: "Ochrona sygnalistów — implementacja dyrektywy UE",
+          topicTag: "praworządność",
+        },
+      ],
+      prints: [{ term: 10, number: "905" }],
+      statementCount: 38,
+      votingCount: 1,
+      uniqueSpeakers: 22,
+      summary:
+        "Projekt implementuje dyrektywę 2019/1937. Spór dotyczył zakresu podmiotowego (sektor prywatny od 50 pracowników) i roli RPO jako organu rozpatrującego zgłoszenia zewnętrzne.",
+      topicTags: ["praca", "praworządność", "UE"],
+      viralQuote: {
+        statementId: 412944,
+        speakerName: "Agnieszka Dziemianowicz-Bąk",
+        clubRef: "Lewica",
+        function: "Minister Rodziny, Pracy i Polityki Społecznej",
+        quote:
+          "Sygnalista to nie donosiciel. To człowiek, który widzi nieprawidłowość i nie chce udawać, że jej nie ma.",
+      },
+    },
+    {
+      agendaItemId: 3,
+      ord: 3,
+      title:
+        "Informacja Ministra Spraw Zagranicznych na temat polityki zagranicznej RP w 2026 roku",
+      date: "2026-05-13",
+      startTime: "16:15",
+      durationMin: 178,
+      stages: ["Informacja"],
+      processes: [],
+      prints: [],
+      statementCount: 67,
+      votingCount: 0,
+      uniqueSpeakers: 67,
+      summary:
+        "Coroczne exposé szefa MSZ. Główne osie: relacje z USA po wyborze administracji, bezpieczeństwo wschodniej flanki, członkostwo Ukrainy w UE, polityka migracyjna.",
+      topicTags: ["polityka zagraniczna", "bezpieczeństwo", "UE"],
+      viralQuote: {
+        statementId: 413102,
+        speakerName: "Radosław Sikorski",
+        clubRef: null,
+        function: "Minister Spraw Zagranicznych",
+        quote:
+          "Polska nie będzie peryferiami Europy. Polska jest tą Europą, która stawia jej granice — także moralne.",
+      },
+    },
+    {
+      agendaItemId: 4,
+      ord: 4,
+      title:
+        "Sprawozdanie Komisji Zdrowia o poselskim projekcie ustawy o zmianie ustawy o świadczeniach opieki zdrowotnej finansowanych ze środków publicznych",
+      date: "2026-05-14",
+      startTime: "09:02",
+      durationMin: 124,
+      stages: ["II czytanie", "Sprawozdanie komisji", "Głosowanie"],
+      processes: [
+        {
+          term: 10,
+          number: "763",
+          shortTitle: "Bezpłatne leki dla seniorów 75+ — rozszerzenie listy",
+          topicTag: "zdrowie",
+        },
+      ],
+      prints: [
+        { term: 10, number: "763" },
+        { term: 10, number: "871" },
+      ],
+      statementCount: 51,
+      votingCount: 4,
+      uniqueSpeakers: 29,
+      summary:
+        "Projekt rozszerza listę 75+ o 312 nowych pozycji. Przyjęto z poprawką Senatu obniżającą wiek do 70 lat dla osób z chorobami przewlekłymi.",
+      topicTags: ["zdrowie", "seniorzy"],
+      viralQuote: {
+        statementId: 413288,
+        speakerName: "Marek Sawicki",
+        clubRef: "PSL-TD",
+        function: "poseł",
+        quote:
+          "Lek za złotówkę to nie jałmużna. To umowa pokoleniowa, którą państwo wreszcie zaczyna spłacać.",
+      },
+    },
+    {
+      agendaItemId: 5,
+      ord: 5,
+      title:
+        "Pytania w sprawach bieżących",
+      date: "2026-05-14",
+      startTime: "12:00",
+      durationMin: 60,
+      stages: ["Pytania w sprawach bieżących"],
+      processes: [],
+      prints: [],
+      statementCount: 30,
+      votingCount: 0,
+      uniqueSpeakers: 30,
+      summary:
+        "15 pytań od opozycji i koalicji. Dominujące tematy: ceny energii (4 pytania), CPK (3), sytuacja w służbie zdrowia (3).",
+      topicTags: ["energia", "infrastruktura", "zdrowie"],
+      viralQuote: null,
+    },
+    {
+      agendaItemId: 6,
+      ord: 6,
+      title:
+        "Sprawozdanie Komisji Infrastruktury oraz Komisji Samorządu Terytorialnego i Polityki Regionalnej o rządowym projekcie ustawy o zmianie ustawy — Prawo budowlane oraz niektórych innych ustaw",
+      date: "2026-05-14",
+      startTime: "14:30",
+      durationMin: 187,
+      stages: ["II czytanie", "Sprawozdanie komisji"],
+      processes: [
+        {
+          term: 10,
+          number: "812",
+          shortTitle: "Reforma planowania przestrzennego — etap II",
+          topicTag: "budownictwo",
+        },
+      ],
+      prints: [
+        { term: 10, number: "812" },
+        { term: 10, number: "812-A" },
+        { term: 10, number: "812-B" },
+      ],
+      statementCount: 73,
+      votingCount: 0,
+      uniqueSpeakers: 38,
+      summary:
+        "Kontynuacja reformy: cyfrowy rejestr planów, skrócenie procedur środowiskowych, ograniczenie zabudowy rozproszonej. Wniosek o odroczenie III czytania.",
+      topicTags: ["mieszkalnictwo", "samorząd", "ekologia"],
+      viralQuote: {
+        statementId: 413541,
+        speakerName: "Dorota Niedziela",
+        clubRef: "KO",
+        function: "sprawozdawca",
+        quote:
+          "Plan miejscowy to nie biurokracja. To umowa między mieszkańcami a deweloperem — i ona nie może już być pisana ołówkiem.",
+      },
+    },
+    {
+      agendaItemId: 7,
+      ord: 7,
+      title:
+        "Trzecie czytanie rządowego projektu ustawy o zmianie ustawy o podatku dochodowym od osób fizycznych oraz niektórych innych ustaw",
+      date: "2026-05-15",
+      startTime: "10:00",
+      durationMin: 22,
+      stages: ["III czytanie", "Głosowanie"],
+      processes: [
+        {
+          term: 10,
+          number: "841",
+          shortTitle: "Zmiany w PIT — kwota wolna 60 tys. zł",
+          topicTag: "podatki",
+        },
+      ],
+      prints: [{ term: 10, number: "841" }],
+      statementCount: 8,
+      votingCount: 12,
+      uniqueSpeakers: 6,
+      summary:
+        "Ustawa przyjęta: 248 ZA, 198 PRZECIW, 12 WSTRZ. Pełny rozłam koalicja–opozycja; trzech posłów PiS zagłosowało ZA.",
+      topicTags: ["podatki"],
+      viralQuote: null,
+    },
+    {
+      agendaItemId: 8,
+      ord: 8,
+      title:
+        "Wniosek o odwołanie Marszałka Sejmu",
+      date: "2026-05-15",
+      startTime: "11:45",
+      durationMin: 95,
+      stages: ["Wniosek formalny", "Głosowanie"],
+      processes: [],
+      prints: [{ term: 10, number: "918" }],
+      statementCount: 22,
+      votingCount: 1,
+      uniqueSpeakers: 18,
+      summary:
+        "Wniosek złożony przez klub PiS odrzucony: 162 ZA, 281 PRZECIW. Główny zarzut: jednostronne stosowanie regulaminu w sprawie immunitetów.",
+      topicTags: ["regulamin", "władze Sejmu"],
+      viralQuote: {
+        statementId: 413892,
+        speakerName: "Mariusz Błaszczak",
+        clubRef: "PiS",
+        function: "przewodniczący klubu",
+        quote:
+          "Pan marszałek prowadzi obrady jak prezes spółki z o.o. — tylko z większościowym pakietem. Sejm to nie spółka.",
+      },
+    },
+  ],
+};

--- a/frontend/app/posiedzenie/mockup/page.tsx
+++ b/frontend/app/posiedzenie/mockup/page.tsx
@@ -1,0 +1,524 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { MOCK_SITTING, type AgendaPoint, type StageBadge } from "./data";
+
+export const metadata: Metadata = {
+  title: "Posiedzenie 19 — porządek obrad · mockup",
+  robots: { index: false, follow: false },
+};
+
+const PL_DATE_LONG = new Intl.DateTimeFormat("pl-PL", {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+});
+const PL_DATE_SHORT = new Intl.DateTimeFormat("pl-PL", {
+  day: "numeric",
+  month: "long",
+});
+const PL_WEEKDAY = new Intl.DateTimeFormat("pl-PL", { weekday: "long" });
+
+function formatDateRange(dates: string[]): string {
+  if (dates.length === 0) return "—";
+  if (dates.length === 1) return PL_DATE_LONG.format(new Date(dates[0]));
+  const f = new Date(dates[0]);
+  const l = new Date(dates[dates.length - 1]);
+  const sameMonth = f.getMonth() === l.getMonth() && f.getFullYear() === l.getFullYear();
+  if (sameMonth) {
+    const monthYear = new Intl.DateTimeFormat("pl-PL", {
+      month: "long",
+      year: "numeric",
+    }).format(f);
+    return `${f.getDate()}–${l.getDate()} ${monthYear}`;
+  }
+  return `${PL_DATE_LONG.format(f)} – ${PL_DATE_LONG.format(l)}`;
+}
+
+function formatDuration(min: number | null): string {
+  if (!min) return "—";
+  if (min < 60) return `${min} min`;
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m === 0 ? `${h} h` : `${h} h ${m} min`;
+}
+
+const STAGE_TONE: Record<StageBadge, "neutral" | "vote" | "info" | "alarm"> = {
+  "I czytanie": "neutral",
+  "II czytanie": "neutral",
+  "III czytanie": "vote",
+  "Głosowanie": "vote",
+  "Sprawozdanie komisji": "neutral",
+  "Pierwsze czytanie": "neutral",
+  "Informacja": "info",
+  "Pytania w sprawach bieżących": "info",
+  "Wniosek formalny": "alarm",
+};
+
+function StageChip({ label }: { label: StageBadge }) {
+  const tone = STAGE_TONE[label] ?? "neutral";
+  const styles: Record<string, React.CSSProperties> = {
+    neutral: {
+      color: "var(--destructive-deep)",
+      background: "var(--muted)",
+      border: "1px solid var(--border)",
+    },
+    vote: {
+      color: "var(--primary-foreground)",
+      background: "var(--destructive-deep)",
+      border: "1px solid var(--destructive-deep)",
+    },
+    info: {
+      color: "var(--secondary-foreground)",
+      background: "var(--secondary)",
+      border: "1px solid var(--border)",
+    },
+    alarm: {
+      color: "var(--destructive)",
+      background: "var(--background)",
+      border: "1px dashed var(--destructive)",
+    },
+  };
+  return (
+    <span
+      className="font-sans uppercase shrink-0"
+      style={{
+        fontSize: 10,
+        letterSpacing: "0.08em",
+        padding: "3px 7px",
+        borderRadius: 2,
+        whiteSpace: "nowrap",
+        ...styles[tone],
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function KpiBlock({
+  value,
+  label,
+  sub,
+}: {
+  value: string | number;
+  label: string;
+  sub?: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="font-mono text-[9px] tracking-[0.18em] uppercase text-muted-foreground mb-1.5">
+        {label}
+      </div>
+      <div
+        className="font-serif font-medium text-foreground"
+        style={{ fontSize: "clamp(1.75rem, 3.4vw, 2.5rem)", lineHeight: 1 }}
+      >
+        {value}
+      </div>
+      {sub && (
+        <div className="font-sans text-[11px] text-muted-foreground mt-1.5 leading-snug">
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DayChip({
+  date,
+  pointCount,
+  active = false,
+}: {
+  date: string;
+  pointCount: number;
+  active?: boolean;
+}) {
+  const d = new Date(date);
+  return (
+    <a
+      href={`#dzien-${date}`}
+      className="block px-4 py-3 border transition-colors hover:bg-muted"
+      style={{
+        borderColor: active ? "var(--destructive-deep)" : "var(--border)",
+        background: active ? "var(--secondary)" : "transparent",
+        minWidth: 140,
+      }}
+    >
+      <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-muted-foreground">
+        {PL_WEEKDAY.format(d)}
+      </div>
+      <div
+        className="font-serif font-medium text-foreground mt-1"
+        style={{ fontSize: 18, lineHeight: 1.1 }}
+      >
+        {PL_DATE_SHORT.format(d)}
+      </div>
+      <div className="font-sans text-[11px] text-muted-foreground mt-1">
+        {pointCount} {pointCount === 1 ? "punkt" : "punktów"}
+      </div>
+    </a>
+  );
+}
+
+function ProcessLink({ p }: { p: AgendaPoint["processes"][number] }) {
+  return (
+    <Link
+      href={`/proces/${p.term}/${p.number}`}
+      className="inline-flex items-center gap-2 px-2.5 py-1 border border-border hover:bg-muted transition-colors"
+      style={{ borderRadius: 2 }}
+    >
+      <span
+        className="font-mono text-[10px] tracking-[0.06em] text-muted-foreground"
+        style={{ minWidth: 36 }}
+      >
+        DRUK&nbsp;{p.number}
+      </span>
+      <span
+        className="font-serif text-secondary-foreground"
+        style={{ fontSize: 12.5, lineHeight: 1.3 }}
+      >
+        {p.shortTitle}
+      </span>
+    </Link>
+  );
+}
+
+function PrintChip({ p }: { p: AgendaPoint["prints"][number] }) {
+  return (
+    <Link
+      href={`/druk/${p.term}/${p.number}`}
+      className="font-mono text-[10px] uppercase tracking-[0.06em] text-muted-foreground hover:text-foreground transition-colors px-1.5 py-0.5"
+      style={{
+        background: "var(--background)",
+        border: "1px dotted var(--border)",
+        borderRadius: 2,
+      }}
+    >
+      druk&nbsp;{p.number}
+    </Link>
+  );
+}
+
+function ViralPull({ q }: { q: NonNullable<AgendaPoint["viralQuote"]> }) {
+  return (
+    <figure
+      className="mt-5 pl-5 border-l-2"
+      style={{ borderColor: "var(--destructive-deep)" }}
+    >
+      <blockquote
+        className="font-serif italic text-foreground"
+        style={{ fontSize: 17, lineHeight: 1.45, textWrap: "pretty" as never }}
+      >
+        „{q.quote}”
+      </blockquote>
+      <figcaption className="font-sans text-[11.5px] text-muted-foreground mt-2">
+        <span className="font-medium text-secondary-foreground">{q.speakerName}</span>
+        {q.clubRef && <span> · {q.clubRef}</span>}
+        {q.function && <span> · {q.function}</span>}
+      </figcaption>
+    </figure>
+  );
+}
+
+function AgendaPointCard({ point }: { point: AgendaPoint }) {
+  const d = new Date(point.date);
+  return (
+    <article
+      className="grid gap-6 md:gap-10 py-8 md:py-10 border-b border-border"
+      style={{ gridTemplateColumns: "minmax(0, 100px) minmax(0, 1fr)" }}
+    >
+      {/* Left column: big ord + meta */}
+      <aside className="min-w-0">
+        <div
+          className="font-serif italic font-medium text-secondary-foreground"
+          style={{ fontSize: 56, lineHeight: 0.9 }}
+        >
+          {String(point.ord).padStart(2, "0")}
+        </div>
+        <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground mt-3 leading-[1.7]">
+          <div>{PL_DATE_SHORT.format(d)}</div>
+          {point.startTime && <div>godz. {point.startTime}</div>}
+          {point.durationMin !== null && (
+            <div className="text-foreground/70">
+              {formatDuration(point.durationMin)}
+            </div>
+          )}
+        </div>
+      </aside>
+
+      {/* Right column: stages, title, links, summary, quote, stats */}
+      <div className="min-w-0 max-w-[820px]">
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {point.stages.map((s) => (
+            <StageChip key={s} label={s} />
+          ))}
+        </div>
+
+        <h3
+          className="font-serif font-medium text-foreground m-0"
+          style={{
+            fontSize: 22,
+            lineHeight: 1.25,
+            letterSpacing: "-0.01em",
+            textWrap: "balance" as never,
+          }}
+        >
+          {point.title}
+        </h3>
+
+        {point.processes.length > 0 && (
+          <div className="mt-4 flex flex-col gap-1.5">
+            {point.processes.map((p) => (
+              <ProcessLink key={p.number} p={p} />
+            ))}
+          </div>
+        )}
+
+        {point.prints.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {point.prints.map((p) => (
+              <PrintChip key={p.number} p={p} />
+            ))}
+          </div>
+        )}
+
+        {point.summary && (
+          <p
+            className="font-serif text-secondary-foreground mt-5"
+            style={{
+              fontSize: 14.5,
+              lineHeight: 1.55,
+              textWrap: "pretty" as never,
+            }}
+          >
+            {point.summary}
+          </p>
+        )}
+
+        {point.viralQuote && <ViralPull q={point.viralQuote} />}
+
+        {/* Inline stat row */}
+        <div className="mt-6 flex flex-wrap items-baseline gap-x-6 gap-y-2 pt-4 border-t border-border">
+          <Stat n={point.statementCount} label="wypowiedzi" />
+          <Stat n={point.uniqueSpeakers} label="mówców" />
+          <Stat n={point.votingCount} label="głosowań" emphasize={point.votingCount > 0} />
+          {point.topicTags.length > 0 && (
+            <div className="ml-auto flex flex-wrap gap-1">
+              {point.topicTags.map((t) => (
+                <span
+                  key={t}
+                  className="font-sans text-[10px] uppercase tracking-[0.1em] text-muted-foreground"
+                >
+                  #{t}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1 font-sans text-[12px]">
+          <a
+            href={`#statements-${point.agendaItemId}`}
+            className="text-destructive hover:underline"
+          >
+            Wypowiedzi w tym punkcie →
+          </a>
+          {point.votingCount > 0 && (
+            <a
+              href={`#votings-${point.agendaItemId}`}
+              className="text-destructive hover:underline"
+            >
+              Wyniki głosowań →
+            </a>
+          )}
+          <a
+            href={`#stenogram-${point.agendaItemId}`}
+            className="text-muted-foreground hover:text-foreground hover:underline"
+          >
+            Stenogram (fragment)
+          </a>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function Stat({
+  n,
+  label,
+  emphasize = false,
+}: {
+  n: number;
+  label: string;
+  emphasize?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <span
+        className="font-serif font-medium"
+        style={{
+          fontSize: 18,
+          color: emphasize ? "var(--destructive-deep)" : "var(--foreground)",
+        }}
+      >
+        {n}
+      </span>
+      <span className="font-sans text-[11px] text-muted-foreground uppercase tracking-[0.08em]">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export default function ProceedingMockupPage() {
+  const s = MOCK_SITTING;
+  const byDay = new Map<string, number>();
+  for (const p of s.points) {
+    byDay.set(p.date, (byDay.get(p.date) ?? 0) + 1);
+  }
+
+  return (
+    <main className="bg-background min-h-screen pb-20">
+      {/* Top breadcrumb / kicker */}
+      <div className="border-b border-border">
+        <div className="max-w-[1280px] mx-auto px-3 md:px-6 py-3 font-sans text-[11px] text-muted-foreground flex items-center gap-2">
+          <Link href="/" className="hover:text-foreground">
+            Tygodnik Sejmowy
+          </Link>
+          <span>·</span>
+          <Link href="/tygodnik" className="hover:text-foreground">
+            Posiedzenia
+          </Link>
+          <span>·</span>
+          <span className="text-foreground">
+            X kadencja, posiedzenie nr {s.number}
+          </span>
+          {s.current && (
+            <span
+              className="ml-auto font-sans uppercase"
+              style={{
+                fontSize: 9,
+                letterSpacing: "0.16em",
+                padding: "2px 8px",
+                borderRadius: 2,
+                color: "var(--destructive-foreground)",
+                background: "var(--destructive)",
+              }}
+            >
+              ● trwa
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Hero */}
+      <section className="border-b border-border">
+        <div className="max-w-[1280px] mx-auto px-3 md:px-6 py-10 md:py-14">
+          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground mb-3">
+            Posiedzenie nr {s.number} · X kadencja · {formatDateRange(s.dates)}
+          </div>
+          <h1
+            className="font-serif font-medium text-foreground m-0"
+            style={{
+              fontSize: "clamp(1.75rem, 4vw, 2.75rem)",
+              lineHeight: 1.1,
+              letterSpacing: "-0.02em",
+              textWrap: "balance" as never,
+              maxWidth: 900,
+            }}
+          >
+            Porządek obrad
+          </h1>
+          <p
+            className="font-serif italic text-muted-foreground mt-3"
+            style={{ fontSize: 16, maxWidth: 720 }}
+          >
+            Wszystkie punkty omówione w czasie trzech dni obrad — z linkami do
+            procesów legislacyjnych, druków, wypowiedzi i wyników głosowań.
+          </p>
+
+          {/* KPI strip */}
+          <div className="mt-10 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-8 pt-8 border-t border-border">
+            <KpiBlock value={s.totalPoints} label="Punkty obrad" sub="zgodnie z porządkiem" />
+            <KpiBlock
+              value={s.totalVotings}
+              label="Głosowań"
+              sub="łącznie w tym posiedzeniu"
+            />
+            <KpiBlock
+              value={s.totalStatements}
+              label="Wypowiedzi"
+              sub={`${s.totalSpeakers} unikalnych mówców`}
+            />
+            <KpiBlock
+              value={s.dates.length}
+              label="Dni obrad"
+              sub={formatDateRange(s.dates)}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Day timeline */}
+      <section className="border-b border-border">
+        <div className="max-w-[1280px] mx-auto px-3 md:px-6 py-6">
+          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground mb-3">
+            Skok do dnia
+          </div>
+          <div className="flex gap-2 overflow-x-auto pb-1">
+            {s.dates.map((d, i) => (
+              <DayChip
+                key={d}
+                date={d}
+                pointCount={byDay.get(d) ?? 0}
+                active={i === 0}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Agenda points list */}
+      <section>
+        <div className="max-w-[1280px] mx-auto px-3 md:px-6 py-8">
+          <div className="flex items-baseline justify-between mb-2 pb-3 border-b border-border">
+            <h2
+              className="font-serif font-medium text-foreground m-0"
+              style={{ fontSize: 22, letterSpacing: "-0.015em" }}
+            >
+              Punkty obrad
+            </h2>
+            <div className="font-sans text-[11px] text-muted-foreground">
+              {s.points.length} z {s.totalPoints} (skrót — kliknij, aby
+              rozwinąć)
+            </div>
+          </div>
+
+          {s.points.map((p) => (
+            <AgendaPointCard key={p.agendaItemId} point={p} />
+          ))}
+        </div>
+      </section>
+
+      {/* Footer ribbon */}
+      <section>
+        <div className="max-w-[1280px] mx-auto px-3 md:px-6 py-10">
+          <div className="flex flex-wrap items-baseline gap-x-6 gap-y-3 font-sans text-[12.5px]">
+            <a className="text-destructive hover:underline" href="#">
+              Pobierz pełny stenogram (PDF) →
+            </a>
+            <a className="text-destructive hover:underline" href="#">
+              Wszystkie głosowania tego posiedzenia →
+            </a>
+            <a className="text-muted-foreground hover:text-foreground hover:underline" href="#">
+              Subskrybuj RSS posiedzeń
+            </a>
+            <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+              źródło: api.sejm.gov.pl · /sejm/term10/proceedings/{s.number}
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/app/posiedzenie/mockup/page.tsx
+++ b/frontend/app/posiedzenie/mockup/page.tsx
@@ -1,524 +1,60 @@
+// Mockup orchestrator for /posiedzenie/mockup. Client component because
+// DayTabs / PorzadekObrad / TwojeSprawy share an activeDay state.
+// All data flows from data.ts — no Supabase access on this route.
+
+"use client";
+
+import { useState } from "react";
 import Link from "next/link";
-import type { Metadata } from "next";
-import { MOCK_SITTING, type AgendaPoint, type StageBadge } from "./data";
-
-export const metadata: Metadata = {
-  title: "Posiedzenie 19 — porządek obrad · mockup",
-  robots: { index: false, follow: false },
-};
-
-const PL_DATE_LONG = new Intl.DateTimeFormat("pl-PL", {
-  day: "numeric",
-  month: "long",
-  year: "numeric",
-});
-const PL_DATE_SHORT = new Intl.DateTimeFormat("pl-PL", {
-  day: "numeric",
-  month: "long",
-});
-const PL_WEEKDAY = new Intl.DateTimeFormat("pl-PL", { weekday: "long" });
-
-function formatDateRange(dates: string[]): string {
-  if (dates.length === 0) return "—";
-  if (dates.length === 1) return PL_DATE_LONG.format(new Date(dates[0]));
-  const f = new Date(dates[0]);
-  const l = new Date(dates[dates.length - 1]);
-  const sameMonth = f.getMonth() === l.getMonth() && f.getFullYear() === l.getFullYear();
-  if (sameMonth) {
-    const monthYear = new Intl.DateTimeFormat("pl-PL", {
-      month: "long",
-      year: "numeric",
-    }).format(f);
-    return `${f.getDate()}–${l.getDate()} ${monthYear}`;
-  }
-  return `${PL_DATE_LONG.format(f)} – ${PL_DATE_LONG.format(l)}`;
-}
-
-function formatDuration(min: number | null): string {
-  if (!min) return "—";
-  if (min < 60) return `${min} min`;
-  const h = Math.floor(min / 60);
-  const m = min % 60;
-  return m === 0 ? `${h} h` : `${h} h ${m} min`;
-}
-
-const STAGE_TONE: Record<StageBadge, "neutral" | "vote" | "info" | "alarm"> = {
-  "I czytanie": "neutral",
-  "II czytanie": "neutral",
-  "III czytanie": "vote",
-  "Głosowanie": "vote",
-  "Sprawozdanie komisji": "neutral",
-  "Pierwsze czytanie": "neutral",
-  "Informacja": "info",
-  "Pytania w sprawach bieżących": "info",
-  "Wniosek formalny": "alarm",
-};
-
-function StageChip({ label }: { label: StageBadge }) {
-  const tone = STAGE_TONE[label] ?? "neutral";
-  const styles: Record<string, React.CSSProperties> = {
-    neutral: {
-      color: "var(--destructive-deep)",
-      background: "var(--muted)",
-      border: "1px solid var(--border)",
-    },
-    vote: {
-      color: "var(--primary-foreground)",
-      background: "var(--destructive-deep)",
-      border: "1px solid var(--destructive-deep)",
-    },
-    info: {
-      color: "var(--secondary-foreground)",
-      background: "var(--secondary)",
-      border: "1px solid var(--border)",
-    },
-    alarm: {
-      color: "var(--destructive)",
-      background: "var(--background)",
-      border: "1px dashed var(--destructive)",
-    },
-  };
-  return (
-    <span
-      className="font-sans uppercase shrink-0"
-      style={{
-        fontSize: 10,
-        letterSpacing: "0.08em",
-        padding: "3px 7px",
-        borderRadius: 2,
-        whiteSpace: "nowrap",
-        ...styles[tone],
-      }}
-    >
-      {label}
-    </span>
-  );
-}
-
-function KpiBlock({
-  value,
-  label,
-  sub,
-}: {
-  value: string | number;
-  label: string;
-  sub?: string;
-}) {
-  return (
-    <div className="min-w-0">
-      <div className="font-mono text-[9px] tracking-[0.18em] uppercase text-muted-foreground mb-1.5">
-        {label}
-      </div>
-      <div
-        className="font-serif font-medium text-foreground"
-        style={{ fontSize: "clamp(1.75rem, 3.4vw, 2.5rem)", lineHeight: 1 }}
-      >
-        {value}
-      </div>
-      {sub && (
-        <div className="font-sans text-[11px] text-muted-foreground mt-1.5 leading-snug">
-          {sub}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function DayChip({
-  date,
-  pointCount,
-  active = false,
-}: {
-  date: string;
-  pointCount: number;
-  active?: boolean;
-}) {
-  const d = new Date(date);
-  return (
-    <a
-      href={`#dzien-${date}`}
-      className="block px-4 py-3 border transition-colors hover:bg-muted"
-      style={{
-        borderColor: active ? "var(--destructive-deep)" : "var(--border)",
-        background: active ? "var(--secondary)" : "transparent",
-        minWidth: 140,
-      }}
-    >
-      <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-muted-foreground">
-        {PL_WEEKDAY.format(d)}
-      </div>
-      <div
-        className="font-serif font-medium text-foreground mt-1"
-        style={{ fontSize: 18, lineHeight: 1.1 }}
-      >
-        {PL_DATE_SHORT.format(d)}
-      </div>
-      <div className="font-sans text-[11px] text-muted-foreground mt-1">
-        {pointCount} {pointCount === 1 ? "punkt" : "punktów"}
-      </div>
-    </a>
-  );
-}
-
-function ProcessLink({ p }: { p: AgendaPoint["processes"][number] }) {
-  return (
-    <Link
-      href={`/proces/${p.term}/${p.number}`}
-      className="inline-flex items-center gap-2 px-2.5 py-1 border border-border hover:bg-muted transition-colors"
-      style={{ borderRadius: 2 }}
-    >
-      <span
-        className="font-mono text-[10px] tracking-[0.06em] text-muted-foreground"
-        style={{ minWidth: 36 }}
-      >
-        DRUK&nbsp;{p.number}
-      </span>
-      <span
-        className="font-serif text-secondary-foreground"
-        style={{ fontSize: 12.5, lineHeight: 1.3 }}
-      >
-        {p.shortTitle}
-      </span>
-    </Link>
-  );
-}
-
-function PrintChip({ p }: { p: AgendaPoint["prints"][number] }) {
-  return (
-    <Link
-      href={`/druk/${p.term}/${p.number}`}
-      className="font-mono text-[10px] uppercase tracking-[0.06em] text-muted-foreground hover:text-foreground transition-colors px-1.5 py-0.5"
-      style={{
-        background: "var(--background)",
-        border: "1px dotted var(--border)",
-        borderRadius: 2,
-      }}
-    >
-      druk&nbsp;{p.number}
-    </Link>
-  );
-}
-
-function ViralPull({ q }: { q: NonNullable<AgendaPoint["viralQuote"]> }) {
-  return (
-    <figure
-      className="mt-5 pl-5 border-l-2"
-      style={{ borderColor: "var(--destructive-deep)" }}
-    >
-      <blockquote
-        className="font-serif italic text-foreground"
-        style={{ fontSize: 17, lineHeight: 1.45, textWrap: "pretty" as never }}
-      >
-        „{q.quote}”
-      </blockquote>
-      <figcaption className="font-sans text-[11.5px] text-muted-foreground mt-2">
-        <span className="font-medium text-secondary-foreground">{q.speakerName}</span>
-        {q.clubRef && <span> · {q.clubRef}</span>}
-        {q.function && <span> · {q.function}</span>}
-      </figcaption>
-    </figure>
-  );
-}
-
-function AgendaPointCard({ point }: { point: AgendaPoint }) {
-  const d = new Date(point.date);
-  return (
-    <article
-      className="grid gap-6 md:gap-10 py-8 md:py-10 border-b border-border"
-      style={{ gridTemplateColumns: "minmax(0, 100px) minmax(0, 1fr)" }}
-    >
-      {/* Left column: big ord + meta */}
-      <aside className="min-w-0">
-        <div
-          className="font-serif italic font-medium text-secondary-foreground"
-          style={{ fontSize: 56, lineHeight: 0.9 }}
-        >
-          {String(point.ord).padStart(2, "0")}
-        </div>
-        <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground mt-3 leading-[1.7]">
-          <div>{PL_DATE_SHORT.format(d)}</div>
-          {point.startTime && <div>godz. {point.startTime}</div>}
-          {point.durationMin !== null && (
-            <div className="text-foreground/70">
-              {formatDuration(point.durationMin)}
-            </div>
-          )}
-        </div>
-      </aside>
-
-      {/* Right column: stages, title, links, summary, quote, stats */}
-      <div className="min-w-0 max-w-[820px]">
-        <div className="flex flex-wrap gap-1.5 mb-3">
-          {point.stages.map((s) => (
-            <StageChip key={s} label={s} />
-          ))}
-        </div>
-
-        <h3
-          className="font-serif font-medium text-foreground m-0"
-          style={{
-            fontSize: 22,
-            lineHeight: 1.25,
-            letterSpacing: "-0.01em",
-            textWrap: "balance" as never,
-          }}
-        >
-          {point.title}
-        </h3>
-
-        {point.processes.length > 0 && (
-          <div className="mt-4 flex flex-col gap-1.5">
-            {point.processes.map((p) => (
-              <ProcessLink key={p.number} p={p} />
-            ))}
-          </div>
-        )}
-
-        {point.prints.length > 0 && (
-          <div className="mt-3 flex flex-wrap gap-1.5">
-            {point.prints.map((p) => (
-              <PrintChip key={p.number} p={p} />
-            ))}
-          </div>
-        )}
-
-        {point.summary && (
-          <p
-            className="font-serif text-secondary-foreground mt-5"
-            style={{
-              fontSize: 14.5,
-              lineHeight: 1.55,
-              textWrap: "pretty" as never,
-            }}
-          >
-            {point.summary}
-          </p>
-        )}
-
-        {point.viralQuote && <ViralPull q={point.viralQuote} />}
-
-        {/* Inline stat row */}
-        <div className="mt-6 flex flex-wrap items-baseline gap-x-6 gap-y-2 pt-4 border-t border-border">
-          <Stat n={point.statementCount} label="wypowiedzi" />
-          <Stat n={point.uniqueSpeakers} label="mówców" />
-          <Stat n={point.votingCount} label="głosowań" emphasize={point.votingCount > 0} />
-          {point.topicTags.length > 0 && (
-            <div className="ml-auto flex flex-wrap gap-1">
-              {point.topicTags.map((t) => (
-                <span
-                  key={t}
-                  className="font-sans text-[10px] uppercase tracking-[0.1em] text-muted-foreground"
-                >
-                  #{t}
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
-
-        <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1 font-sans text-[12px]">
-          <a
-            href={`#statements-${point.agendaItemId}`}
-            className="text-destructive hover:underline"
-          >
-            Wypowiedzi w tym punkcie →
-          </a>
-          {point.votingCount > 0 && (
-            <a
-              href={`#votings-${point.agendaItemId}`}
-              className="text-destructive hover:underline"
-            >
-              Wyniki głosowań →
-            </a>
-          )}
-          <a
-            href={`#stenogram-${point.agendaItemId}`}
-            className="text-muted-foreground hover:text-foreground hover:underline"
-          >
-            Stenogram (fragment)
-          </a>
-        </div>
-      </div>
-    </article>
-  );
-}
-
-function Stat({
-  n,
-  label,
-  emphasize = false,
-}: {
-  n: number;
-  label: string;
-  emphasize?: boolean;
-}) {
-  return (
-    <div className="flex items-baseline gap-1.5">
-      <span
-        className="font-serif font-medium"
-        style={{
-          fontSize: 18,
-          color: emphasize ? "var(--destructive-deep)" : "var(--foreground)",
-        }}
-      >
-        {n}
-      </span>
-      <span className="font-sans text-[11px] text-muted-foreground uppercase tracking-[0.08em]">
-        {label}
-      </span>
-    </div>
-  );
-}
+import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
+import { MOCK } from "./data";
+import { Hero } from "./_components/Hero";
+import { DayHeadline } from "./_components/DayHeadline";
+import { MomentOfDay } from "./_components/MomentOfDay";
+import { WhatPassed } from "./_components/WhatPassed";
+import { DayTimeline } from "./_components/DayTimeline";
+import { AgendaList } from "./_components/AgendaList";
+import { TopQuotes } from "./_components/TopQuotes";
+import { YourTopics } from "./_components/YourTopics";
+import { TopSpeakers } from "./_components/TopSpeakers";
+import { Friction } from "./_components/Friction";
+import { Tomorrow } from "./_components/Tomorrow";
+import { Sources } from "./_components/Sources";
 
 export default function ProceedingMockupPage() {
-  const s = MOCK_SITTING;
-  const byDay = new Map<string, number>();
-  for (const p of s.points) {
-    byDay.set(p.date, (byDay.get(p.date) ?? 0) + 1);
-  }
+  // Default to the "live" day (index 1) so the live cursor on OsDnia is visible.
+  const liveIdx = MOCK.days.findIndex((d) => d.status === "live");
+  const [activeDay, setActiveDay] = useState<number>(
+    liveIdx >= 0 ? liveIdx : 0,
+  );
+  const day = MOCK.days[activeDay];
 
   return (
-    <main className="bg-background min-h-screen pb-20">
-      {/* Top breadcrumb / kicker */}
-      <div className="border-b border-border">
-        <div className="max-w-[1280px] mx-auto px-3 md:px-6 py-3 font-sans text-[11px] text-muted-foreground flex items-center gap-2">
-          <Link href="/" className="hover:text-foreground">
-            Tygodnik Sejmowy
-          </Link>
-          <span>·</span>
-          <Link href="/tygodnik" className="hover:text-foreground">
-            Posiedzenia
-          </Link>
-          <span>·</span>
-          <span className="text-foreground">
-            X kadencja, posiedzenie nr {s.number}
-          </span>
-          {s.current && (
-            <span
-              className="ml-auto font-sans uppercase"
-              style={{
-                fontSize: 9,
-                letterSpacing: "0.16em",
-                padding: "2px 8px",
-                borderRadius: 2,
-                color: "var(--destructive-foreground)",
-                background: "var(--destructive)",
-              }}
-            >
-              ● trwa
-            </span>
-          )}
-        </div>
+    <main className="bg-background font-serif text-foreground">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 pt-5">
+        <PageBreadcrumb
+          items={[
+            { label: "Tygodnik", href: "/tygodnik" },
+            { label: "Posiedzenia", href: "/tygodnik" },
+            {
+              label: `X kadencja, posiedzenie nr ${MOCK.number}`,
+            },
+          ]}
+        />
       </div>
 
-      {/* Hero */}
-      <section className="border-b border-border">
-        <div className="max-w-[1280px] mx-auto px-3 md:px-6 py-10 md:py-14">
-          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground mb-3">
-            Posiedzenie nr {s.number} · X kadencja · {formatDateRange(s.dates)}
-          </div>
-          <h1
-            className="font-serif font-medium text-foreground m-0"
-            style={{
-              fontSize: "clamp(1.75rem, 4vw, 2.75rem)",
-              lineHeight: 1.1,
-              letterSpacing: "-0.02em",
-              textWrap: "balance" as never,
-              maxWidth: 900,
-            }}
-          >
-            Porządek obrad
-          </h1>
-          <p
-            className="font-serif italic text-muted-foreground mt-3"
-            style={{ fontSize: 16, maxWidth: 720 }}
-          >
-            Wszystkie punkty omówione w czasie trzech dni obrad — z linkami do
-            procesów legislacyjnych, druków, wypowiedzi i wyników głosowań.
-          </p>
-
-          {/* KPI strip */}
-          <div className="mt-10 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-8 pt-8 border-t border-border">
-            <KpiBlock value={s.totalPoints} label="Punkty obrad" sub="zgodnie z porządkiem" />
-            <KpiBlock
-              value={s.totalVotings}
-              label="Głosowań"
-              sub="łącznie w tym posiedzeniu"
-            />
-            <KpiBlock
-              value={s.totalStatements}
-              label="Wypowiedzi"
-              sub={`${s.totalSpeakers} unikalnych mówców`}
-            />
-            <KpiBlock
-              value={s.dates.length}
-              label="Dni obrad"
-              sub={formatDateRange(s.dates)}
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* Day timeline */}
-      <section className="border-b border-border">
-        <div className="max-w-[1280px] mx-auto px-3 md:px-6 py-6">
-          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground mb-3">
-            Skok do dnia
-          </div>
-          <div className="flex gap-2 overflow-x-auto pb-1">
-            {s.dates.map((d, i) => (
-              <DayChip
-                key={d}
-                date={d}
-                pointCount={byDay.get(d) ?? 0}
-                active={i === 0}
-              />
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Agenda points list */}
-      <section>
-        <div className="max-w-[1280px] mx-auto px-3 md:px-6 py-8">
-          <div className="flex items-baseline justify-between mb-2 pb-3 border-b border-border">
-            <h2
-              className="font-serif font-medium text-foreground m-0"
-              style={{ fontSize: 22, letterSpacing: "-0.015em" }}
-            >
-              Punkty obrad
-            </h2>
-            <div className="font-sans text-[11px] text-muted-foreground">
-              {s.points.length} z {s.totalPoints} (skrót — kliknij, aby
-              rozwinąć)
-            </div>
-          </div>
-
-          {s.points.map((p) => (
-            <AgendaPointCard key={p.agendaItemId} point={p} />
-          ))}
-        </div>
-      </section>
-
-      {/* Footer ribbon */}
-      <section>
-        <div className="max-w-[1280px] mx-auto px-3 md:px-6 py-10">
-          <div className="flex flex-wrap items-baseline gap-x-6 gap-y-3 font-sans text-[12.5px]">
-            <a className="text-destructive hover:underline" href="#">
-              Pobierz pełny stenogram (PDF) →
-            </a>
-            <a className="text-destructive hover:underline" href="#">
-              Wszystkie głosowania tego posiedzenia →
-            </a>
-            <a className="text-muted-foreground hover:text-foreground hover:underline" href="#">
-              Subskrybuj RSS posiedzeń
-            </a>
-            <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-              źródło: api.sejm.gov.pl · /sejm/term10/proceedings/{s.number}
-            </span>
-          </div>
-        </div>
-      </section>
+      <Hero activeDay={activeDay} setActiveDay={setActiveDay} />
+      <DayHeadline day={day} />
+      <MomentOfDay />
+      <WhatPassed activeDay={activeDay} />
+      <DayTimeline activeDay={activeDay} />
+      <AgendaList />
+      <TopQuotes />
+      <YourTopics />
+      <TopSpeakers />
+      <Friction />
+      <Tomorrow />
+      <Sources />
     </main>
   );
 }

--- a/frontend/app/posiedzenie/mockup/tokens.ts
+++ b/frontend/app/posiedzenie/mockup/tokens.ts
@@ -4,7 +4,7 @@
 // tone palette lives) and components/tygodnik/atoms/VoteResultBar.tsx
 // (verdict colours).
 
-import type { Tone } from "./data";
+import type { Tone, Vote } from "./data";
 
 // Tones use the same six-value palette as ToneBadge — see
 // components/statement/ToneBadge.tsx. Two values still resolve to hex
@@ -28,9 +28,25 @@ export const TONE_LABEL: Record<Tone, string> = {
   neutralny: "neutralny",
 };
 
-// Verdict colour for decision cards + VoteMini. Matches semantics from
-// VoteResultBar: pass-shaped outcome → success, reject-shaped → destructive.
-export function verdictInk(result: string): string {
+// Verdict colour for decision cards + VoteMini. Mirrors the logic in
+// components/tygodnik/atoms/VoteResultBar.tsx (computeBillOutcome): the
+// final colour depends on the motion's polarity, not just whether
+// "PRZYJĘTA" or "ODRZUCONA" appears in the verdict text.
+//
+// - "reject"/"minority" motions invert: a passed reject motion = bill
+//   killed = destructive; a rejected reject motion = bill survives = success.
+// - "procedural" motions are not bill-level decisions (e.g. odwołanie
+//   marszałka). Render warm/neutral instead of red/green.
+// - "pass"/"amendment" and missing polarity fall back to the verdict text.
+export function verdictInk(
+  result: Vote["result"],
+  motionPolarity?: Vote["motionPolarity"],
+): string {
+  if (motionPolarity === "procedural") return "var(--warning)";
+  if (motionPolarity === "reject" || motionPolarity === "minority") {
+    if (result.includes("PRZYJ")) return "var(--destructive)";
+    if (result.includes("ODRZUC")) return "var(--success)";
+  }
   if (result.includes("PRZYJ")) return "var(--success)";
   if (result.includes("ODRZUC")) return "var(--destructive)";
   return "var(--warning)";

--- a/frontend/app/posiedzenie/mockup/tokens.ts
+++ b/frontend/app/posiedzenie/mockup/tokens.ts
@@ -1,0 +1,37 @@
+// Shared semantic colour resolution for the proceeding-points mockup.
+// All values are CSS-var references — no hex codes leak into JSX. This
+// mirrors the convention in components/statement/ToneBadge.tsx (where the
+// tone palette lives) and components/tygodnik/atoms/VoteResultBar.tsx
+// (verdict colours).
+
+import type { Tone } from "./data";
+
+// Tones use the same six-value palette as ToneBadge — see
+// components/statement/ToneBadge.tsx. Two values still resolve to hex
+// rather than var() because the design system has no dedicated token for
+// "navy analytical" or "amber appeal" yet.
+export const TONE_INK: Record<Tone, string> = {
+  konfrontacyjny: "var(--destructive)",
+  techniczny: "#1e3a8a",
+  argumentowy: "var(--success)",
+  emocjonalny: "#a16207",
+  apel: "#a16207",
+  neutralny: "var(--muted-foreground)",
+};
+
+export const TONE_LABEL: Record<Tone, string> = {
+  konfrontacyjny: "konfrontacyjny",
+  techniczny: "techniczny",
+  argumentowy: "argumentowy",
+  emocjonalny: "emocjonalny",
+  apel: "apel",
+  neutralny: "neutralny",
+};
+
+// Verdict colour for decision cards + VoteMini. Matches semantics from
+// VoteResultBar: pass-shaped outcome → success, reject-shaped → destructive.
+export function verdictInk(result: string): string {
+  if (result.includes("PRZYJ")) return "var(--success)";
+  if (result.includes("ODRZUC")) return "var(--destructive)";
+  return "var(--warning)";
+}


### PR DESCRIPTION
## Summary

Adds a new `/posiedzenie/mockup` route that serves as a design-iteration sandbox for the proceeding (Sejm sitting) detail page. All data is hardcoded in `data.ts` to eliminate infrastructure dependencies during layout work. The mockup mirrors the shape of a real data loader (joining proceedings, days, agenda items, statements, and votings) but requires no database access.

## Key Changes

- **`data.ts`** — 837 lines of hardcoded proceeding mock data:
  - `ProceedingMock` type: term, number, title, dates, live status, KPI totals
  - `Day` type: date, status (done/live/planned), open/close times, headline, stats
  - `AgendaPoint` type: full agenda item with duration, summary, stages, prints, processes, tone distribution, topics, importance flag, viral quote, and vote result
  - `Vote`, `ViralQuote`, `TopQuote`, `TopSpeaker`, `Starcie` (clash), `Rebel` (defector), `PlannedCard` types
  - Polish typographic quotes throughout („ and " instead of ASCII `"`)
  - Sample data for term 10, sitting 19 (2026-05-13 to 2026-05-15)

- **`page.tsx`** — Client-side orchestrator:
  - Manages `activeDay` state shared across Hero, DayHeadline, and AgendaList
  - Renders full proceeding narrative: Hero → DayHeadline → MomentOfDay → WhatPassed → DayTimeline → AgendaList → YourTopics → TopQuotes → TopSpeakers → Friction → Tomorrow → Sources

- **Component suite** (11 new files):
  - **`Hero.tsx`** — Sitting title, 4 KPI tiles (points, statements, votes, speakers), day-tab row with active underline
  - **`DayHeadline.tsx`** — Newsroom-style 3-sentence summary on warm secondary surface
  - **`MomentOfDay.tsx`** — Top viral quote of the day with speaker photo, club badge, and editorial reason
  - **`WhatPassed.tsx`** — 3-column grid of decision cards (only points with votes)
  - **`DayTimeline.tsx`** — Hourly horizontal timeline; each punkt = block; height = speaker count; color = dominant tone; live cursor label in separate row to avoid overlap
  - **`AgendaList.tsx`** — Filterable chronological agenda (all/done/planned/vote/flagship); each row: time rail + title+summary+stats + vote OR quote OR planned badge
  - **`YourTopics.tsx`** — Topic rail (11 categories) on left; selected topic's points on right; personalisation entry point
  - **`TopQuotes.tsx`** — Ranking of 5 most-shareable quotes; rank replaces numeric score; reason explainer in right column
  - **`TopSpeakers.tsx`** — Top 8 speakers by minutes; dominant tone + best quote excerpt (not decimal score)
  - **`Friction.tsx`** — 3 biggest verbal clashes + 4 MPs who voted against their klub
  - **`Tomorrow.tsx`** — Next-day preview; planned points with topic chips and flagship flags
  - **`Sources.tsx`** — Editorial footer: primary sources, how-we-read note, share row
  - **`SectionHead.tsx`** — Reusable roman-numeral section markers (I–X) with serif styling
  - **`DayHeadline.tsx`** — Newsroom-style day summary

- **`tokens.ts`** — Shared semantic colour resolution:
  - `TONE_INK`: maps 6 tones (konfrontacyjny, techniczny, argumentowy, emocjonalny, apel, neutralny) to CSS vars
  - `TONE_LABEL`: human-readable tone names
  - `verdictInk()`: maps vote results (PRZYJĘTA, ODRZUCONA

https://claude.ai/code/session_017cGQGiKD23uoyaPFqswrpv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full proceedings mockup: hero/dashboard, day headline, filterable chronological agenda, interactive day timeline with live cursor, and next-day preview.
  * New sections: moment of the day, top quotes, top speakers, friction (debates/renegades), topic-based navigation, primary sources/share tools, and vote/result summaries.
  * UI enhancements: speaker stats, vote visualizations, tone indicators, responsive layouts, anchors for quick navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miskibin/tygodnik-sejmowy/pull/58)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->