### PR TITLE
feat(posiedzenie): wire /posiedzenie/[number] to real sitting data

### DIFF
--- a/frontend/app/posiedzenie/[number]/page.tsx
+++ b/frontend/app/posiedzenie/[number]/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getSittingView } from "@/lib/db/sittings";
+import { SittingViewClient } from "../_components/SittingViewClient";
+
+export const revalidate = 300;
+
+const DEFAULT_TERM = 10;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ number: string }>;
+}): Promise<Metadata> {
+  const { number: raw } = await params;
+  const sittingNum = Number(raw);
+  if (!Number.isFinite(sittingNum) || sittingNum < 1) return {};
+  const data = await getSittingView(DEFAULT_TERM, sittingNum);
+  if (!data) return {};
+  const title = `${data.number}. posiedzenie Sejmu — Tygodnik Sejmowy`;
+  const desc = data.title;
+  const path = `/posiedzenie/${data.number}`;
+  return {
+    title,
+    description: desc,
+    alternates: { canonical: path },
+    openGraph: { title, description: desc, url: path, type: "article" },
+    twitter: { card: "summary_large_image", title, description: desc },
+  };
+}
+
+export default async function PosiedzeniePage({
+  params,
+}: {
+  params: Promise<{ number: string }>;
+}) {
+  const { number: raw } = await params;
+  const sittingNum = Number(raw);
+  if (!Number.isFinite(sittingNum) || sittingNum < 1) notFound();
+
+  const data = await getSittingView(DEFAULT_TERM, sittingNum);
+  if (!data) notFound();
+
+  return <SittingViewClient data={data} />;
+}

--- a/frontend/app/posiedzenie/_components/AgendaList.tsx
+++ b/frontend/app/posiedzenie/_components/AgendaList.tsx
@@ -1,7 +1,4 @@
 // "Porządek obrad" — the main agenda list. Filterable, chronological.
-// Each row: ord+time rail / title+summary+stats / vote OR quote OR planned.
-// On mobile the 3-column grid stacks; the rail collapses to a horizontal
-// "PKT N · HH:MM" strip.
 
 "use client";
 
@@ -11,15 +8,8 @@ import { MPAvatarPhoto } from "@/components/tygodnik/MPAvatar";
 import { ClubBadge } from "@/components/clubs/ClubBadge";
 import { TopicChips } from "@/components/tygodnik/atoms/TopicChips";
 import { ToneBadge } from "@/components/statement/ToneBadge";
-import { TOPICS } from "@/lib/topics";
-import {
-  MOCK,
-  type AgendaPoint,
-  type Vote as VoteType,
-  type ViralQuote,
-  type Tone,
-} from "../data";
-import { TONE_INK, TONE_LABEL, verdictInk } from "../tokens";
+import type { AgendaPoint, SittingView, Tone, ViralQuote, Vote as VoteType } from "./types";
+import { TONE_INK, TONE_LABEL, verdictInk } from "./tokens";
 import { Kicker, SectionHead } from "./SectionHead";
 
 type FilterId = "all" | "done" | "planned" | "vote" | "flagship";
@@ -150,7 +140,7 @@ function VoteMini({ v }: { v: VoteType }) {
         className="font-sans"
         style={{ fontSize: 12, color: "var(--secondary-foreground)", marginBottom: 10 }}
       >
-        większością <b>{v.za}–{v.przeciw}</b>, różnica {v.margin}
+        większością <b>{v.yes}–{v.no}</b>, różnica {v.margin}
       </div>
 
       <div
@@ -158,18 +148,19 @@ function VoteMini({ v }: { v: VoteType }) {
         style={{ height: 8, border: "1px solid var(--border)" }}
         aria-hidden
       >
-        <div style={{ width: `${(v.za / 460) * 100}%`, background: "var(--success)" }} />
-        <div style={{ width: `${(v.przeciw / 460) * 100}%`, background: "var(--destructive)" }} />
-        <div style={{ width: `${(v.wstrzym / 460) * 100}%`, background: "var(--warning)" }} />
-        <div style={{ width: `${(v.nieob / 460) * 100}%`, background: "var(--border)" }} />
+        <div style={{ width: `${(v.yes / 460) * 100}%`, background: "var(--success)" }} />
+        <div style={{ width: `${(v.no / 460) * 100}%`, background: "var(--destructive)" }} />
+        <div style={{ width: `${(v.abstain / 460) * 100}%`, background: "var(--warning)" }} />
+        <div style={{ width: `${(v.absent / 460) * 100}%`, background: "var(--border)" }} />
       </div>
 
       {v.byClub && (
         <div className="mt-3 grid gap-1.5" style={{ gridTemplateColumns: "repeat(4, 1fr)" }}>
           {Object.entries(v.byClub).map(([club, cb]) => {
-            const total = (cb.za + cb.pr + cb.ws + Math.max(0, cb.nb)) || 1;
+            if (!cb) return null;
+            const total = (cb.yes + cb.no + cb.abstain + Math.max(0, cb.absent)) || 1;
             return (
-              <div key={club} title={`${club}: ZA ${cb.za}, PR ${cb.pr}, WS ${cb.ws}`}>
+              <div key={club} title={`${club}: ZA ${cb.yes}, PR ${cb.no}, WS ${cb.abstain}`}>
                 <div
                   className="font-mono"
                   style={{
@@ -182,9 +173,9 @@ function VoteMini({ v }: { v: VoteType }) {
                   {club.slice(0, 4)}
                 </div>
                 <div className="flex" style={{ height: 4 }} aria-hidden>
-                  <div style={{ width: `${(cb.za / total) * 100}%`, background: "var(--success)" }} />
-                  <div style={{ width: `${(cb.pr / total) * 100}%`, background: "var(--destructive)" }} />
-                  <div style={{ width: `${(cb.ws / total) * 100}%`, background: "var(--warning)" }} />
+                  <div style={{ width: `${(cb.yes / total) * 100}%`, background: "var(--success)" }} />
+                  <div style={{ width: `${(cb.no / total) * 100}%`, background: "var(--destructive)" }} />
+                  <div style={{ width: `${(cb.abstain / total) * 100}%`, background: "var(--warning)" }} />
                 </div>
               </div>
             );
@@ -266,7 +257,7 @@ function PlannedMini({ p }: { p: AgendaPoint }) {
   );
 }
 
-function PunktRow({ p }: { p: AgendaPoint }) {
+function AgendaRow({ p }: { p: AgendaPoint }) {
   const isFlag = p.importance === "flagship";
   return (
     <li
@@ -285,7 +276,6 @@ function PunktRow({ p }: { p: AgendaPoint }) {
           gap: 32,
         }}
       >
-        {/* Rail */}
         <div>
           <div
             className="font-serif italic font-medium"
@@ -339,10 +329,8 @@ function PunktRow({ p }: { p: AgendaPoint }) {
           )}
         </div>
 
-        {/* Center */}
-        <PunktCenter p={p} />
+        <AgendaCenter p={p} />
 
-        {/* Right */}
         <div>
           {p.vote ? (
             <VoteMini v={p.vote} />
@@ -354,7 +342,6 @@ function PunktRow({ p }: { p: AgendaPoint }) {
         </div>
       </div>
 
-      {/* Mobile stacked */}
       <div className="md:hidden">
         <div className="flex items-baseline gap-3 mb-3">
           <span
@@ -401,7 +388,7 @@ function PunktRow({ p }: { p: AgendaPoint }) {
             )}
           </div>
         </div>
-        <PunktCenter p={p} />
+        <AgendaCenter p={p} />
         <div className="mt-5">
           {p.vote ? (
             <VoteMini v={p.vote} />
@@ -416,7 +403,7 @@ function PunktRow({ p }: { p: AgendaPoint }) {
   );
 }
 
-function PunktCenter({ p }: { p: AgendaPoint }) {
+function AgendaCenter({ p }: { p: AgendaPoint }) {
   return (
     <div className="min-w-0">
       <div className="flex gap-1.5 mb-2.5 flex-wrap">
@@ -426,7 +413,7 @@ function PunktCenter({ p }: { p: AgendaPoint }) {
         {p.prints.map((d) => (
           <PrintRef key={`${d.term}-${d.number}`} term={d.term} number={d.number} />
         ))}
-        {p.procesy.map((pr) => (
+        {p.processes.map((pr) => (
           <ProcessRef key={`${pr.term}-${pr.number}`} term={pr.term} number={pr.number} />
         ))}
       </div>
@@ -443,17 +430,19 @@ function PunktCenter({ p }: { p: AgendaPoint }) {
       >
         {p.shortTitle}.
       </h3>
-      <p
-        className="font-serif m-0 mb-3.5"
-        style={{
-          fontSize: 14.5,
-          lineHeight: 1.55,
-          color: "var(--secondary-foreground)",
-          textWrap: "pretty",
-        }}
-      >
-        {p.plainSummary}
-      </p>
+      {p.plainSummary && (
+        <p
+          className="font-serif m-0 mb-3.5"
+          style={{
+            fontSize: 14.5,
+            lineHeight: 1.55,
+            color: "var(--secondary-foreground)",
+            textWrap: "pretty",
+          }}
+        >
+          {p.plainSummary}
+        </p>
+      )}
 
       <details className="mb-4">
         <summary
@@ -491,20 +480,20 @@ function PunktCenter({ p }: { p: AgendaPoint }) {
         >
           <span>
             <b style={{ color: "var(--foreground)", fontWeight: 700 }}>
-              {p.stats.wypowiedzi}
+              {p.stats.statements}
             </b>{" "}
             wypowiedzi
           </span>
           <span>
             <b style={{ color: "var(--foreground)", fontWeight: 700 }}>
-              {p.stats.mowcy}
+              {p.stats.speakers}
             </b>{" "}
             mówców
           </span>
-          {p.stats.glosowania > 0 && (
+          {p.stats.votes > 0 && (
             <span>
               <b style={{ color: "var(--foreground)", fontWeight: 700 }}>
-                {p.stats.glosowania}
+                {p.stats.votes}
               </b>{" "}
               głosowań
             </span>
@@ -522,18 +511,18 @@ function PunktCenter({ p }: { p: AgendaPoint }) {
   );
 }
 
-export function AgendaList() {
+export function AgendaList({ data }: { data: SittingView }) {
   const [filter, setFilter] = useState<FilterId>("all");
 
   const counts: Record<FilterId, number> = {
-    all: MOCK.punkty.length,
-    done: MOCK.punkty.filter((p) => !p.planned).length,
-    planned: MOCK.punkty.filter((p) => p.planned).length,
-    vote: MOCK.punkty.filter((p) => !!p.vote).length,
-    flagship: MOCK.punkty.filter((p) => p.importance === "flagship").length,
+    all: data.agendaPoints.length,
+    done: data.agendaPoints.filter((p) => !p.planned).length,
+    planned: data.agendaPoints.filter((p) => p.planned).length,
+    vote: data.agendaPoints.filter((p) => !!p.vote).length,
+    flagship: data.agendaPoints.filter((p) => p.importance === "flagship").length,
   };
 
-  const visible = MOCK.punkty.filter(FILTERS.find((f) => f.id === filter)!.pred);
+  const visible = data.agendaPoints.filter(FILTERS.find((f) => f.id === filter)!.pred);
 
   return (
     <section className="border-b border-border">
@@ -580,7 +569,7 @@ export function AgendaList() {
 
         <ol className="list-none p-0 m-0">
           {visible.map((p) => (
-            <PunktRow key={p.ord} p={p} />
+            <AgendaRow key={p.ord} p={p} />
           ))}
         </ol>
       </div>

--- a/frontend/app/posiedzenie/_components/DayHeadline.tsx
+++ b/frontend/app/posiedzenie/_components/DayHeadline.tsx
@@ -1,13 +1,11 @@
-// Newsroom-style 3-sentence summary of a single day. Sits on a warm
-// secondary surface (no inverted black panel) and uses the destructive
-// accent for the kicker rule, mirroring the editorial voice elsewhere
-// in the site (BriefList atoms, ViralQuote card).
+// Newsroom-style 3-sentence summary of a single day.
 
-import type { Day } from "../data";
+import type { Day } from "./types";
 import { Kicker } from "./SectionHead";
 
 export function DayHeadline({ day }: { day: Day }) {
   const year = day.date ? new Date(day.date).getFullYear() : "";
+  const hasHeadline = !!day.headline && day.headline.trim().length > 0;
   return (
     <section
       className="border-b border-border"
@@ -51,19 +49,33 @@ export function DayHeadline({ day }: { day: Day }) {
           </div>
 
           <div>
-            <p
-              className="font-serif m-0"
-              style={{
-                fontSize: 28,
-                lineHeight: 1.25,
-                letterSpacing: "-0.012em",
-                color: "var(--foreground)",
-                textWrap: "balance",
-                fontWeight: 400,
-              }}
-            >
-              {day.headline}
-            </p>
+            {hasHeadline ? (
+              <p
+                className="font-serif m-0"
+                style={{
+                  fontSize: 28,
+                  lineHeight: 1.25,
+                  letterSpacing: "-0.012em",
+                  color: "var(--foreground)",
+                  textWrap: "balance",
+                  fontWeight: 400,
+                }}
+              >
+                {day.headline}
+              </p>
+            ) : (
+              <p
+                className="font-serif italic m-0"
+                style={{
+                  fontSize: 18,
+                  lineHeight: 1.4,
+                  color: "var(--muted-foreground)",
+                }}
+              >
+                Redaktorska syntéza tego dnia jeszcze niegotowa — patrz statystyki
+                obok i pełny porządek obrad poniżej.
+              </p>
+            )}
 
             <div
               className="mt-5 flex gap-x-9 gap-y-2 flex-wrap font-sans text-secondary-foreground"
@@ -71,17 +83,17 @@ export function DayHeadline({ day }: { day: Day }) {
             >
               <span>
                 <b style={{ color: "var(--success)" }}>
-                  {day.stats.glosowania} głosowań
+                  {day.stats.votes} głosowań
                 </b>
                 {" "}rozstrzygających
               </span>
               <span>
-                <b style={{ color: "var(--foreground)" }}>{day.stats.punkty}</b>{" "}
+                <b style={{ color: "var(--foreground)" }}>{day.stats.points}</b>{" "}
                 punktów porządku obrad
               </span>
               <span>
                 <b style={{ color: "var(--foreground)" }}>
-                  {day.stats.wypowiedzi}
+                  {day.stats.statements}
                 </b>{" "}
                 wypowiedzi z mównicy
               </span>

--- a/frontend/app/posiedzenie/_components/DayHeadline.tsx
+++ b/frontend/app/posiedzenie/_components/DayHeadline.tsx
@@ -72,7 +72,7 @@ export function DayHeadline({ day }: { day: Day }) {
                   color: "var(--muted-foreground)",
                 }}
               >
-                Redaktorska syntéza tego dnia jeszcze niegotowa — patrz statystyki
+                Redaktorska synteza tego dnia jeszcze niegotowa — patrz statystyki
                 obok i pełny porządek obrad poniżej.
               </p>
             )}

--- a/frontend/app/posiedzenie/_components/DayTimeline.tsx
+++ b/frontend/app/posiedzenie/_components/DayTimeline.tsx
@@ -1,11 +1,8 @@
-// Hourly horizontal timeline. Each punkt = a block; block height = number
-// of speakers; block fill colour = dominant tone (uses ToneBadge palette
-// via tokens.ts). Live cursor label sits BELOW the hour ruler in its own
-// row so it never overlaps hour ticks. Narrow blocks (<60px) hide the
-// title text — only "PKT N" remains visible, full title appears on hover.
+// Hourly horizontal timeline. Each agenda point = a block; block height =
+// number of speakers; block fill colour = dominant tone.
 
-import { MOCK, type AgendaPoint, type Tone } from "../data";
-import { TONE_INK, TONE_LABEL } from "../tokens";
+import type { SittingView, Tone } from "./types";
+import { TONE_INK, TONE_LABEL } from "./tokens";
 import { Kicker, SectionHead } from "./SectionHead";
 
 function timeToMin(t: string): number {
@@ -38,19 +35,26 @@ const TONES_IN_LEGEND: Tone[] = [
   "neutralny",
 ];
 
-export function DayTimeline({ activeDay }: { activeDay: number }) {
-  const day = MOCK.days[activeDay];
+export function DayTimeline({
+  data,
+  activeDay,
+}: {
+  data: SittingView;
+  activeDay: number;
+}) {
+  const day = data.days[activeDay];
   if (!day) return null;
-  const points = MOCK.punkty.filter((p) => p.date === day.date);
+  const points = data.agendaPoints.filter((p) => p.date === day.date);
   if (points.length === 0) {
     return null;
   }
-  // Pick a comfortable window covering all blocks + a little margin.
   const startMin = 9 * 60;
   const endMin = 22 * 60;
   const span = endMin - startMin;
 
-  const liveMin = day.status === "live" ? timeToMin(MOCK.liveAt) - startMin : null;
+  const liveMin = day.status === "live" && data.liveAt
+    ? timeToMin(data.liveAt) - startMin
+    : null;
   const toPct = (t: string) => ((timeToMin(t) - startMin) / span) * 100;
 
   const hours: number[] = [];
@@ -66,7 +70,6 @@ export function DayTimeline({ activeDay }: { activeDay: number }) {
           anchor="os"
         />
 
-        {/* Live-cursor label row — separate row to avoid overlapping hour ticks */}
         {liveMin !== null && (
           <div className="relative mb-2" style={{ height: 18 }}>
             <span
@@ -79,12 +82,11 @@ export function DayTimeline({ activeDay }: { activeDay: number }) {
                 letterSpacing: "0.14em",
               }}
             >
-              ▼ {MOCK.liveAt} na żywo
+              ▼ {data.liveAt} na żywo
             </span>
           </div>
         )}
 
-        {/* Hour ruler */}
         <div className="relative mb-1" style={{ height: 18 }}>
           {hours.map((h) => (
             <span
@@ -103,7 +105,6 @@ export function DayTimeline({ activeDay }: { activeDay: number }) {
           ))}
         </div>
 
-        {/* Track */}
         <div
           className="relative"
           style={{
@@ -145,19 +146,15 @@ export function DayTimeline({ activeDay }: { activeDay: number }) {
             const left = toPct(p.timeStart);
             const widthPct = (p.durMin / span) * 100;
             const tones = sumTones(p.tones);
+            void tones;
             const dom = dominantTone(p.tones);
             const fill = p.planned
               ? "var(--muted)"
               : dom
                 ? TONE_INK[dom]
                 : "var(--muted-foreground)";
-            const height = Math.max(38, Math.min(170, p.stats.mowcy * 5 + 28));
-            // approximate min pixel width at common viewports to decide whether to render title
-            // (we don't know runtime width here; fall back to widthPct threshold)
+            const height = Math.max(38, Math.min(170, p.stats.speakers * 5 + 28));
             const narrow = widthPct < 4.2;
-            // Vote-marker offset inside the block. Guard against zero duration
-            // and clamp to the [0, 100] range so a stale time never paints
-            // the marker outside its parent.
             const voteLeftPct = p.vote && p.durMin > 0
               ? Math.max(
                   0,
@@ -234,7 +231,6 @@ export function DayTimeline({ activeDay }: { activeDay: number }) {
           })}
         </div>
 
-        {/* Legend */}
         <div
           className="mt-4 flex flex-wrap items-center justify-between gap-3 font-sans"
           style={{ fontSize: 11.5, color: "var(--muted-foreground)" }}

--- a/frontend/app/posiedzenie/_components/Friction.tsx
+++ b/frontend/app/posiedzenie/_components/Friction.tsx
@@ -1,13 +1,11 @@
-// "Iskry i renegaci" — three biggest verbal clashes + four MPs who voted
-// against their klub. Both sides use the same warm-paper palette and the
-// destructive accent as the friction-marker.
+// "Iskry i renegaci" — verbal clashes + rebels (voted against own klub).
 
 import { MPAvatarPhoto } from "@/components/tygodnik/MPAvatar";
 import { ClubBadge } from "@/components/clubs/ClubBadge";
-import { MOCK, type Starcie, type Rebel } from "../data";
+import type { Clash, Rebel, SittingView } from "./types";
 import { Kicker, SectionHead } from "./SectionHead";
 
-function StarcieCard({ s }: { s: Starcie }) {
+function ClashCard({ s }: { s: Clash }) {
   return (
     <div
       style={{
@@ -25,7 +23,7 @@ function StarcieCard({ s }: { s: Starcie }) {
             letterSpacing: "0.14em",
           }}
         >
-          pkt {s.punktOrd} · {s.punktShort}
+          pkt {s.pointOrd} · {s.pointShort}
         </span>
         <span
           className="font-mono uppercase"
@@ -123,7 +121,7 @@ function RebelRow({ r, first }: { r: Rebel; first: boolean }) {
             style={{ fontSize: 11.5, color: "var(--muted-foreground)" }}
           >
             <ClubBadge klub={r.club} size="xs" />
-            <span>· pkt {r.punktOrd} — {r.punktShort}</span>
+            <span>· pkt {r.pointOrd} — {r.pointShort}</span>
           </div>
         </div>
         <div className="flex items-center gap-1.5 font-mono" style={{ fontSize: 10 }}>
@@ -165,7 +163,8 @@ function RebelRow({ r, first }: { r: Rebel; first: boolean }) {
   );
 }
 
-export function Friction() {
+export function Friction({ data }: { data: SittingView }) {
+  const empty = data.clashes.length === 0 && data.rebels.length === 0;
   return (
     <section className="border-b border-border">
       <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
@@ -176,35 +175,67 @@ export function Friction() {
           anchor="iskry"
         />
 
-        <div className="grid gap-10 md:gap-14 md:grid-cols-[1.1fr_1fr]">
-          <div>
-            <Kicker
-              color="var(--destructive-deep)"
-              className="mb-3.5"
-            >
-              trzy największe starcia
-            </Kicker>
-            <div className="flex flex-col gap-4">
-              {MOCK.starcia.map((s, i) => (
-                <StarcieCard key={i} s={s} />
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <Kicker
-              color="var(--destructive-deep)"
-              className="mb-3.5"
-            >
-              głosowali wbrew klubowi
-            </Kicker>
+        {empty ? (
+          <p
+            className="font-serif italic"
+            style={{
+              fontSize: 15,
+              color: "var(--muted-foreground)",
+              maxWidth: 720,
+            }}
+          >
+            Brak danych o starciach i głosach wbrew klubowi dla tego posiedzenia.
+            Sekcja zapełni się po wzbogaceniu wypowiedzi i analizie głosowań.
+          </p>
+        ) : (
+          <div className="grid gap-10 md:gap-14 md:grid-cols-[1.1fr_1fr]">
             <div>
-              {MOCK.renegaci.map((r, i) => (
-                <RebelRow key={i} r={r} first={i === 0} />
-              ))}
+              <Kicker
+                color="var(--destructive-deep)"
+                className="mb-3.5"
+              >
+                trzy największe starcia
+              </Kicker>
+              {data.clashes.length === 0 ? (
+                <p
+                  className="font-serif italic"
+                  style={{ fontSize: 14, color: "var(--muted-foreground)" }}
+                >
+                  Brak danych o starciach.
+                </p>
+              ) : (
+                <div className="flex flex-col gap-4">
+                  {data.clashes.map((s, i) => (
+                    <ClashCard key={i} s={s} />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <Kicker
+                color="var(--destructive-deep)"
+                className="mb-3.5"
+              >
+                głosowali wbrew klubowi
+              </Kicker>
+              {data.rebels.length === 0 ? (
+                <p
+                  className="font-serif italic"
+                  style={{ fontSize: 14, color: "var(--muted-foreground)" }}
+                >
+                  Wszyscy posłowie głosowali z klubem.
+                </p>
+              ) : (
+                <div>
+                  {data.rebels.map((r, i) => (
+                    <RebelRow key={i} r={r} first={i === 0} />
+                  ))}
+                </div>
+              )}
             </div>
           </div>
-        </div>
+        )}
       </div>
     </section>
   );

--- a/frontend/app/posiedzenie/_components/Hero.tsx
+++ b/frontend/app/posiedzenie/_components/Hero.tsx
@@ -1,8 +1,6 @@
 // Hero: full sitting headline + 4 KPI tiles + day-tabs row.
-// Day-tab underline uses border-b on the active button only (no negative
-// margins) to avoid the alignment glitch from the inspiration.
 
-import { MOCK, type Day } from "../data";
+import type { Day, SittingView } from "./types";
 import { Kicker } from "./SectionHead";
 
 function StatTile({ value, label }: { value: number; label: string }) {
@@ -90,19 +88,19 @@ function DayTab({
       <div className="font-sans flex gap-4 mt-2" style={{ fontSize: 11.5 }}>
         <span>
           <b className={active ? "text-foreground" : "text-secondary-foreground"}>
-            {day.stats.punkty}
+            {day.stats.points}
           </b>{" "}
           pkt
         </span>
         <span>
           <b className={active ? "text-foreground" : "text-secondary-foreground"}>
-            {day.stats.glosowania}
+            {day.stats.votes}
           </b>{" "}
           głos.
         </span>
         <span>
           <b className={active ? "text-foreground" : "text-secondary-foreground"}>
-            {day.stats.wypowiedzi}
+            {day.stats.statements}
           </b>{" "}
           wypow.
         </span>
@@ -112,9 +110,11 @@ function DayTab({
 }
 
 export function Hero({
+  data,
   activeDay,
   setActiveDay,
 }: {
+  data: SittingView;
   activeDay: number;
   setActiveDay: (i: number) => void;
 }) {
@@ -122,7 +122,7 @@ export function Hero({
     <section className="border-b border-border">
       <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-12 md:py-16">
         <Kicker className="mb-4">
-          X kadencja Sejmu &nbsp;·&nbsp; {MOCK.dates.length}-dniowe posiedzenie
+          X kadencja Sejmu &nbsp;·&nbsp; {data.dates.length}-dniowe posiedzenie
         </Kicker>
 
         <div className="grid gap-x-14 gap-y-10 md:grid-cols-[1.5fr_1fr] items-end">
@@ -140,7 +140,7 @@ export function Hero({
               className="italic"
               style={{ color: "var(--destructive-deep)" }}
             >
-              {MOCK.number}.
+              {data.number}.
             </span>{" "}
             posiedzenie
             <br />
@@ -150,14 +150,14 @@ export function Hero({
 
           <div className="md:justify-self-end">
             <Kicker className="mb-2">
-              łącznie za {MOCK.days.length}{" "}
-              {MOCK.days.length === 1 ? "dzień" : "dni"}
+              łącznie za {data.days.length}{" "}
+              {data.days.length === 1 ? "dzień" : "dni"}
             </Kicker>
             <div className="flex gap-6 md:gap-8 justify-end items-baseline flex-wrap">
-              <StatTile value={MOCK.totals.punkty} label="punktów" />
-              <StatTile value={MOCK.totals.wypowiedzi} label="wypowiedzi" />
-              <StatTile value={MOCK.totals.glosowania} label="głosowań" />
-              <StatTile value={MOCK.totals.mowcy} label="mówców" />
+              <StatTile value={data.totals.points} label="punktów" />
+              <StatTile value={data.totals.statements} label="wypowiedzi" />
+              <StatTile value={data.totals.votes} label="głosowań" />
+              <StatTile value={data.totals.speakers} label="mówców" />
             </div>
           </div>
         </div>
@@ -166,7 +166,7 @@ export function Hero({
           className="mt-10 flex gap-6 md:gap-10 overflow-x-auto"
           style={{ borderBottom: "2px solid var(--rule)" }}
         >
-          {MOCK.days.map((d, i) => (
+          {data.days.map((d, i) => (
             <DayTab
               key={d.idx}
               day={d}

--- a/frontend/app/posiedzenie/_components/MomentOfDay.tsx
+++ b/frontend/app/posiedzenie/_components/MomentOfDay.tsx
@@ -1,20 +1,40 @@
-// "Moment dnia" — the highest-ranked viral quote of the day. Replaces the
-// inspiration's pure-black aside with a warm secondary panel + destructive
-// accent, and drops every visible reference to "viral_score". The reader
-// gets the quote, the speaker, the agenda-point context, and a short
-// editorial note about why it landed.
+// "Moment dnia" — the highest-ranked viral quote of the day.
 
 import { MPAvatarPhoto } from "@/components/tygodnik/MPAvatar";
 import { ClubBadge } from "@/components/clubs/ClubBadge";
-import { MOCK } from "../data";
+import type { SittingView } from "./types";
 import { Kicker, SectionHead } from "./SectionHead";
-import { verdictInk } from "../tokens";
+import { verdictInk } from "./tokens";
 
-export function MomentOfDay() {
+export function MomentOfDay({ data }: { data: SittingView }) {
   const top =
-    MOCK.topQuotes.find((q) => q.rank === 1) ?? MOCK.topQuotes[0];
-  if (!top) return null;
-  const punkt = MOCK.punkty.find((p) => p.ord === top.punktOrd) ?? null;
+    data.topQuotes.find((q) => q.rank === 1) ?? data.topQuotes[0];
+  if (!top) {
+    return (
+      <section className="border-b border-border">
+        <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+          <SectionHead
+            num={1}
+            title="Moment dnia"
+            sub="Brak wybranego cytatu dla tego posiedzenia — wracaj po wzbogaceniu danych."
+            anchor="moment"
+          />
+          <p
+            className="font-serif italic"
+            style={{
+              fontSize: 16,
+              color: "var(--muted-foreground)",
+              maxWidth: 720,
+            }}
+          >
+            Redaktor-AI nie wybrał jeszcze cytatu dnia. Pojawi się tu po
+            zakończeniu wzbogacania wypowiedzi.
+          </p>
+        </div>
+      </section>
+    );
+  }
+  const point = data.agendaPoints.find((p) => p.ord === top.pointOrd) ?? null;
 
   return (
     <section className="border-b border-border">
@@ -22,7 +42,7 @@ export function MomentOfDay() {
         <SectionHead
           num={1}
           title="Moment dnia"
-          sub="Najmocniejszy cytat z dziewiętnastego posiedzenia — wybrany przez redaktora-AI z 612 wypowiedzi."
+          sub={`Najmocniejszy cytat z ${data.number}. posiedzenia — wybrany przez redaktora-AI z ${data.totals.statements} wypowiedzi.`}
           anchor="moment"
         />
 
@@ -117,7 +137,7 @@ export function MomentOfDay() {
           </div>
 
           {/* Agenda-point context aside — warm beige, NOT inverted black */}
-          {punkt && (
+          {point && (
             <aside
               className="p-7 md:p-8"
               style={{
@@ -135,7 +155,7 @@ export function MomentOfDay() {
                     color: "var(--destructive-deep)",
                   }}
                 >
-                  {punkt.ord}
+                  {point.ord}
                 </span>
                 <div
                   className="font-mono uppercase"
@@ -146,9 +166,9 @@ export function MomentOfDay() {
                     lineHeight: 1.5,
                   }}
                 >
-                  {punkt.timeStart}—{punkt.timeEnd}
+                  {point.timeStart}—{point.timeEnd}
                   <br />
-                  {punkt.durMin} min
+                  {point.durMin} min
                 </div>
               </div>
               <h3
@@ -160,21 +180,23 @@ export function MomentOfDay() {
                   textWrap: "balance",
                 }}
               >
-                {punkt.shortTitle}.
+                {point.shortTitle}.
               </h3>
-              <p
-                className="font-serif m-0"
-                style={{
-                  fontSize: 14.5,
-                  lineHeight: 1.55,
-                  color: "var(--secondary-foreground)",
-                  textWrap: "pretty",
-                }}
-              >
-                {punkt.plainSummary}
-              </p>
+              {point.plainSummary && (
+                <p
+                  className="font-serif m-0"
+                  style={{
+                    fontSize: 14.5,
+                    lineHeight: 1.55,
+                    color: "var(--secondary-foreground)",
+                    textWrap: "pretty",
+                  }}
+                >
+                  {point.plainSummary}
+                </p>
+              )}
 
-              {punkt.vote && (
+              {point.vote && (
                 <div
                   className="mt-5 pt-4"
                   style={{ borderTop: "1px solid var(--border)" }}
@@ -185,11 +207,11 @@ export function MomentOfDay() {
                       className="font-serif italic font-medium"
                       style={{
                         fontSize: 24,
-                        color: verdictInk(punkt.vote.result, punkt.vote.motionPolarity),
+                        color: verdictInk(point.vote.result, point.vote.motionPolarity),
                         lineHeight: 1,
                       }}
                     >
-                      {punkt.vote.result}
+                      {point.vote.result}
                     </span>
                     <span
                       className="font-mono"
@@ -199,8 +221,8 @@ export function MomentOfDay() {
                         letterSpacing: "0.1em",
                       }}
                     >
-                      {punkt.vote.za}–{punkt.vote.przeciw} · różnica{" "}
-                      {punkt.vote.margin}
+                      {point.vote.yes}–{point.vote.no} · różnica{" "}
+                      {point.vote.margin}
                     </span>
                   </div>
                 </div>

--- a/frontend/app/posiedzenie/_components/SectionHead.tsx
+++ b/frontend/app/posiedzenie/_components/SectionHead.tsx
@@ -1,6 +1,4 @@
-// Roman-numeral section markers used across the proceeding-points narrative.
-// The italic serif numeral + serif h2 + optional sans subtitle echoes the
-// styling already used inside ProceedingPoints.tsx and BriefList atoms.
+// Roman-numeral section markers used across the sitting view.
 
 import type { ReactNode } from "react";
 
@@ -17,7 +15,6 @@ export function SectionHead({
   title: string;
   sub?: ReactNode;
   anchor?: string;
-  /** "inverted" swaps colours for sections that sit on muted/secondary surfaces. */
   tone?: "default" | "muted" | "inverted";
 }) {
   const numColor =

--- a/frontend/app/posiedzenie/_components/SittingViewClient.tsx
+++ b/frontend/app/posiedzenie/_components/SittingViewClient.tsx
@@ -1,0 +1,60 @@
+// Client orchestrator for /posiedzenie/[number] and /posiedzenie/mockup.
+// Owns the activeDay state shared by Hero / DayHeadline / WhatPassed /
+// DayTimeline.
+
+"use client";
+
+import { useState } from "react";
+import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
+import type { SittingView } from "./types";
+import { Hero } from "./Hero";
+import { DayHeadline } from "./DayHeadline";
+import { MomentOfDay } from "./MomentOfDay";
+import { WhatPassed } from "./WhatPassed";
+import { DayTimeline } from "./DayTimeline";
+import { AgendaList } from "./AgendaList";
+import { TopQuotes } from "./TopQuotes";
+import { YourTopics } from "./YourTopics";
+import { TopSpeakers } from "./TopSpeakers";
+import { Friction } from "./Friction";
+import { Tomorrow } from "./Tomorrow";
+import { Sources } from "./Sources";
+
+export function SittingViewClient({ data }: { data: SittingView }) {
+  // Default to the "live" day so the live cursor on the timeline is visible.
+  // Falls back to the first day when no live day exists (past sittings).
+  const liveIdx = data.days.findIndex((d) => d.status === "live");
+  const [activeDay, setActiveDay] = useState<number>(
+    liveIdx >= 0 ? liveIdx : 0,
+  );
+  const day = data.days[activeDay] ?? data.days[0] ?? null;
+
+  return (
+    <main className="bg-background font-serif text-foreground">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-8 pt-5">
+        <PageBreadcrumb
+          items={[
+            { label: "Tygodnik", href: "/tygodnik" },
+            { label: "Posiedzenia", href: "/tygodnik" },
+            {
+              label: `X kadencja, posiedzenie nr ${data.number}`,
+            },
+          ]}
+        />
+      </div>
+
+      <Hero data={data} activeDay={activeDay} setActiveDay={setActiveDay} />
+      {day && <DayHeadline day={day} />}
+      <MomentOfDay data={data} />
+      <WhatPassed data={data} activeDay={activeDay} />
+      <DayTimeline data={data} activeDay={activeDay} />
+      <AgendaList data={data} />
+      <TopQuotes data={data} />
+      <YourTopics data={data} />
+      <TopSpeakers data={data} />
+      <Friction data={data} />
+      <Tomorrow data={data} />
+      <Sources data={data} />
+    </main>
+  );
+}

--- a/frontend/app/posiedzenie/_components/Sources.tsx
+++ b/frontend/app/posiedzenie/_components/Sources.tsx
@@ -4,7 +4,7 @@ import type { SittingView } from "./types";
 import { Kicker } from "./SectionHead";
 
 export function Sources({ data }: { data: SittingView }) {
-  const referenceDate = data.dates[Math.min(1, data.dates.length - 1)] ?? data.dates[0] ?? null;
+  const referenceDate = data.dates.at(-1) ?? null;
   const lastUpdateDate = referenceDate
     ? referenceDate.split("-").reverse().join(".")
     : "—";

--- a/frontend/app/posiedzenie/_components/Sources.tsx
+++ b/frontend/app/posiedzenie/_components/Sources.tsx
@@ -1,13 +1,12 @@
 // Editorial footer — primary sources, how-we-read note, share row.
-// Pure typography, no decorative surfaces.
 
+import type { SittingView } from "./types";
 import { Kicker } from "./SectionHead";
-import { MOCK } from "../data";
 
-export function Sources() {
-  // 2026-05-14 → 14.05.2026 — derived rather than hardcoded.
-  const lastUpdateDate = MOCK.dates[1]
-    ? MOCK.dates[1].split("-").reverse().join(".")
+export function Sources({ data }: { data: SittingView }) {
+  const referenceDate = data.dates[Math.min(1, data.dates.length - 1)] ?? data.dates[0] ?? null;
+  const lastUpdateDate = referenceDate
+    ? referenceDate.split("-").reverse().join(".")
     : "—";
   return (
     <section
@@ -26,7 +25,6 @@ export function Sources() {
               <li>↗ Stenogramy dnia (PDF, ok. 14:00 i ~22:00)</li>
               <li>↗ Wyniki głosowań — sejm.gov.pl</li>
               <li>↗ Transmisja archiwalna — Sejm TV</li>
-              <li>↗ Druki sejmowe 763, 812, 841, 856…</li>
             </ul>
           </div>
           <div>
@@ -55,7 +53,7 @@ export function Sources() {
                 border: "1px solid var(--border)",
               }}
             >
-              tygodniksejmowy.pl/posiedzenie/10/{MOCK.number}
+              tygodniksejmowy.pl/posiedzenie/{data.number}
             </div>
             <div className="flex gap-2 flex-wrap">
               {["kopiuj link", "pdf dnia", "newsletter", "rss"].map((b) => (
@@ -96,7 +94,8 @@ export function Sources() {
               letterSpacing: "0.12em",
             }}
           >
-            Posiedzenie {MOCK.number} · ostatnia aktualizacja {lastUpdateDate}, {MOCK.liveAt}
+            Posiedzenie {data.number} · ostatnia aktualizacja {lastUpdateDate}
+            {data.liveAt ? `, ${data.liveAt}` : ""}
           </span>
         </div>
       </div>

--- a/frontend/app/posiedzenie/_components/Tomorrow.tsx
+++ b/frontend/app/posiedzenie/_components/Tomorrow.tsx
@@ -1,12 +1,10 @@
-// "Jutro w Sejmie" — next-day preview. Drops the inspiration's full-bleed
-// black panel for a muted warm-paper surface with destructive accents.
+// "Jutro w Sejmie" — next-day preview.
 
 import { TOPICS } from "@/lib/topics";
-import { MOCK, type PlannedCard } from "../data";
+import type { PlannedAgendaPoint, SittingView } from "./types";
 import { Kicker, SectionHead } from "./SectionHead";
 
-function PlanCardTile({ p }: { p: PlannedCard }) {
-  // Resolve once so an unknown topic key doesn't crash the render path.
+function PlanCardTile({ p }: { p: PlannedAgendaPoint }) {
   const topic = p.topic ? TOPICS[p.topic] : null;
   return (
     <div
@@ -80,8 +78,33 @@ function PlanCardTile({ p }: { p: PlannedCard }) {
   );
 }
 
-export function Tomorrow() {
-  const planned = MOCK.jutro;
+export function Tomorrow({ data }: { data: SittingView }) {
+  const planned = data.tomorrow;
+  if (!planned) {
+    return (
+      <section className="border-b border-border" style={{ background: "var(--muted)" }}>
+        <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+          <SectionHead
+            num={9}
+            title="Jutro w Sejmie"
+            sub="Brak zaplanowanego kolejnego dnia."
+            anchor="jutro"
+          />
+          <p
+            className="font-serif italic"
+            style={{
+              fontSize: 15,
+              color: "var(--muted-foreground)",
+              maxWidth: 720,
+            }}
+          >
+            To posiedzenie nie ma dalszych zaplanowanych dni. Następne posiedzenie
+            zostanie ogłoszone przez Marszałka Sejmu.
+          </p>
+        </div>
+      </section>
+    );
+  }
   const plannedDate = planned.date
     ? planned.date.split("-").reverse().join(".")
     : "—";
@@ -95,54 +118,38 @@ export function Tomorrow() {
           anchor="jutro"
         />
 
-        <p
-          className="font-serif m-0 mb-9"
-          style={{
-            fontSize: 22,
-            lineHeight: 1.35,
-            color: "var(--foreground)",
-            maxWidth: 880,
-            textWrap: "balance",
-          }}
-        >
-          {planned.headline}
-        </p>
+        {planned.headline && (
+          <p
+            className="font-serif m-0 mb-9"
+            style={{
+              fontSize: 22,
+              lineHeight: 1.35,
+              color: "var(--foreground)",
+              maxWidth: 880,
+              textWrap: "balance",
+            }}
+          >
+            {planned.headline}
+          </p>
+        )}
 
-        <div className="grid gap-4 md:gap-5 grid-cols-1 md:grid-cols-3">
-          {planned.plannedPoints.map((p) => (
-            <PlanCardTile key={p.ord} p={p} />
-          ))}
-        </div>
-
-        <div
-          className="mt-10 pt-6 flex justify-between items-baseline flex-wrap gap-3"
-          style={{ borderTop: "1px solid var(--border)" }}
-        >
-          <span
+        {planned.plannedPoints.length > 0 ? (
+          <div className="grid gap-4 md:gap-5 grid-cols-1 md:grid-cols-3">
+            {planned.plannedPoints.map((p) => (
+              <PlanCardTile key={p.ord} p={p} />
+            ))}
+          </div>
+        ) : (
+          <p
             className="font-serif italic"
             style={{
               fontSize: 14,
               color: "var(--muted-foreground)",
-              maxWidth: 720,
             }}
           >
-            Po piątku 19. posiedzenie zostanie zamknięte. Najbliższe — 20. posiedzenie — planowane w dn. 27–29 maja.
-          </span>
-          <button
-            type="button"
-            className="cursor-pointer hover:opacity-80 transition-opacity"
-            style={{
-              padding: "9px 18px",
-              background: "var(--destructive-deep)",
-              color: "var(--background)",
-              fontSize: 13,
-              fontWeight: 500,
-              border: "none",
-            }}
-          >
-            ✦ obserwuj posiedzenie 20
-          </button>
-        </div>
+            Porządek obrad na kolejny dzień jeszcze nieopublikowany.
+          </p>
+        )}
       </div>
     </section>
   );

--- a/frontend/app/posiedzenie/_components/TopQuotes.tsx
+++ b/frontend/app/posiedzenie/_components/TopQuotes.tsx
@@ -1,11 +1,9 @@
-// Ranking of the 5 most-shareable quotes. Rank position replaces the
-// numeric score from the inspiration ("№1 cytat dnia" instead of
-// "viral 0.87"). The reason explainer lives in the right column.
+// Ranking of the 5 most-shareable quotes.
 
 import { MPAvatarPhoto } from "@/components/tygodnik/MPAvatar";
 import { ClubBadge } from "@/components/clubs/ClubBadge";
 import { ToneBadge } from "@/components/statement/ToneBadge";
-import { MOCK, type TopQuote } from "../data";
+import type { SittingView, TopQuote } from "./types";
 import { Kicker, SectionHead } from "./SectionHead";
 
 function QuoteRow({ q }: { q: TopQuote }) {
@@ -86,16 +84,16 @@ function QuoteRow({ q }: { q: TopQuote }) {
                 className="font-mono"
                 style={{ color: "var(--foreground)", fontSize: 12 }}
               >
-                PKT {q.punktOrd}
+                PKT {q.pointOrd}
               </b>{" "}
               <span
                 className="font-mono"
                 style={{ fontSize: 10, color: "var(--muted-foreground)" }}
               >
-                {q.punktTime}
+                {q.pointTime}
               </span>
               <br />
-              {q.punktShort}.
+              {q.pointShort}.
             </div>
             <Kicker className="mb-1.5">tonacja</Kicker>
             <div className="mb-3">
@@ -119,7 +117,31 @@ function QuoteRow({ q }: { q: TopQuote }) {
   );
 }
 
-export function TopQuotes() {
+export function TopQuotes({ data }: { data: SittingView }) {
+  if (data.topQuotes.length === 0) {
+    return (
+      <section
+        className="border-b border-border"
+        style={{ background: "var(--secondary)" }}
+      >
+        <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+          <SectionHead
+            num={5}
+            title="Pięć cytatów dnia"
+            sub="Brak wybranych cytatów dla tego posiedzenia."
+            anchor="cytaty"
+          />
+          <p
+            className="font-serif italic"
+            style={{ fontSize: 15, color: "var(--muted-foreground)" }}
+          >
+            Wypowiedzi z tego posiedzenia czekają na wzbogacenie — ranking
+            cytatów pojawi się tutaj automatycznie.
+          </p>
+        </div>
+      </section>
+    );
+  }
   return (
     <section
       className="border-b border-border"
@@ -133,7 +155,7 @@ export function TopQuotes() {
           anchor="cytaty"
         />
         <ol className="list-none p-0 m-0">
-          {MOCK.topQuotes.map((q) => (
+          {data.topQuotes.map((q) => (
             <QuoteRow key={q.rank} q={q} />
           ))}
         </ol>

--- a/frontend/app/posiedzenie/_components/TopSpeakers.tsx
+++ b/frontend/app/posiedzenie/_components/TopSpeakers.tsx
@@ -1,17 +1,33 @@
-// "Kto najdłużej mówił" — ranking of top speakers by minutes on the
-// rostrum, paired with their dominant tone and best quote (replaces the
-// inspiration's "viral ø 0.71" decimal — we surface an actual quote
-// excerpt instead, which carries more editorial signal anyway).
+// "Kto najdłużej mówił" — ranking of top speakers by minutes on the rostrum.
 
 import { MPAvatarPhoto } from "@/components/tygodnik/MPAvatar";
 import { ClubBadge } from "@/components/clubs/ClubBadge";
 import { ToneBadge } from "@/components/statement/ToneBadge";
-import { MOCK } from "../data";
+import type { SittingView } from "./types";
 import { Kicker, SectionHead } from "./SectionHead";
 
-export function TopSpeakers() {
-  // Guard against an all-zero dataset; the bars use this as a denominator.
-  const maxMin = Math.max(1, ...MOCK.topSpeakers.map((s) => s.minutes));
+export function TopSpeakers({ data }: { data: SittingView }) {
+  if (data.topSpeakers.length === 0) {
+    return (
+      <section className="border-b border-border">
+        <div className="max-w-[1280px] mx-auto px-4 md:px-8 py-14 md:py-16">
+          <SectionHead
+            num={7}
+            title="Kto najdłużej mówił"
+            sub="Brak danych o czasie wypowiedzi dla tego posiedzenia."
+            anchor="mowcy"
+          />
+          <p
+            className="font-serif italic"
+            style={{ fontSize: 14.5, color: "var(--muted-foreground)" }}
+          >
+            Ranking mówców pojawi się po zaindeksowaniu stenogramów.
+          </p>
+        </div>
+      </section>
+    );
+  }
+  const maxMin = Math.max(1, ...data.topSpeakers.map((s) => s.minutes));
 
   return (
     <section className="border-b border-border">
@@ -42,9 +58,9 @@ export function TopSpeakers() {
           <span>Najlepszy fragment</span>
         </div>
 
-        {MOCK.topSpeakers.map((s, i) => (
+        {data.topSpeakers.map((s, i) => (
           <div
-            key={i}
+            key={`${s.name}-${i}`}
             className="hidden md:grid items-center py-4"
             style={{
               gridTemplateColumns: "40px minmax(220px, 1fr) minmax(240px, 1.2fr) 80px 160px minmax(220px, 1.4fr)",
@@ -117,7 +133,7 @@ export function TopSpeakers() {
               className="text-right font-mono"
               style={{ fontSize: 13, color: "var(--secondary-foreground)" }}
             >
-              {s.wypowiedzi}
+              {s.statements}
             </div>
 
             <div>
@@ -138,11 +154,10 @@ export function TopSpeakers() {
           </div>
         ))}
 
-        {/* Mobile: stacked card list */}
         <div className="md:hidden flex flex-col">
-          {MOCK.topSpeakers.map((s, i) => (
+          {data.topSpeakers.map((s, i) => (
             <div
-              key={i}
+              key={`${s.name}-${i}`}
               className="py-4"
               style={{
                 borderBottom: "1px solid var(--border)",
@@ -189,7 +204,7 @@ export function TopSpeakers() {
                   >
                     {s.minutes}
                   </div>
-                  <Kicker>min · {s.wypowiedzi} wyp.</Kicker>
+                  <Kicker>min · {s.statements} wyp.</Kicker>
                 </div>
               </div>
               <div className="mt-2 mb-2 flex">

--- a/frontend/app/posiedzenie/_components/WhatPassed.tsx
+++ b/frontend/app/posiedzenie/_components/WhatPassed.tsx
@@ -1,12 +1,8 @@
-// "Co Sejm dziś zrobił" — only the punkty with a decisive vote.
-// 3-column grid of decision cards. No hard sticker shadow (it was
-// clipping outside the container on the inspiration); subtle border +
-// hover translate is enough.
+// "Co Sejm dziś zrobił" — only the agenda points with a decisive vote.
 
-import { MOCK, type AgendaPoint, type Club, type Vote } from "../data";
+import type { AgendaPoint, SittingView, Vote } from "./types";
 import { Kicker, SectionHead } from "./SectionHead";
-import { verdictInk } from "../tokens";
-import { KLUB_COLORS, KLUB_LABELS } from "@/lib/atlas/constants";
+import { verdictInk } from "./tokens";
 
 function DecisionCard({ p }: { p: AgendaPoint }) {
   if (!p.vote) return null;
@@ -83,17 +79,19 @@ function DecisionCard({ p }: { p: AgendaPoint }) {
       >
         {p.shortTitle}.
       </h3>
-      <p
-        className="font-serif m-0 mb-4"
-        style={{
-          fontSize: 13.5,
-          lineHeight: 1.5,
-          color: "var(--secondary-foreground)",
-          textWrap: "pretty",
-        }}
-      >
-        {v.plainNote ?? p.plainSummary}
-      </p>
+      {(v.plainNote || p.plainSummary) && (
+        <p
+          className="font-serif m-0 mb-4"
+          style={{
+            fontSize: 13.5,
+            lineHeight: 1.5,
+            color: "var(--secondary-foreground)",
+            textWrap: "pretty",
+          }}
+        >
+          {v.plainNote ?? p.plainSummary}
+        </p>
+      )}
 
       <VoteBar v={v} />
     </a>
@@ -108,18 +106,18 @@ function VoteBar({ v }: { v: Vote }) {
         style={{ height: 16, border: "1px solid var(--border)" }}
         aria-hidden
       >
-        <div style={{ width: `${(v.za / 460) * 100}%`, background: "var(--success)" }} />
-        <div style={{ width: `${(v.przeciw / 460) * 100}%`, background: "var(--destructive)" }} />
+        <div style={{ width: `${(v.yes / 460) * 100}%`, background: "var(--success)" }} />
+        <div style={{ width: `${(v.no / 460) * 100}%`, background: "var(--destructive)" }} />
         <div
           style={{
-            width: `${(v.wstrzym / 460) * 100}%`,
+            width: `${(v.abstain / 460) * 100}%`,
             background: "var(--warning)",
             opacity: 0.85,
           }}
         />
         <div
           style={{
-            width: `${(v.nieob / 460) * 100}%`,
+            width: `${(v.absent / 460) * 100}%`,
             background: "var(--border)",
           }}
         />
@@ -133,26 +131,30 @@ function VoteBar({ v }: { v: Vote }) {
         }}
       >
         <span>
-          <b style={{ color: "var(--success)" }}>ZA {v.za}</b>
+          <b style={{ color: "var(--success)" }}>ZA {v.yes}</b>
         </span>
         <span>
-          <b style={{ color: "var(--destructive)" }}>PRZ {v.przeciw}</b>
+          <b style={{ color: "var(--destructive)" }}>PRZ {v.no}</b>
         </span>
         <span>
-          <b style={{ color: "var(--warning)" }}>WS {v.wstrzym}</b>
+          <b style={{ color: "var(--warning)" }}>WS {v.abstain}</b>
         </span>
-        <span>NB {v.nieob}</span>
+        <span>NB {v.absent}</span>
       </div>
     </>
   );
 }
 
-export function WhatPassed({ activeDay }: { activeDay: number }) {
-  const dayDate = MOCK.days[activeDay]?.date;
-  // Bounds-check: out-of-range activeDay used to fall through to "all days"
-  // because of the `!dayDate ||` short-circuit. Require the day to exist.
+export function WhatPassed({
+  data,
+  activeDay,
+}: {
+  data: SittingView;
+  activeDay: number;
+}) {
+  const dayDate = data.days[activeDay]?.date;
   const decisive = dayDate
-    ? MOCK.punkty.filter((p) => !!p.vote && p.date === dayDate)
+    ? data.agendaPoints.filter((p) => !!p.vote && p.date === dayDate)
     : [];
   if (decisive.length === 0) {
     return (

--- a/frontend/app/posiedzenie/_components/YourTopics.tsx
+++ b/frontend/app/posiedzenie/_components/YourTopics.tsx
@@ -1,20 +1,18 @@
-// "Twoje sprawy" — topic rail (11 categories from lib/topics.ts) on the
-// left; selected topic's punkty on the right. Personalisation entry point.
-// Not sticky — that caused empty-tail layouts in the inspiration.
+// "Twoje sprawy" — topic rail + selected topic's agenda points.
 
 "use client";
 
 import { useState } from "react";
 import { TOPICS, type TopicId } from "@/lib/topics";
-import { MOCK, type AgendaPoint } from "../data";
+import type { AgendaPoint, SittingView } from "./types";
 import { Kicker, SectionHead } from "./SectionHead";
-import { verdictInk } from "../tokens";
+import { verdictInk } from "./tokens";
 
-function topicsAggregate(): Record<TopicId, AgendaPoint[]> {
+function topicsAggregate(data: SittingView): Record<TopicId, AgendaPoint[]> {
   const out: Record<TopicId, AgendaPoint[]> = Object.fromEntries(
     (Object.keys(TOPICS) as TopicId[]).map((t) => [t, []]),
   ) as Record<TopicId, AgendaPoint[]>;
-  for (const p of MOCK.punkty) {
+  for (const p of data.agendaPoints) {
     for (const t of p.topics) {
       out[t]?.push(p);
     }
@@ -22,9 +20,9 @@ function topicsAggregate(): Record<TopicId, AgendaPoint[]> {
   return out;
 }
 
-const PUNKT_PLURAL = new Intl.PluralRules("pl-PL");
-function punktLabel(count: number): string {
-  switch (PUNKT_PLURAL.select(count)) {
+const POINT_PLURAL = new Intl.PluralRules("pl-PL");
+function pointLabel(count: number): string {
+  switch (POINT_PLURAL.select(count)) {
     case "one":
       return "punkt";
     case "few":
@@ -34,11 +32,9 @@ function punktLabel(count: number): string {
   }
 }
 
-export function YourTopics() {
-  const agg = topicsAggregate();
+export function YourTopics({ data }: { data: SittingView }) {
+  const agg = topicsAggregate(data);
   const topicIds = Object.keys(TOPICS) as TopicId[];
-  // Force-unwrap would crash on an all-empty taxonomy. Fall back to the
-  // first topic key so `selected` is always a valid TopicId.
   const firstWithContent =
     topicIds.find((t) => agg[t].length > 0) ?? topicIds[0];
   const [selected, setSelected] = useState<TopicId>(firstWithContent);
@@ -55,14 +51,13 @@ export function YourTopics() {
         />
 
         <div className="grid gap-8 md:gap-12 md:grid-cols-[300px_1fr]">
-          {/* Topic rail */}
           <div>
             <div className="flex flex-col">
               {(Object.keys(TOPICS) as TopicId[]).map((id) => {
                 const meta = TOPICS[id];
-                const punkty = agg[id];
+                const points = agg[id];
                 const on = id === selected;
-                const has = punkty.length > 0;
+                const has = points.length > 0;
                 return (
                   <button
                     key={id}
@@ -113,7 +108,7 @@ export function YourTopics() {
                         letterSpacing: "0.1em",
                       }}
                     >
-                      {has ? `${punkty.length}` : "—"}
+                      {has ? `${points.length}` : "—"}
                     </span>
                   </button>
                 );
@@ -132,7 +127,6 @@ export function YourTopics() {
             </div>
           </div>
 
-          {/* Content */}
           <div style={{ minHeight: 360 }}>
             <div className="flex items-baseline gap-4 mb-5 flex-wrap">
               <span
@@ -164,7 +158,7 @@ export function YourTopics() {
                   letterSpacing: "0.12em",
                 }}
               >
-                {current.length} {punktLabel(current.length)} dziś
+                {current.length} {pointLabel(current.length)} dziś
               </span>
             </div>
 
@@ -214,16 +208,18 @@ export function YourTopics() {
                     >
                       {p.shortTitle}.
                     </h4>
-                    <p
-                      className="font-serif m-0 mb-2.5"
-                      style={{
-                        fontSize: 13.5,
-                        lineHeight: 1.5,
-                        color: "var(--secondary-foreground)",
-                      }}
-                    >
-                      {p.plainSummary}
-                    </p>
+                    {p.plainSummary && (
+                      <p
+                        className="font-serif m-0 mb-2.5"
+                        style={{
+                          fontSize: 13.5,
+                          lineHeight: 1.5,
+                          color: "var(--secondary-foreground)",
+                        }}
+                      >
+                        {p.plainSummary}
+                      </p>
+                    )}
                     <div
                       className="flex items-center gap-x-4 gap-y-1 flex-wrap font-mono uppercase"
                       style={{
@@ -254,7 +250,7 @@ export function YourTopics() {
                         className="ml-auto"
                         style={{ color: "var(--secondary-foreground)" }}
                       >
-                        {p.stats.wypowiedzi} wypow. · {p.stats.mowcy} mówców
+                        {p.stats.statements} wypow. · {p.stats.speakers} mówców
                       </span>
                     </div>
                   </div>

--- a/frontend/app/posiedzenie/_components/tokens.ts
+++ b/frontend/app/posiedzenie/_components/tokens.ts
@@ -1,10 +1,9 @@
-// Shared semantic colour resolution for the proceeding-points mockup.
-// All values are CSS-var references — no hex codes leak into JSX. This
-// mirrors the convention in components/statement/ToneBadge.tsx (where the
-// tone palette lives) and components/tygodnik/atoms/VoteResultBar.tsx
-// (verdict colours).
+// Shared semantic colour resolution for the sitting view.
+// All values are CSS-var references — no hex codes leak into JSX. Mirrors
+// the convention in components/statement/ToneBadge.tsx (tone palette) and
+// components/tygodnik/atoms/VoteResultBar.tsx (verdict colours).
 
-import type { Tone, Vote } from "./data";
+import type { Tone, Vote } from "./types";
 
 // Tones use the same six-value palette as ToneBadge — see
 // components/statement/ToneBadge.tsx. Two values still resolve to hex
@@ -32,12 +31,6 @@ export const TONE_LABEL: Record<Tone, string> = {
 // components/tygodnik/atoms/VoteResultBar.tsx (computeBillOutcome): the
 // final colour depends on the motion's polarity, not just whether
 // "PRZYJĘTA" or "ODRZUCONA" appears in the verdict text.
-//
-// - "reject"/"minority" motions invert: a passed reject motion = bill
-//   killed = destructive; a rejected reject motion = bill survives = success.
-// - "procedural" motions are not bill-level decisions (e.g. odwołanie
-//   marszałka). Render warm/neutral instead of red/green.
-// - "pass"/"amendment" and missing polarity fall back to the verdict text.
 export function verdictInk(
   result: Vote["result"],
   motionPolarity?: Vote["motionPolarity"],

--- a/frontend/app/posiedzenie/_components/types.ts
+++ b/frontend/app/posiedzenie/_components/types.ts
@@ -1,0 +1,160 @@
+// Shape consumed by the sitting-view section components. Mirrors the join
+// of proceedings + proceeding_days + agenda_items + agenda_item_processes +
+// agenda_item_prints + proceeding_statements (with enrichment from
+// migration 0061) + votings (with the "Pkt. N ..." title heuristic from
+// migration 0092). The hardcoded MOCK in mockup/data.ts feeds the same
+// shape so the route at /posiedzenie/mockup keeps working as a design
+// control.
+
+import type { TopicId } from "@/lib/topics";
+
+export type Club = string;
+
+export type Tone =
+  | "konfrontacyjny"
+  | "techniczny"
+  | "argumentowy"
+  | "emocjonalny"
+  | "apel"
+  | "neutralny";
+
+export type ViralQuote = {
+  text: string;
+  speaker: string;
+  mpId?: number | null;
+  photoUrl?: string | null;
+  club: Club | null;
+  function: string | null;
+  tone: Tone;
+  reason: string;
+};
+
+export type Vote = {
+  time: string;
+  votingNumber: number;
+  result: "PRZYJĘTA" | "ODRZUCONA" | "WNIOSEK PRZYJĘTY" | "WNIOSEK ODRZUCONY";
+  subtitle?: string | null;
+  yes: number;
+  no: number;
+  abstain: number;
+  absent: number;
+  margin: number;
+  motionPolarity?: "pass" | "reject" | "amendment" | "minority" | "procedural" | null;
+  byClub?: Partial<Record<Club, { yes: number; no: number; abstain: number; absent: number }>>;
+  plainNote?: string | null;
+};
+
+export type AgendaPoint = {
+  ord: number;
+  date: string;
+  timeStart: string;
+  timeEnd: string;
+  durMin: number;
+  title: string;
+  shortTitle: string;
+  plainSummary: string;
+  stages: string[];
+  prints: { term: number; number: string }[];
+  processes: { term: number; number: string }[];
+  stats: { statements: number; speakers: number; votes: number };
+  tones: Partial<Record<Tone, number>>;
+  topics: TopicId[];
+  importance: "flagship" | "normal";
+  ongoing: boolean;
+  planned: boolean;
+  viralQuote: ViralQuote | null;
+  vote: Vote | null;
+};
+
+export type Day = {
+  idx: number;
+  date: string;
+  weekday: string;
+  short: string;
+  status: "done" | "live" | "planned";
+  open: string | null;
+  close: string | null;
+  headline: string;
+  stats: { points: number; statements: number; votes: number };
+};
+
+export type TopQuote = {
+  rank: number;
+  text: string;
+  speaker: string;
+  mpId?: number | null;
+  photoUrl?: string | null;
+  club: Club;
+  function: string;
+  tone: Tone;
+  reason: string;
+  pointOrd: number;
+  pointShort: string;
+  pointTime: string;
+};
+
+export type TopSpeaker = {
+  name: string;
+  mpId?: number | null;
+  photoUrl?: string | null;
+  club: Club;
+  function: string;
+  minutes: number;
+  statements: number;
+  dominantTone: Tone;
+  bestQuote: string;
+};
+
+export type Clash = {
+  a: string;
+  aClub: Club;
+  b: string;
+  bClub: Club;
+  pointOrd: number;
+  pointShort: string;
+  exchanges: number;
+  snippet: string;
+};
+
+export type Rebel = {
+  name: string;
+  mpId?: number | null;
+  club: Club;
+  expectedClub: Club;
+  actual: "ZA" | "PR" | "WS";
+  pointOrd: number;
+  pointShort: string;
+  note: string;
+};
+
+export type PlannedAgendaPoint = {
+  ord: number;
+  title: string;
+  subtitle: string;
+  topic: TopicId | null;
+  flag?: boolean;
+};
+
+export type TomorrowPreview = {
+  date: string;
+  weekday: string;
+  headline: string;
+  plannedPoints: PlannedAgendaPoint[];
+};
+
+export type SittingView = {
+  term: number;
+  number: number;
+  title: string;
+  dates: string[];
+  current: boolean;
+  liveAt: string;
+  totals: { points: number; statements: number; votes: number; speakers: number };
+  days: Day[];
+  agendaPoints: AgendaPoint[];
+  topQuotes: TopQuote[];
+  topSpeakers: TopSpeaker[];
+  clashes: Clash[];
+  rebels: Rebel[];
+  tomorrow: TomorrowPreview | null;
+};

--- a/frontend/app/posiedzenie/mockup/data.ts
+++ b/frontend/app/posiedzenie/mockup/data.ts
@@ -1,4 +1,4 @@
-// Mockup data for /posiedzenie/mockup. Mirrors the shape a real loader
+// Hardcoded MOCK for /posiedzenie/mockup. Mirrors the shape a real loader
 // would produce by joining proceedings + proceeding_days + agenda_items +
 // agenda_item_processes + agenda_item_prints + proceeding_statements
 // (with utterance enrichment from migration 0061) + votings (with the
@@ -7,172 +7,20 @@
 // No DB access — all values hardcoded so designer & user can iterate on
 // layout without infra in the way.
 
-import type { TopicId } from "@/lib/topics";
-
-export type Club =
-  | "KO"
-  | "PiS"
-  | "Lewica"
-  | "PSL-TD"
-  | "Konfederacja"
-  | "Polska2050"
-  | "Razem"
-  | "niez.";
-
-export type Tone =
-  | "konfrontacyjny"
-  | "techniczny"
-  | "argumentowy"
-  | "emocjonalny"
-  | "apel"
-  | "neutralny";
-
-export type ViralQuote = {
-  text: string;
-  speaker: string;
-  mpId?: number | null;
-  photoUrl?: string | null;
-  club: Club | null;
-  function: string | null;
-  tone: Tone;
-  reason: string;
-};
-
-export type Vote = {
-  time: string;
-  votingNumber: number;
-  result: "PRZYJĘTA" | "ODRZUCONA" | "WNIOSEK PRZYJĘTY" | "WNIOSEK ODRZUCONY";
-  subtitle?: string | null;
-  za: number;
-  przeciw: number;
-  wstrzym: number;
-  nieob: number;
-  margin: number;
-  motionPolarity?: "pass" | "reject" | "amendment" | "minority" | "procedural" | null;
-  byClub?: Partial<Record<Club, { za: number; pr: number; ws: number; nb: number }>>;
-  plainNote?: string | null;
-};
-
-export type AgendaPoint = {
-  ord: number;
-  date: string;
-  timeStart: string;
-  timeEnd: string;
-  durMin: number;
-  title: string;
-  shortTitle: string;
-  plainSummary: string;
-  stages: string[];
-  prints: { term: number; number: string }[];
-  procesy: { term: number; number: string }[];
-  stats: { wypowiedzi: number; mowcy: number; glosowania: number };
-  tones: Partial<Record<Tone, number>>;
-  topics: TopicId[];
-  importance: "flagship" | "normal";
-  ongoing: boolean;
-  planned: boolean;
-  viralQuote: ViralQuote | null;
-  vote: Vote | null;
-};
-
-export type Day = {
-  idx: number;
-  date: string;
-  weekday: string;
-  short: string;
-  status: "done" | "live" | "planned";
-  open: string | null;
-  close: string | null;
-  headline: string;
-  stats: { punkty: number; wypowiedzi: number; glosowania: number };
-};
-
-export type TopQuote = {
-  rank: number;
-  text: string;
-  speaker: string;
-  mpId?: number | null;
-  photoUrl?: string | null;
-  club: Club;
-  function: string;
-  tone: Tone;
-  reason: string;
-  punktOrd: number;
-  punktShort: string;
-  punktTime: string;
-};
-
-export type TopSpeaker = {
-  name: string;
-  mpId?: number | null;
-  photoUrl?: string | null;
-  club: Club;
-  function: string;
-  minutes: number;
-  wypowiedzi: number;
-  dominantTone: Tone;
-  bestQuote: string;
-};
-
-export type Starcie = {
-  a: string;
-  aClub: Club;
-  b: string;
-  bClub: Club;
-  punktOrd: number;
-  punktShort: string;
-  exchanges: number;
-  snippet: string;
-};
-
-export type Rebel = {
-  name: string;
-  mpId?: number | null;
-  club: Club;
-  expectedClub: Club;
-  actual: "ZA" | "PR" | "WS";
-  punktOrd: number;
-  punktShort: string;
-  note: string;
-};
-
-export type PlannedCard = {
-  ord: number;
-  title: string;
-  subtitle: string;
-  topic: TopicId | null;
-  flag?: boolean;
-};
-
-export type ProceedingMock = {
-  term: number;
-  number: number;
-  title: string;
-  dates: string[];
-  current: boolean;
-  liveAt: string;
-  totals: { punkty: number; wypowiedzi: number; glosowania: number; mowcy: number };
-  days: Day[];
-  punkty: AgendaPoint[];
-  topQuotes: TopQuote[];
-  topSpeakers: TopSpeaker[];
-  starcia: Starcie[];
-  renegaci: Rebel[];
-  jutro: { date: string; weekday: string; headline: string; plannedPoints: PlannedCard[] };
-};
+import type { SittingView } from "../_components/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Polish typographic quotes throughout: opening „ (U+201E) and closing " (U+201D).
 // Plain ASCII " is reserved for string delimiters only.
 
-export const MOCK: ProceedingMock = {
+export const MOCK: SittingView = {
   term: 10,
   number: 19,
   title: "19. posiedzenie Sejmu Rzeczypospolitej Polskiej X kadencji",
   dates: ["2026-05-13", "2026-05-14", "2026-05-15"],
   current: true,
   liveAt: "16:42",
-  totals: { punkty: 24, wypowiedzi: 612, glosowania: 47, mowcy: 218 },
+  totals: { points: 24, statements: 612, votes: 47, speakers: 218 },
 
   days: [
     {
@@ -185,7 +33,7 @@ export const MOCK: ProceedingMock = {
       close: "21:48",
       headline:
         "Sejm przyjął w II czytaniu projekt podnoszący kwotę wolną do 60 tys. zł — rekordowo długa debata podatkowa zakończona poprawkami rządowymi.",
-      stats: { punkty: 8, wypowiedzi: 224, glosowania: 18 },
+      stats: { points: 8, statements: 224, votes: 18 },
     },
     {
       idx: 1,
@@ -197,7 +45,7 @@ export const MOCK: ProceedingMock = {
       close: null,
       headline:
         "Trzecie czytanie PIT — ustawa przeszła stosunkiem 248–198. Wniosek o odwołanie Marszałka odrzucony.",
-      stats: { punkty: 11, wypowiedzi: 296, glosowania: 23 },
+      stats: { points: 11, statements: 296, votes: 23 },
     },
     {
       idx: 2,
@@ -209,11 +57,11 @@ export const MOCK: ProceedingMock = {
       close: null,
       headline:
         "Zaplanowany blok głosowań końcowych — m.in. e-doręczenia (III czytanie) i pakiet onkologiczny.",
-      stats: { punkty: 5, wypowiedzi: 92, glosowania: 6 },
+      stats: { points: 5, statements: 92, votes: 6 },
     },
   ],
 
-  punkty: [
+  agendaPoints: [
     {
       ord: 1,
       date: "2026-05-14",
@@ -231,8 +79,8 @@ export const MOCK: ProceedingMock = {
         { term: 10, number: "892" },
         { term: 10, number: "892-A" },
       ],
-      procesy: [{ term: 10, number: "841" }],
-      stats: { wypowiedzi: 41, mowcy: 28, glosowania: 12 },
+      processes: [{ term: 10, number: "841" }],
+      stats: { statements: 41, speakers: 28, votes: 12 },
       tones: { konfrontacyjny: 18, emocjonalny: 7, argumentowy: 9, techniczny: 5, neutralny: 2 },
       topics: ["biznes-podatki", "edukacja-rodzina"],
       importance: "flagship",
@@ -251,21 +99,21 @@ export const MOCK: ProceedingMock = {
         time: "10:54",
         votingNumber: 84,
         result: "PRZYJĘTA",
-        za: 248,
-        przeciw: 198,
-        wstrzym: 12,
-        nieob: 2,
+        yes: 248,
+        no: 198,
+        abstain: 12,
+        absent: 2,
         margin: 50,
         motionPolarity: "pass",
         byClub: {
-          KO: { za: 142, pr: 0, ws: 1, nb: 0 },
-          Lewica: { za: 26, pr: 0, ws: 0, nb: 0 },
-          "PSL-TD": { za: 32, pr: 0, ws: 0, nb: 0 },
-          Polska2050: { za: 32, pr: 0, ws: 0, nb: 0 },
-          PiS: { za: 3, pr: 167, ws: 8, nb: 1 },
-          Konfederacja: { za: 0, pr: 14, ws: 3, nb: 0 },
-          Razem: { za: 8, pr: 0, ws: 0, nb: 0 },
-          "niez.": { za: 5, pr: 17, ws: 0, nb: 1 },
+          KO: { yes: 142, no: 0, abstain: 1, absent: 0 },
+          Lewica: { yes: 26, no: 0, abstain: 0, absent: 0 },
+          "PSL-TD": { yes: 32, no: 0, abstain: 0, absent: 0 },
+          Polska2050: { yes: 32, no: 0, abstain: 0, absent: 0 },
+          PiS: { yes: 3, no: 167, abstain: 8, absent: 1 },
+          Konfederacja: { yes: 0, no: 14, abstain: 3, absent: 0 },
+          Razem: { yes: 8, no: 0, abstain: 0, absent: 0 },
+          "niez.": { yes: 5, no: 17, abstain: 0, absent: 1 },
         },
         plainNote:
           "Większością 50 głosów. Trzech posłów PiS (Suski, Mularczyk, Czartoryski) złamało dyscyplinę i zagłosowało ZA.",
@@ -284,8 +132,8 @@ export const MOCK: ProceedingMock = {
         "Wniosek klubu PiS o odwołanie Marszałka odrzucony: 162 ZA, 281 PRZECIW. Zarzut: jednostronne stosowanie regulaminu w sprawie immunitetów.",
       stages: ["Wniosek formalny", "Głosowanie"],
       prints: [{ term: 10, number: "918" }],
-      procesy: [],
-      stats: { wypowiedzi: 22, mowcy: 18, glosowania: 1 },
+      processes: [],
+      stats: { statements: 22, speakers: 18, votes: 1 },
       tones: { konfrontacyjny: 14, emocjonalny: 5, neutralny: 3 },
       topics: ["sady-prawa"],
       importance: "flagship",
@@ -304,21 +152,21 @@ export const MOCK: ProceedingMock = {
         time: "12:42",
         votingNumber: 85,
         result: "WNIOSEK ODRZUCONY",
-        za: 162,
-        przeciw: 281,
-        wstrzym: 4,
-        nieob: 13,
+        yes: 162,
+        no: 281,
+        abstain: 4,
+        absent: 13,
         margin: 119,
         motionPolarity: "procedural",
         byClub: {
-          PiS: { za: 162, pr: 0, ws: 1, nb: 7 },
-          Konfederacja: { za: 0, pr: 14, ws: 3, nb: 0 },
-          KO: { za: 0, pr: 142, ws: 0, nb: 1 },
-          Lewica: { za: 0, pr: 26, ws: 0, nb: 0 },
-          "PSL-TD": { za: 0, pr: 32, ws: 0, nb: 0 },
-          Polska2050: { za: 0, pr: 32, ws: 0, nb: 0 },
-          Razem: { za: 0, pr: 8, ws: 0, nb: 0 },
-          "niez.": { za: 0, pr: 27, ws: 0, nb: 0 },
+          PiS: { yes: 162, no: 0, abstain: 1, absent: 7 },
+          Konfederacja: { yes: 0, no: 14, abstain: 3, absent: 0 },
+          KO: { yes: 0, no: 142, abstain: 0, absent: 1 },
+          Lewica: { yes: 0, no: 26, abstain: 0, absent: 0 },
+          "PSL-TD": { yes: 0, no: 32, abstain: 0, absent: 0 },
+          Polska2050: { yes: 0, no: 32, abstain: 0, absent: 0 },
+          Razem: { yes: 0, no: 8, abstain: 0, absent: 0 },
+          "niez.": { yes: 0, no: 27, abstain: 0, absent: 0 },
         },
       },
     },
@@ -334,8 +182,8 @@ export const MOCK: ProceedingMock = {
         "15 pytań od opozycji i koalicji. Dominujące tematy: ceny energii (4 pytania), CPK (3), sytuacja w służbie zdrowia (3).",
       stages: ["Pytania w sprawach bieżących"],
       prints: [],
-      procesy: [],
-      stats: { wypowiedzi: 30, mowcy: 30, glosowania: 0 },
+      processes: [],
+      stats: { statements: 30, speakers: 30, votes: 0 },
       tones: { argumentowy: 10, konfrontacyjny: 8, neutralny: 12 },
       topics: ["zdrowie", "transport"],
       importance: "normal",
@@ -360,8 +208,8 @@ export const MOCK: ProceedingMock = {
         { term: 10, number: "763" },
         { term: 10, number: "871" },
       ],
-      procesy: [{ term: 10, number: "763" }],
-      stats: { wypowiedzi: 51, mowcy: 29, glosowania: 4 },
+      processes: [{ term: 10, number: "763" }],
+      stats: { statements: 51, speakers: 29, votes: 4 },
       tones: { argumentowy: 24, emocjonalny: 11, neutralny: 8, techniczny: 6, apel: 2 },
       topics: ["zdrowie", "emerytury"],
       importance: "flagship",
@@ -380,10 +228,10 @@ export const MOCK: ProceedingMock = {
         time: "16:30",
         votingNumber: 88,
         result: "PRZYJĘTA",
-        za: 412,
-        przeciw: 24,
-        wstrzym: 18,
-        nieob: 6,
+        yes: 412,
+        no: 24,
+        abstain: 18,
+        absent: 6,
         margin: 388,
         motionPolarity: "pass",
         plainNote:
@@ -403,8 +251,8 @@ export const MOCK: ProceedingMock = {
         "Aktualizacja harmonogramu: pierwsza fala wywłaszczeń przesunięta na II połowę 2027. Brak rozstrzygnięcia w sprawie finansowania linii dużych prędkości.",
       stages: ["Informacja"],
       prints: [],
-      procesy: [],
-      stats: { wypowiedzi: 28, mowcy: 22, glosowania: 0 },
+      processes: [],
+      stats: { statements: 28, speakers: 22, votes: 0 },
       tones: { techniczny: 14, argumentowy: 8, konfrontacyjny: 4, neutralny: 2 },
       topics: ["transport", "biznes-podatki"],
       importance: "normal",
@@ -438,8 +286,8 @@ export const MOCK: ProceedingMock = {
         { term: 10, number: "812-A" },
         { term: 10, number: "812-B" },
       ],
-      procesy: [{ term: 10, number: "812" }],
-      stats: { wypowiedzi: 38, mowcy: 24, glosowania: 0 },
+      processes: [{ term: 10, number: "812" }],
+      stats: { statements: 38, speakers: 24, votes: 0 },
       tones: { argumentowy: 16, techniczny: 11, konfrontacyjny: 7, neutralny: 4 },
       topics: ["mieszkanie-media", "srodowisko-klimat"],
       importance: "normal",
@@ -469,8 +317,8 @@ export const MOCK: ProceedingMock = {
         "Stanowisko poparte przez koalicję — odrzucone poprawki PiS dot. mechanizmu warunkowości. Konfederacja: przeciw całemu stanowisku.",
       stages: ["II czytanie", "Głosowanie"],
       prints: [{ term: 10, number: "901" }],
-      procesy: [{ term: 10, number: "901" }],
-      stats: { wypowiedzi: 22, mowcy: 16, glosowania: 6 },
+      processes: [{ term: 10, number: "901" }],
+      stats: { statements: 22, speakers: 16, votes: 6 },
       tones: { konfrontacyjny: 9, argumentowy: 7, neutralny: 4, techniczny: 2 },
       topics: ["sady-prawa", "bezpieczenstwo-obrona"],
       importance: "normal",
@@ -481,10 +329,10 @@ export const MOCK: ProceedingMock = {
         time: "21:10",
         votingNumber: 91,
         result: "PRZYJĘTA",
-        za: 294,
-        przeciw: 132,
-        wstrzym: 28,
-        nieob: 6,
+        yes: 294,
+        no: 132,
+        abstain: 28,
+        absent: 6,
         margin: 162,
         motionPolarity: "pass",
       },
@@ -501,8 +349,8 @@ export const MOCK: ProceedingMock = {
         "Komunikaty proceduralne i ogłoszenie planu jutrzejszego dnia. 5 zaplanowanych głosowań końcowych.",
       stages: ["Informacja"],
       prints: [],
-      procesy: [],
-      stats: { wypowiedzi: 4, mowcy: 4, glosowania: 0 },
+      processes: [],
+      stats: { statements: 4, speakers: 4, votes: 0 },
       tones: { neutralny: 4 },
       topics: [],
       importance: "normal",
@@ -524,8 +372,8 @@ export const MOCK: ProceedingMock = {
         "Cyfryzacja korespondencji urzędowej. Po negatywnej opinii Senatu rząd wprowadza autopoprawkę wydłużającą okres przejściowy do 18 mies.",
       stages: ["III czytanie", "Głosowanie"],
       prints: [{ term: 10, number: "856" }],
-      procesy: [{ term: 10, number: "856" }],
-      stats: { wypowiedzi: 0, mowcy: 0, glosowania: 0 },
+      processes: [{ term: 10, number: "856" }],
+      stats: { statements: 0, speakers: 0, votes: 0 },
       tones: {},
       topics: ["biznes-podatki"],
       importance: "normal",
@@ -547,8 +395,8 @@ export const MOCK: ProceedingMock = {
         "Coroczny raport. Zwiększona kwota refundacji terapii CAR-T; rozszerzenie programu badań przesiewowych do 16 województw.",
       stages: ["Informacja"],
       prints: [],
-      procesy: [],
-      stats: { wypowiedzi: 0, mowcy: 0, glosowania: 0 },
+      processes: [],
+      stats: { statements: 0, speakers: 0, votes: 0 },
       tones: {},
       topics: ["zdrowie", "edukacja-rodzina"],
       importance: "normal",
@@ -569,8 +417,8 @@ export const MOCK: ProceedingMock = {
         "Zaplanowano łącznie 14 głosowań końcowych: pakiet onkologiczny, e-doręczenia, prawo budowlane, sprawa Marszałka — wszystkie do rozstrzygnięcia.",
       stages: ["Głosowanie"],
       prints: [],
-      procesy: [],
-      stats: { wypowiedzi: 0, mowcy: 0, glosowania: 0 },
+      processes: [],
+      stats: { statements: 0, speakers: 0, votes: 0 },
       tones: {},
       topics: [],
       importance: "flagship",
@@ -591,9 +439,9 @@ export const MOCK: ProceedingMock = {
       tone: "konfrontacyjny",
       reason:
         "Mocna metafora („sześć złotych dziennie”) sprowadza abstrakcyjną liczbę 60 tys. do codziennego doświadczenia. „Alibi” zamiast „ulga” odwraca framing przeciwnika.",
-      punktOrd: 1,
-      punktShort: "Trzecie czytanie ustawy PIT",
-      punktTime: "10:48",
+      pointOrd: 1,
+      pointShort: "Trzecie czytanie ustawy PIT",
+      pointTime: "10:48",
     },
     {
       rank: 2,
@@ -604,9 +452,9 @@ export const MOCK: ProceedingMock = {
       tone: "konfrontacyjny",
       reason:
         "Porównanie Marszałka do prezesa spółki to wprost zarzut o instrumentalizację. Krótka pointa, mocna typografia mentalna — idealna na cytat.",
-      punktOrd: 2,
-      punktShort: "Wniosek o odwołanie Marszałka",
-      punktTime: "11:42",
+      pointOrd: 2,
+      pointShort: "Wniosek o odwołanie Marszałka",
+      pointTime: "11:42",
     },
     {
       rank: 3,
@@ -617,9 +465,9 @@ export const MOCK: ProceedingMock = {
       tone: "argumentowy",
       reason:
         "Rzadkie cytowanie z PSL — partia nieprzyzwyczajona do mocnych pointów. Słowo „spłacać” przesuwa narrację z „dawania” na „oddawania należnego”.",
-      punktOrd: 4,
-      punktShort: "Bezpłatne leki 75+",
-      punktTime: "15:12",
+      pointOrd: 4,
+      pointShort: "Bezpłatne leki 75+",
+      pointTime: "15:12",
     },
     {
       rank: 4,
@@ -630,9 +478,9 @@ export const MOCK: ProceedingMock = {
       tone: "argumentowy",
       reason:
         "Eleganckie odwrócenie populizmu („biurokracja”) w stronę praw obywatelskich. „Pisana ołówkiem” — wizualna, pamięciowa metafora.",
-      punktOrd: 6,
-      punktShort: "Reforma planowania przestrzennego",
-      punktTime: "19:23",
+      pointOrd: 6,
+      pointShort: "Reforma planowania przestrzennego",
+      pointTime: "19:23",
     },
     {
       rank: 5,
@@ -643,9 +491,9 @@ export const MOCK: ProceedingMock = {
       tone: "emocjonalny",
       reason:
         "Personalizacja zarzutu („moja wnuczka”) plus suchy żart polityczny — łatwo udostępniać.",
-      punktOrd: 5,
-      punktShort: "Informacja MI o stanie CPK",
-      punktTime: "18:02",
+      pointOrd: 5,
+      pointShort: "Informacja MI o stanie CPK",
+      pointTime: "18:02",
     },
   ],
 
@@ -655,7 +503,7 @@ export const MOCK: ProceedingMock = {
       club: "KO",
       function: "Minister Finansów",
       minutes: 78,
-      wypowiedzi: 9,
+      statements: 9,
       dominantTone: "techniczny",
       bestQuote:
         "Skala redystrybucji w tym pakiecie jest największa od czasu wprowadzenia 500+. Liczby są publiczne — każdy może sprawdzić.",
@@ -665,7 +513,7 @@ export const MOCK: ProceedingMock = {
       club: "Konfederacja",
       function: "poseł",
       minutes: 64,
-      wypowiedzi: 14,
+      statements: 14,
       dominantTone: "konfrontacyjny",
       bestQuote:
         "Zwiększacie kwotę wolną o sześć złotych dziennie i nazywacie to ulgą dla rodzin. To nie ulga — to alibi.",
@@ -675,7 +523,7 @@ export const MOCK: ProceedingMock = {
       club: "PiS",
       function: "przewodniczący klubu",
       minutes: 52,
-      wypowiedzi: 11,
+      statements: 11,
       dominantTone: "konfrontacyjny",
       bestQuote:
         "Pan marszałek prowadzi obrady jak prezes spółki z o.o. — tylko z większościowym pakietem.",
@@ -685,7 +533,7 @@ export const MOCK: ProceedingMock = {
       club: "PiS",
       function: "posłanka",
       minutes: 38,
-      wypowiedzi: 7,
+      statements: 7,
       dominantTone: "emocjonalny",
       bestQuote:
         "Trzy lata mówicie „za chwilę”. W tym tempie pierwszego pociągu doczeka się moja wnuczka.",
@@ -695,7 +543,7 @@ export const MOCK: ProceedingMock = {
       club: "KO",
       function: "sprawozdawca",
       minutes: 34,
-      wypowiedzi: 5,
+      statements: 5,
       dominantTone: "argumentowy",
       bestQuote:
         "Plan miejscowy to nie biurokracja. To umowa między mieszkańcami a deweloperem.",
@@ -705,7 +553,7 @@ export const MOCK: ProceedingMock = {
       club: "PSL-TD",
       function: "poseł",
       minutes: 29,
-      wypowiedzi: 6,
+      statements: 6,
       dominantTone: "argumentowy",
       bestQuote:
         "Lek za złotówkę to nie jałmużna. To umowa pokoleniowa, którą państwo wreszcie zaczyna spłacać.",
@@ -715,7 +563,7 @@ export const MOCK: ProceedingMock = {
       club: "Lewica",
       function: "wicemarszałek Sejmu",
       minutes: 24,
-      wypowiedzi: 4,
+      statements: 4,
       dominantTone: "argumentowy",
       bestQuote:
         "Jeśli mówimy „rodzina”, musimy mówić też o opiece — bo bez niej praca jest złudzeniem.",
@@ -725,21 +573,21 @@ export const MOCK: ProceedingMock = {
       club: "Lewica",
       function: "Marszałek Sejmu",
       minutes: 21,
-      wypowiedzi: 8,
+      statements: 8,
       dominantTone: "neutralny",
       bestQuote:
         "Proszę nie przerywać. Pan poseł skończy myśl i wtedy będzie czas na repliki.",
     },
   ],
 
-  starcia: [
+  clashes: [
     {
       a: "Bosak",
       aClub: "Konfederacja",
       b: "Domański",
       bClub: "KO",
-      punktOrd: 1,
-      punktShort: "Trzecie czytanie ustawy PIT",
+      pointOrd: 1,
+      pointShort: "Trzecie czytanie ustawy PIT",
       exchanges: 6,
       snippet:
         "Bosak: „Liczby są fałszywe, bo zakłada się stałą inflację 2,5%.” Domański: „Pan poseł czyta jeden slajd, a w drugim jest waloryzacja kwartalna.”",
@@ -749,8 +597,8 @@ export const MOCK: ProceedingMock = {
       aClub: "PiS",
       b: "Czarzasty",
       bClub: "Lewica",
-      punktOrd: 2,
-      punktShort: "Wniosek o odwołanie Marszałka",
+      pointOrd: 2,
+      pointShort: "Wniosek o odwołanie Marszałka",
       exchanges: 4,
       snippet:
         "Błaszczak: „Pan marszałek nie udziela głosu posłom opozycji.” Czarzasty: „Udzielam głosu kolejno z listy, panie pośle — proszę się z nią zapoznać.”",
@@ -760,22 +608,22 @@ export const MOCK: ProceedingMock = {
       aClub: "PiS",
       b: "Klimczak",
       bClub: "Polska2050",
-      punktOrd: 5,
-      punktShort: "Informacja MI o CPK",
+      pointOrd: 5,
+      pointShort: "Informacja MI o CPK",
       exchanges: 3,
       snippet:
         "Siarkowska: „Trzy lata i ani jednej łopaty.” Klimczak: „Pani posłanka mówi o łopatach — my mówimy o procedurach środowiskowych, których wasi nie chcieli zacząć.”",
     },
   ],
 
-  renegaci: [
+  rebels: [
     {
       name: "Marek Suski",
       club: "PiS",
       expectedClub: "PiS",
       actual: "ZA",
-      punktOrd: 1,
-      punktShort: "PIT — kwota wolna 60 tys.",
+      pointOrd: 1,
+      pointShort: "PIT — kwota wolna 60 tys.",
       note: "Trzeci raz w tej kadencji wyłamuje się klubowi w głosowaniu podatkowym. Powołuje się na okręg radomski.",
     },
     {
@@ -783,8 +631,8 @@ export const MOCK: ProceedingMock = {
       club: "PiS",
       expectedClub: "PiS",
       actual: "ZA",
-      punktOrd: 1,
-      punktShort: "PIT — kwota wolna 60 tys.",
+      pointOrd: 1,
+      pointShort: "PIT — kwota wolna 60 tys.",
       note: "Były wiceminister sprawiedliwości — pierwszy raz głosuje za projektem koalicji.",
     },
     {
@@ -792,8 +640,8 @@ export const MOCK: ProceedingMock = {
       club: "Konfederacja",
       expectedClub: "Konfederacja",
       actual: "WS",
-      punktOrd: 4,
-      punktShort: "Bezpłatne leki 75+",
+      pointOrd: 4,
+      pointShort: "Bezpłatne leki 75+",
       note: "Klub Konfederacji ZA, Hoffmann WSTRZ. — sygnalizuje sceptycyzm wobec dalszej rozbudowy programów osłonowych.",
     },
     {
@@ -801,13 +649,13 @@ export const MOCK: ProceedingMock = {
       club: "Polska2050",
       expectedClub: "Polska2050",
       actual: "PR",
-      punktOrd: 7,
-      punktShort: "Stanowisko Sejmu wobec polityki UE",
+      pointOrd: 7,
+      pointShort: "Stanowisko Sejmu wobec polityki UE",
       note: "Klub ZA, Mucha PRZECIW — uzasadnia dystansem wobec mechanizmu warunkowości w obecnej formie.",
     },
   ],
 
-  jutro: {
+  tomorrow: {
     date: "2026-05-15",
     weekday: "piątek",
     headline:

--- a/frontend/app/posiedzenie/mockup/page.tsx
+++ b/frontend/app/posiedzenie/mockup/page.tsx
@@ -1,60 +1,10 @@
-// Mockup orchestrator for /posiedzenie/mockup. Client component because
-// DayTabs / PorzadekObrad / TwojeSprawy share an activeDay state.
-// All data flows from data.ts — no Supabase access on this route.
+// Design control for /posiedzenie/[number]. Feeds the shared
+// SittingViewClient with a hardcoded MOCK so the section components can be
+// iterated on without infra in the way.
 
-"use client";
-
-import { useState } from "react";
-import Link from "next/link";
-import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
+import { SittingViewClient } from "../_components/SittingViewClient";
 import { MOCK } from "./data";
-import { Hero } from "./_components/Hero";
-import { DayHeadline } from "./_components/DayHeadline";
-import { MomentOfDay } from "./_components/MomentOfDay";
-import { WhatPassed } from "./_components/WhatPassed";
-import { DayTimeline } from "./_components/DayTimeline";
-import { AgendaList } from "./_components/AgendaList";
-import { TopQuotes } from "./_components/TopQuotes";
-import { YourTopics } from "./_components/YourTopics";
-import { TopSpeakers } from "./_components/TopSpeakers";
-import { Friction } from "./_components/Friction";
-import { Tomorrow } from "./_components/Tomorrow";
-import { Sources } from "./_components/Sources";
 
 export default function ProceedingMockupPage() {
-  // Default to the "live" day (index 1) so the live cursor on OsDnia is visible.
-  const liveIdx = MOCK.days.findIndex((d) => d.status === "live");
-  const [activeDay, setActiveDay] = useState<number>(
-    liveIdx >= 0 ? liveIdx : 0,
-  );
-  const day = MOCK.days[activeDay];
-
-  return (
-    <main className="bg-background font-serif text-foreground">
-      <div className="max-w-[1280px] mx-auto px-4 md:px-8 pt-5">
-        <PageBreadcrumb
-          items={[
-            { label: "Tygodnik", href: "/tygodnik" },
-            { label: "Posiedzenia", href: "/tygodnik" },
-            {
-              label: `X kadencja, posiedzenie nr ${MOCK.number}`,
-            },
-          ]}
-        />
-      </div>
-
-      <Hero activeDay={activeDay} setActiveDay={setActiveDay} />
-      <DayHeadline day={day} />
-      <MomentOfDay />
-      <WhatPassed activeDay={activeDay} />
-      <DayTimeline activeDay={activeDay} />
-      <AgendaList />
-      <TopQuotes />
-      <YourTopics />
-      <TopSpeakers />
-      <Friction />
-      <Tomorrow />
-      <Sources />
-    </main>
-  );
+  return <SittingViewClient data={MOCK} />;
 }

--- a/frontend/lib/db/sittings.ts
+++ b/frontend/lib/db/sittings.ts
@@ -34,7 +34,7 @@ const TONE_MAP: Record<string, Tone> = {
 
 function mapTone(raw: string | null | undefined): Tone | null {
   if (!raw) return null;
-  return TONE_MAP[raw] ?? null;
+  return TONE_MAP[raw] ?? "neutralny";
 }
 
 function warsawTodayDate(): string {
@@ -277,9 +277,9 @@ async function loadSitting(
   const proc = procRes.data as ProceedingRow | null;
   if (!proc) return null;
 
-  const dates = (proc.dates ?? []).slice().sort();
-
-  // 2. proceeding_days
+  // 2. proceeding_days — used as fallback for `dates` when proceedings.dates
+  //    is empty (early-load state where the array column hasn't been backfilled
+  //    yet) so the page still produces a day timeline.
   const daysRes = await sb
     .from("proceeding_days")
     .select("id, date")
@@ -287,6 +287,11 @@ async function loadSitting(
     .order("date", { ascending: true });
   if (daysRes.error) throw daysRes.error;
   const dayRows = (daysRes.data ?? []) as ProceedingDayRow[];
+  const procDates = (proc.dates ?? []).slice().sort();
+  const dates =
+    procDates.length > 0
+      ? procDates
+      : dayRows.map((d) => d.date).slice().sort();
   const dayIdsByDate = new Map<string, number>();
   for (const d of dayRows) dayIdsByDate.set(d.date, d.id);
   const dayIds = dayRows.map((d) => d.id);

--- a/frontend/lib/db/sittings.ts
+++ b/frontend/lib/db/sittings.ts
@@ -1,0 +1,830 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+import { supabase } from "@/lib/supabase";
+import { dbTagsToTopics, type TopicId } from "@/lib/topics";
+import type {
+  AgendaPoint,
+  Clash,
+  Day,
+  Rebel,
+  SittingView,
+  TomorrowPreview,
+  Tone,
+  TopQuote,
+  TopSpeaker,
+  ViralQuote,
+  Vote,
+} from "@/app/posiedzenie/_components/types";
+
+const SITTING_REVALIDATE_SEC = 300;
+
+// DB tone enum (migration 0061: konfrontacyjny | merytoryczny | populistyczny |
+// emocjonalny | techniczny | proceduralny) does not align 1:1 with the
+// frontend Tone palette used by ToneBadge / TONE_INK. This map narrows DB
+// values into the displayable union — unknowns fall back to "neutralny".
+const TONE_MAP: Record<string, Tone> = {
+  konfrontacyjny: "konfrontacyjny",
+  merytoryczny: "argumentowy",
+  populistyczny: "konfrontacyjny",
+  emocjonalny: "emocjonalny",
+  techniczny: "techniczny",
+  proceduralny: "neutralny",
+};
+
+function mapTone(raw: string | null | undefined): Tone | null {
+  if (!raw) return null;
+  return TONE_MAP[raw] ?? null;
+}
+
+function warsawTodayDate(): string {
+  return new Intl.DateTimeFormat("sv-SE", { timeZone: "Europe/Warsaw" }).format(
+    new Date(),
+  );
+}
+
+function warsawHhMm(): string {
+  return new Intl.DateTimeFormat("pl-PL", {
+    timeZone: "Europe/Warsaw",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(new Date());
+}
+
+const WEEKDAY_FMT = new Intl.DateTimeFormat("pl-PL", {
+  timeZone: "Europe/Warsaw",
+  weekday: "long",
+});
+const MONTHDAY_FMT = new Intl.DateTimeFormat("pl-PL", {
+  timeZone: "Europe/Warsaw",
+  day: "numeric",
+  month: "long",
+});
+
+function formatWeekday(dateIso: string): string {
+  return WEEKDAY_FMT.format(new Date(`${dateIso}T12:00:00Z`));
+}
+
+function formatShortDate(dateIso: string): string {
+  return MONTHDAY_FMT.format(new Date(`${dateIso}T12:00:00Z`));
+}
+
+function hhMm(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  const fmt = new Intl.DateTimeFormat("pl-PL", {
+    timeZone: "Europe/Warsaw",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  return fmt.format(d);
+}
+
+function dateOnly(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  return iso.slice(0, 10);
+}
+
+function diffMinutes(start: string | null, end: string | null): number {
+  if (!start || !end) return 0;
+  const a = new Date(start).getTime();
+  const b = new Date(end).getTime();
+  if (!Number.isFinite(a) || !Number.isFinite(b) || b <= a) return 0;
+  return Math.round((b - a) / 60000);
+}
+
+function shortenTitle(title: string, max = 100): string {
+  if (title.length <= max) return title.replace(/\.$/, "");
+  const slice = title.slice(0, max);
+  const lastSpace = slice.lastIndexOf(" ");
+  return (lastSpace > 40 ? slice.slice(0, lastSpace) : slice) + "…";
+}
+
+// Extract the ord from a voting title like "Pkt. 12 ..." (migration 0092
+// heuristic). Returns null when the title doesn't match.
+const PKT_ORD_RE = /^Pkt\.\s+(\d+)\b/;
+function extractPktOrd(title: string | null | undefined): number | null {
+  if (!title) return null;
+  const m = PKT_ORD_RE.exec(title);
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+// "Pkt. 12 <rest>" → "<rest>" trimmed. Falls back to original.
+function stripPktPrefix(title: string | null | undefined): string {
+  if (!title) return "";
+  return title.replace(/^Pkt\.\s+\d+\s*/, "").trim();
+}
+
+type ProceedingRow = {
+  id: number;
+  term: number;
+  number: number;
+  title: string;
+  dates: string[] | null;
+};
+
+type ProceedingDayRow = { id: number; date: string };
+
+type AgendaItemRow = { id: number; ord: number; title: string };
+
+type StatementRow = {
+  id: number;
+  num: number;
+  proceeding_day_id: number;
+  mp_id: number | null;
+  speaker_name: string | null;
+  function: string | null;
+  start_datetime: string | null;
+  end_datetime: string | null;
+  tone: string | null;
+  topic_tags: string[] | null;
+  viral_score: number | string | null;
+  viral_quote: string | null;
+  viral_reason: string | null;
+};
+
+type VotingRow = {
+  id: number;
+  voting_number: number;
+  date: string;
+  title: string;
+  yes: number;
+  no: number;
+  abstain: number;
+  not_participating: number;
+  majority_votes: number | null;
+  motion_polarity:
+    | "pass" | "reject" | "amendment" | "minority" | "procedural" | "other" | null;
+  short_title: string | null;
+};
+
+type VoteRow = {
+  voting_id: number;
+  mp_id: number;
+  club_ref: string | null;
+  vote: "YES" | "NO" | "ABSTAIN" | "PRESENT" | "ABSENT" | string;
+};
+
+type StatementPrintLinkRow = {
+  statement_id: number;
+  agenda_item_id: number | null;
+};
+
+type AgendaItemPrintRow = {
+  agenda_item_id: number;
+  term: number;
+  print_number: string;
+};
+
+type AgendaItemProcessRow = {
+  agenda_item_id: number;
+  term: number;
+  process_id: string;
+};
+
+type MpRow = { mp_id: number; photo_url: string | null };
+type MembershipRow = { mp_id: number; club_id: string };
+
+type ViralQuoteEventRow = {
+  event_date: string | null;
+  impact_score: number | string | null;
+  payload: {
+    statement_id?: number;
+    mp_id?: number | null;
+    speaker_name?: string | null;
+    function?: string | null;
+    tone?: string | null;
+    topic_tags?: string[] | null;
+    viral_quote?: string | null;
+    viral_reason?: string | null;
+    start_datetime?: string | null;
+    agenda_point_title?: string | null;
+    proceeding_title?: string | null;
+  };
+};
+
+function deriveResult(
+  v: VotingRow,
+): {
+  result: Vote["result"];
+  motionPolarity: Vote["motionPolarity"];
+} {
+  const passed = v.yes > v.no;
+  const rawPolarity = v.motion_polarity ?? null;
+  const motionPolarity: Vote["motionPolarity"] =
+    rawPolarity && rawPolarity !== "other" ? rawPolarity : null;
+  const procedural =
+    motionPolarity === "reject" ||
+    motionPolarity === "minority" ||
+    motionPolarity === "procedural";
+  if (procedural) {
+    return {
+      result: passed ? "WNIOSEK PRZYJĘTY" : "WNIOSEK ODRZUCONY",
+      motionPolarity,
+    };
+  }
+  return {
+    result: passed ? "PRZYJĘTA" : "ODRZUCONA",
+    motionPolarity,
+  };
+}
+
+function buildVote(v: VotingRow, voteRows: VoteRow[]): Vote {
+  const { result, motionPolarity } = deriveResult(v);
+  const byClub: NonNullable<Vote["byClub"]> = {};
+  for (const r of voteRows) {
+    const club = r.club_ref ?? "niez.";
+    const bucket = byClub[club] ?? { yes: 0, no: 0, abstain: 0, absent: 0 };
+    if (r.vote === "YES") bucket.yes += 1;
+    else if (r.vote === "NO") bucket.no += 1;
+    else if (r.vote === "ABSTAIN") bucket.abstain += 1;
+    else bucket.absent += 1;
+    byClub[club] = bucket;
+  }
+  return {
+    time: hhMm(v.date),
+    votingNumber: v.voting_number,
+    result,
+    yes: v.yes,
+    no: v.no,
+    abstain: v.abstain,
+    absent: v.not_participating,
+    margin: Math.abs(v.yes - v.no),
+    motionPolarity,
+    byClub: Object.keys(byClub).length > 0 ? byClub : undefined,
+    subtitle: v.short_title,
+  };
+}
+
+async function loadSitting(
+  term: number,
+  sittingNum: number,
+): Promise<SittingView | null> {
+  const sb = supabase();
+
+  // 1. proceedings row — bail when missing.
+  const procRes = await sb
+    .from("proceedings")
+    .select("id, term, number, title, dates")
+    .eq("term", term)
+    .eq("number", sittingNum)
+    .maybeSingle();
+  if (procRes.error) throw procRes.error;
+  const proc = procRes.data as ProceedingRow | null;
+  if (!proc) return null;
+
+  const dates = (proc.dates ?? []).slice().sort();
+
+  // 2. proceeding_days
+  const daysRes = await sb
+    .from("proceeding_days")
+    .select("id, date")
+    .eq("proceeding_id", proc.id)
+    .order("date", { ascending: true });
+  if (daysRes.error) throw daysRes.error;
+  const dayRows = (daysRes.data ?? []) as ProceedingDayRow[];
+  const dayIdsByDate = new Map<string, number>();
+  for (const d of dayRows) dayIdsByDate.set(d.date, d.id);
+  const dayIds = dayRows.map((d) => d.id);
+
+  // 3. agenda_items
+  const agendaRes = await sb
+    .from("agenda_items")
+    .select("id, ord, title")
+    .eq("proceeding_id", proc.id)
+    .order("ord", { ascending: true });
+  if (agendaRes.error) throw agendaRes.error;
+  const agendaRows = (agendaRes.data ?? []) as AgendaItemRow[];
+  const agendaById = new Map<number, AgendaItemRow>();
+  const agendaByOrd = new Map<number, AgendaItemRow>();
+  for (const a of agendaRows) {
+    agendaById.set(a.id, a);
+    agendaByOrd.set(a.ord, a);
+  }
+  const agendaIds = agendaRows.map((a) => a.id);
+
+  // 4. parallel fetches: statements, votings, junction rows, viral events,
+  //    statement_print_links.
+  const [
+    statementsRes,
+    votingsRes,
+    agendaPrintsRes,
+    agendaProcessesRes,
+    viralRes,
+  ] = await Promise.all([
+    dayIds.length > 0
+      ? sb
+          .from("proceeding_statements")
+          .select(
+            "id, num, proceeding_day_id, mp_id, speaker_name, function, start_datetime, end_datetime, tone, topic_tags, viral_score, viral_quote, viral_reason",
+          )
+          .in("proceeding_day_id", dayIds)
+      : Promise.resolve({ data: [] as StatementRow[], error: null }),
+    sb
+      .from("votings")
+      .select(
+        "id, voting_number, date, title, yes, no, abstain, not_participating, majority_votes, motion_polarity, short_title",
+      )
+      .eq("term", term)
+      .eq("sitting", sittingNum)
+      .order("date", { ascending: true }),
+    agendaIds.length > 0
+      ? sb
+          .from("agenda_item_prints")
+          .select("agenda_item_id, term, print_number")
+          .in("agenda_item_id", agendaIds)
+      : Promise.resolve({ data: [] as AgendaItemPrintRow[], error: null }),
+    agendaIds.length > 0
+      ? sb
+          .from("agenda_item_processes")
+          .select("agenda_item_id, term, process_id")
+          .in("agenda_item_id", agendaIds)
+      : Promise.resolve({ data: [] as AgendaItemProcessRow[], error: null }),
+    sb
+      .from("viral_quote_events_v")
+      .select("event_date, impact_score, payload")
+      .eq("term", term)
+      .eq("sitting_num", sittingNum)
+      .order("impact_score", { ascending: false }),
+  ]);
+  if (statementsRes.error) throw statementsRes.error;
+  if (votingsRes.error) throw votingsRes.error;
+  if (agendaPrintsRes.error) throw agendaPrintsRes.error;
+  if (agendaProcessesRes.error) throw agendaProcessesRes.error;
+  if (viralRes.error) throw viralRes.error;
+
+  const statements = (statementsRes.data ?? []) as StatementRow[];
+  const votings = (votingsRes.data ?? []) as VotingRow[];
+  const agendaPrints = (agendaPrintsRes.data ?? []) as AgendaItemPrintRow[];
+  const agendaProcesses = (agendaProcessesRes.data ?? []) as AgendaItemProcessRow[];
+  const viralEvents = (viralRes.data ?? []) as ViralQuoteEventRow[];
+
+  // 5. follow-up parallel: votes (for byClub), statement_print_links (for
+  //    agenda_item grouping), mps (photos), memberships (club resolution).
+  const votingIds = votings.map((v) => v.id);
+  const statementIds = statements.map((s) => s.id);
+  const mpIds = Array.from(
+    new Set([
+      ...statements
+        .map((s) => s.mp_id)
+        .filter((x): x is number => x != null),
+    ]),
+  );
+
+  const [votesRes, linksRes, mpsRes, memRes] = await Promise.all([
+    votingIds.length > 0
+      ? sb
+          .from("votes")
+          .select("voting_id, mp_id, club_ref, vote")
+          .in("voting_id", votingIds)
+      : Promise.resolve({ data: [] as VoteRow[], error: null }),
+    statementIds.length > 0
+      ? sb
+          .from("statement_print_links")
+          .select("statement_id, agenda_item_id")
+          .in("statement_id", statementIds)
+      : Promise.resolve({ data: [] as StatementPrintLinkRow[], error: null }),
+    mpIds.length > 0
+      ? sb
+          .from("mps")
+          .select("mp_id, photo_url")
+          .eq("term", term)
+          .in("mp_id", mpIds)
+      : Promise.resolve({ data: [] as MpRow[], error: null }),
+    mpIds.length > 0
+      ? sb
+          .from("mp_club_membership")
+          .select("mp_id, club_id")
+          .eq("term", term)
+          .in("mp_id", mpIds)
+      : Promise.resolve({ data: [] as MembershipRow[], error: null }),
+  ]);
+  if (votesRes.error) throw votesRes.error;
+  if (linksRes.error) throw linksRes.error;
+  if (mpsRes.error) throw mpsRes.error;
+  if (memRes.error) throw memRes.error;
+
+  const votes = (votesRes.data ?? []) as VoteRow[];
+  const links = (linksRes.data ?? []) as StatementPrintLinkRow[];
+  const mpRows = (mpsRes.data ?? []) as MpRow[];
+  const memRows = (memRes.data ?? []) as MembershipRow[];
+
+  const mpPhotos = new Map<number, string | null>();
+  for (const m of mpRows) mpPhotos.set(m.mp_id, m.photo_url);
+  const mpClubs = new Map<number, string>();
+  for (const m of memRows) mpClubs.set(m.mp_id, m.club_id);
+
+  // Index votes by voting_id.
+  const votesByVoting = new Map<number, VoteRow[]>();
+  for (const v of votes) {
+    const list = votesByVoting.get(v.voting_id) ?? [];
+    list.push(v);
+    votesByVoting.set(v.voting_id, list);
+  }
+
+  // Statement → agenda_item_id (collapsed). First non-null wins.
+  const stmtAgendaId = new Map<number, number>();
+  for (const l of links) {
+    if (l.agenda_item_id == null) continue;
+    if (!stmtAgendaId.has(l.statement_id)) {
+      stmtAgendaId.set(l.statement_id, l.agenda_item_id);
+    }
+  }
+
+  // 6. Day-level aggregates.
+  const today = warsawTodayDate();
+  const days: Day[] = dates.map((date, idx) => {
+    const dayStatements = statements.filter(
+      (s) => dayIdsByDate.get(date) === s.proceeding_day_id,
+    );
+    const startTimes = dayStatements
+      .map((s) => s.start_datetime)
+      .filter((x): x is string => !!x);
+    const endTimes = dayStatements
+      .map((s) => s.end_datetime)
+      .filter((x): x is string => !!x);
+    const open = startTimes.length > 0 ? hhMm(startTimes.sort()[0]) : null;
+    const close = endTimes.length > 0 ? hhMm(endTimes.sort()[endTimes.length - 1]) : null;
+    let status: Day["status"];
+    if (date < today) status = "done";
+    else if (date === today) status = "live";
+    else status = "planned";
+    const votesOnDay = votings.filter((v) => dateOnly(v.date) === date).length;
+    const pointsOnDay = agendaRows.length > 0
+      ? // No direct linkage; approximate by votings linked to agenda ords via
+        // their title prefix that hit this date.
+        new Set(
+          votings
+            .filter((v) => dateOnly(v.date) === date)
+            .map((v) => extractPktOrd(v.title))
+            .filter((x): x is number => x != null),
+        ).size
+      : 0;
+    return {
+      idx,
+      date,
+      weekday: formatWeekday(date),
+      short: formatShortDate(date),
+      status,
+      open,
+      close,
+      headline: "",
+      stats: {
+        points: pointsOnDay,
+        statements: dayStatements.length,
+        votes: votesOnDay,
+      },
+    };
+  });
+
+  // 7. Per-agenda-point aggregates.
+  // Group statements by agenda_item_id (via statement_print_links).
+  const stmtsByAgendaId = new Map<number, StatementRow[]>();
+  for (const s of statements) {
+    const aid = stmtAgendaId.get(s.id);
+    if (aid == null) continue;
+    const list = stmtsByAgendaId.get(aid) ?? [];
+    list.push(s);
+    stmtsByAgendaId.set(aid, list);
+  }
+  const printsByAgendaId = new Map<number, { term: number; number: string }[]>();
+  for (const p of agendaPrints) {
+    const list = printsByAgendaId.get(p.agenda_item_id) ?? [];
+    list.push({ term: p.term, number: p.print_number });
+    printsByAgendaId.set(p.agenda_item_id, list);
+  }
+  const processesByAgendaId = new Map<
+    number,
+    { term: number; number: string }[]
+  >();
+  for (const p of agendaProcesses) {
+    const list = processesByAgendaId.get(p.agenda_item_id) ?? [];
+    list.push({ term: p.term, number: p.process_id });
+    processesByAgendaId.set(p.agenda_item_id, list);
+  }
+
+  // Votings grouped by their Pkt-ord.
+  const votingsByPktOrd = new Map<number, VotingRow[]>();
+  for (const v of votings) {
+    const ord = extractPktOrd(v.title);
+    if (ord == null) continue;
+    const list = votingsByPktOrd.get(ord) ?? [];
+    list.push(v);
+    votingsByPktOrd.set(ord, list);
+  }
+
+  // Top viral quote per agenda ord (from the viral_quote_events_v stream
+  // which is already filtered to viral_score > 0 and ordered DESC).
+  const viralByOrd = new Map<number, ViralQuoteEventRow>();
+  for (const ev of viralEvents) {
+    const ord = extractPktOrd(ev.payload.agenda_point_title);
+    if (ord == null) continue;
+    if (!viralByOrd.has(ord)) viralByOrd.set(ord, ev);
+  }
+
+  const now = Date.now();
+  const liveAtNow = warsawHhMm();
+
+  const agendaPoints: AgendaPoint[] = agendaRows.map((a): AgendaPoint => {
+    const stmts = stmtsByAgendaId.get(a.id) ?? [];
+    const stmtStartTimes = stmts
+      .map((s) => s.start_datetime)
+      .filter((x): x is string => !!x);
+    const stmtEndTimes = stmts
+      .map((s) => s.end_datetime)
+      .filter((x): x is string => !!x);
+    // When statement_print_links lack rows for this agenda_item (pure-debate
+    // points or backfill gap), fall back to: (a) matching votings'
+    // timestamps, (b) the viral_quote_events_v statement that resolved to
+    // this ord. Keeps the time rail meaningful even without link data.
+    const matchingVotings = (votingsByPktOrd.get(a.ord) ?? []).slice();
+    matchingVotings.sort((x, y) =>
+      new Date(x.date).getTime() - new Date(y.date).getTime(),
+    );
+    const votingStarts = matchingVotings.map((v) => v.date);
+    const viralEv = viralByOrd.get(a.ord);
+    const viralStart = viralEv?.payload.start_datetime ?? null;
+    const fallbackTimes = [
+      ...votingStarts,
+      ...(viralStart ? [viralStart] : []),
+    ];
+    const startCandidates = stmtStartTimes.length > 0 ? stmtStartTimes : fallbackTimes;
+    const endCandidates = stmtEndTimes.length > 0 ? stmtEndTimes : fallbackTimes;
+    const earliestStart = startCandidates.slice().sort()[0] ?? null;
+    const latestEnd = endCandidates.slice().sort()[endCandidates.length - 1] ?? null;
+    const pointDate = dateOnly(earliestStart) ?? dates[0] ?? "";
+    const timeStart = earliestStart ? hhMm(earliestStart) : "—";
+    const timeEnd = latestEnd ? hhMm(latestEnd) : "—";
+    const durMin = stmtStartTimes.length > 0 && stmtEndTimes.length > 0
+      ? diffMinutes(earliestStart, latestEnd)
+      : 0;
+
+    const tones: Partial<Record<Tone, number>> = {};
+    const topicSet = new Set<string>();
+    const speakerSet = new Set<number>();
+    for (const s of stmts) {
+      const t = mapTone(s.tone);
+      if (t) tones[t] = (tones[t] ?? 0) + 1;
+      for (const tag of s.topic_tags ?? []) topicSet.add(tag);
+      if (s.mp_id != null) speakerSet.add(s.mp_id);
+    }
+
+    const primaryVoting = matchingVotings[0] ?? null;
+    const vote: Vote | null = primaryVoting
+      ? buildVote(primaryVoting, votesByVoting.get(primaryVoting.id) ?? [])
+      : null;
+
+    // Viral quote for this point — first lookup by ord, then fall back to
+    // the highest-score statement assigned to this agenda_item.
+    let viralQuote: ViralQuote | null = null;
+    if (viralEv?.payload.viral_quote) {
+      const tone = mapTone(viralEv.payload.tone) ?? "neutralny";
+      const mpId = viralEv.payload.mp_id ?? null;
+      viralQuote = {
+        text: viralEv.payload.viral_quote,
+        speaker: viralEv.payload.speaker_name ?? "—",
+        mpId,
+        photoUrl: mpId != null ? mpPhotos.get(mpId) ?? null : null,
+        club: mpId != null ? mpClubs.get(mpId) ?? null : null,
+        function: viralEv.payload.function ?? null,
+        tone,
+        reason: viralEv.payload.viral_reason ?? "",
+      };
+    } else {
+      // Fallback: max viral_score statement linked to this agenda_item.
+      const candidate = stmts
+        .filter((s) => s.viral_quote && (s.viral_score != null))
+        .sort((x, y) => {
+          const sx =
+            typeof x.viral_score === "string"
+              ? parseFloat(x.viral_score)
+              : x.viral_score ?? 0;
+          const sy =
+            typeof y.viral_score === "string"
+              ? parseFloat(y.viral_score)
+              : y.viral_score ?? 0;
+          return sy - sx;
+        })[0];
+      if (candidate?.viral_quote) {
+        const tone = mapTone(candidate.tone) ?? "neutralny";
+        viralQuote = {
+          text: candidate.viral_quote,
+          speaker: candidate.speaker_name ?? "—",
+          mpId: candidate.mp_id,
+          photoUrl: candidate.mp_id != null ? mpPhotos.get(candidate.mp_id) ?? null : null,
+          club: candidate.mp_id != null ? mpClubs.get(candidate.mp_id) ?? null : null,
+          function: candidate.function ?? null,
+          tone,
+          reason: candidate.viral_reason ?? "",
+        };
+      }
+    }
+
+    const planned = pointDate > today || stmts.length === 0 && pointDate >= today;
+    const ongoing = !!earliestStart && !!latestEnd
+      && new Date(earliestStart).getTime() <= now
+      && new Date(latestEnd).getTime() >= now;
+
+    return {
+      ord: a.ord,
+      date: pointDate,
+      timeStart,
+      timeEnd,
+      durMin,
+      title: a.title,
+      shortTitle: shortenTitle(a.title),
+      plainSummary: "",
+      stages: [],
+      prints: printsByAgendaId.get(a.id) ?? [],
+      processes: processesByAgendaId.get(a.id) ?? [],
+      stats: {
+        statements: stmts.length,
+        speakers: speakerSet.size,
+        votes: matchingVotings.length,
+      },
+      tones,
+      topics: dbTagsToTopics([...topicSet]),
+      importance: "normal",
+      ongoing,
+      planned,
+      viralQuote,
+      vote,
+    };
+  });
+
+  // 8. Top quotes — top 5 from the viral feed, with point context resolved
+  //    against agendaByOrd.
+  const topQuotes: TopQuote[] = [];
+  for (const ev of viralEvents.slice(0, 5)) {
+    const ord = extractPktOrd(ev.payload.agenda_point_title);
+    const agenda = ord != null ? agendaByOrd.get(ord) : null;
+    const tone = mapTone(ev.payload.tone) ?? "neutralny";
+    const mpId = ev.payload.mp_id ?? null;
+    topQuotes.push({
+      rank: topQuotes.length + 1,
+      text: ev.payload.viral_quote ?? "",
+      speaker: ev.payload.speaker_name ?? "—",
+      mpId,
+      photoUrl: mpId != null ? mpPhotos.get(mpId) ?? null : null,
+      club: (mpId != null ? mpClubs.get(mpId) : null) ?? "niez.",
+      function: ev.payload.function ?? "",
+      tone,
+      reason: ev.payload.viral_reason ?? "",
+      pointOrd: ord ?? 0,
+      pointShort: agenda
+        ? shortenTitle(agenda.title)
+        : shortenTitle(stripPktPrefix(ev.payload.agenda_point_title)),
+      pointTime: hhMm(ev.payload.start_datetime),
+    });
+  }
+
+  // 9. Top speakers — aggregate from statements (sum minutes + count +
+  //    dominant tone + best viral quote). Top 8 by minutes.
+  type SpeakerAgg = {
+    name: string;
+    mpId: number | null;
+    function: string;
+    minutes: number;
+    count: number;
+    toneTally: Map<Tone, number>;
+    bestQuote: string;
+    bestScore: number;
+  };
+  const speakerAgg = new Map<string, SpeakerAgg>();
+  for (const s of statements) {
+    if (!s.speaker_name) continue;
+    const key = s.mp_id != null ? `mp:${s.mp_id}` : `name:${s.speaker_name}`;
+    let agg = speakerAgg.get(key);
+    if (!agg) {
+      agg = {
+        name: s.speaker_name,
+        mpId: s.mp_id,
+        function: s.function ?? "",
+        minutes: 0,
+        count: 0,
+        toneTally: new Map(),
+        bestQuote: "",
+        bestScore: -1,
+      };
+      speakerAgg.set(key, agg);
+    }
+    agg.minutes += diffMinutes(s.start_datetime, s.end_datetime);
+    agg.count += 1;
+    const t = mapTone(s.tone);
+    if (t) agg.toneTally.set(t, (agg.toneTally.get(t) ?? 0) + 1);
+    const score =
+      s.viral_score == null
+        ? -1
+        : typeof s.viral_score === "string"
+          ? parseFloat(s.viral_score)
+          : s.viral_score;
+    if (s.viral_quote && score > agg.bestScore) {
+      agg.bestQuote = s.viral_quote;
+      agg.bestScore = score;
+    }
+  }
+  const topSpeakers: TopSpeaker[] = [...speakerAgg.values()]
+    .filter((a) => a.minutes > 0)
+    .sort((a, b) => b.minutes - a.minutes)
+    .slice(0, 8)
+    .map((a): TopSpeaker => {
+      let dominantTone: Tone = "neutralny";
+      let bestN = 0;
+      for (const [t, n] of a.toneTally) {
+        if (n > bestN) {
+          bestN = n;
+          dominantTone = t;
+        }
+      }
+      return {
+        name: a.name,
+        mpId: a.mpId,
+        photoUrl: a.mpId != null ? mpPhotos.get(a.mpId) ?? null : null,
+        club: (a.mpId != null ? mpClubs.get(a.mpId) : null) ?? "niez.",
+        function: a.function,
+        minutes: a.minutes,
+        statements: a.count,
+        dominantTone,
+        bestQuote: a.bestQuote,
+      };
+    });
+
+  // 10. Tomorrow preview — first future day in the sitting; agenda points
+  //     filtered by date. Headline left blank when no DB source.
+  const futureDay = days.find((d) => d.date > today) ?? null;
+  let tomorrow: TomorrowPreview | null = null;
+  if (futureDay) {
+    const plannedPoints = agendaPoints
+      .filter((p) => p.date === futureDay.date)
+      .slice(0, 3)
+      .map((p) => ({
+        ord: p.ord,
+        title: p.shortTitle,
+        subtitle: p.processes.length > 0
+          ? `proces ${p.processes[0].number}`
+          : p.prints.length > 0
+            ? `druk ${p.prints[0].number}`
+            : "",
+        topic: (p.topics[0] as TopicId | undefined) ?? null,
+        flag: p.importance === "flagship",
+      }));
+    tomorrow = {
+      date: futureDay.date,
+      weekday: futureDay.weekday,
+      headline: "",
+      plannedPoints,
+    };
+  }
+
+  // 11. Totals.
+  const totals = {
+    points: agendaPoints.length,
+    statements: statements.length,
+    votes: votings.length,
+    speakers: new Set(
+      statements
+        .map((s) => s.mp_id)
+        .filter((x): x is number => x != null),
+    ).size,
+  };
+
+  // 12. Live flag — true when warsaw "today" falls inside the sitting date range.
+  const current =
+    dates.length > 0 && today >= dates[0] && today <= dates[dates.length - 1];
+  const liveAt = current ? liveAtNow : "";
+
+  const clashes: Clash[] = [];
+  const rebels: Rebel[] = [];
+
+  return {
+    term: proc.term,
+    number: proc.number,
+    title: proc.title,
+    dates,
+    current,
+    liveAt,
+    totals,
+    days,
+    agendaPoints,
+    topQuotes,
+    topSpeakers,
+    clashes,
+    rebels,
+    tomorrow,
+  };
+}
+
+export function getSittingView(
+  term: number,
+  sittingNum: number,
+): Promise<SittingView | null> {
+  return unstable_cache(
+    () => loadSitting(term, sittingNum),
+    ["sitting-view", "v2", String(term), String(sittingNum)],
+    { revalidate: SITTING_REVALIDATE_SEC },
+  )();
+}

--- a/frontend/lib/db/sittings.ts
+++ b/frontend/lib/db/sittings.ts
@@ -95,6 +95,18 @@ function diffMinutes(start: string | null, end: string | null): number {
   return Math.round((b - a) / 60000);
 }
 
+// Stable identity for a speaker across statements. Ministers / guests /
+// non-MPs have `mp_id = null` but still produce a `speaker_name`; counting
+// only by mp_id under-counts them and also disagrees with topSpeakers
+// (which already keys by mp_id|name).
+function speakerKey(s: { mp_id: number | null; speaker_name: string | null }): string | null {
+  if (s.mp_id != null) return `mp:${s.mp_id}`;
+  if (s.speaker_name && s.speaker_name.trim().length > 0) {
+    return `name:${s.speaker_name.trim().toLowerCase()}`;
+  }
+  return null;
+}
+
 function shortenTitle(title: string, max = 100): string {
   if (title.length <= max) return title.replace(/\.$/, "");
   const slice = title.slice(0, max);
@@ -431,13 +443,16 @@ async function loadSitting(
     votesByVoting.set(v.voting_id, list);
   }
 
-  // Statement → agenda_item_id (collapsed). First non-null wins.
-  const stmtAgendaId = new Map<number, number>();
+  // Statement → agenda_item_ids. statement_print_links is a many-to-many
+  // junction (PK is (statement_id, print_id, source)) so a single statement
+  // can be linked to multiple agenda items. Keep them all so per-point
+  // counts and tone/topic tallies cover every linked point.
+  const stmtAgendaIds = new Map<number, Set<number>>();
   for (const l of links) {
     if (l.agenda_item_id == null) continue;
-    if (!stmtAgendaId.has(l.statement_id)) {
-      stmtAgendaId.set(l.statement_id, l.agenda_item_id);
-    }
+    const ids = stmtAgendaIds.get(l.statement_id) ?? new Set<number>();
+    ids.add(l.agenda_item_id);
+    stmtAgendaIds.set(l.statement_id, ids);
   }
 
   // 6. Day-level aggregates.
@@ -487,14 +502,16 @@ async function loadSitting(
   });
 
   // 7. Per-agenda-point aggregates.
-  // Group statements by agenda_item_id (via statement_print_links).
+  // Group statements by agenda_item_id (via statement_print_links). Each
+  // statement is counted under every agenda item it links to — see
+  // stmtAgendaIds above.
   const stmtsByAgendaId = new Map<number, StatementRow[]>();
   for (const s of statements) {
-    const aid = stmtAgendaId.get(s.id);
-    if (aid == null) continue;
-    const list = stmtsByAgendaId.get(aid) ?? [];
-    list.push(s);
-    stmtsByAgendaId.set(aid, list);
+    for (const aid of stmtAgendaIds.get(s.id) ?? []) {
+      const list = stmtsByAgendaId.get(aid) ?? [];
+      list.push(s);
+      stmtsByAgendaId.set(aid, list);
+    }
   }
   const printsByAgendaId = new Map<number, { term: number; number: string }[]>();
   for (const p of agendaPrints) {
@@ -570,12 +587,13 @@ async function loadSitting(
 
     const tones: Partial<Record<Tone, number>> = {};
     const topicSet = new Set<string>();
-    const speakerSet = new Set<number>();
+    const speakerSet = new Set<string>();
     for (const s of stmts) {
       const t = mapTone(s.tone);
       if (t) tones[t] = (tones[t] ?? 0) + 1;
       for (const tag of s.topic_tags ?? []) topicSet.add(tag);
-      if (s.mp_id != null) speakerSet.add(s.mp_id);
+      const key = speakerKey(s);
+      if (key) speakerSet.add(key);
     }
 
     const primaryVoting = matchingVotings[0] ?? null;
@@ -792,8 +810,8 @@ async function loadSitting(
     votes: votings.length,
     speakers: new Set(
       statements
-        .map((s) => s.mp_id)
-        .filter((x): x is number => x != null),
+        .map((s) => speakerKey(s))
+        .filter((x): x is string => x != null),
     ).size,
   };
 
@@ -829,7 +847,7 @@ export function getSittingView(
 ): Promise<SittingView | null> {
   return unstable_cache(
     () => loadSitting(term, sittingNum),
-    ["sitting-view", "v2", String(term), String(sittingNum)],
+    ["sitting-view", "v3", String(term), String(sittingNum)],
     { revalidate: SITTING_REVALIDATE_SEC },
   )();
 }


### PR DESCRIPTION
## Summary
- New dynamic route [`/posiedzenie/[number]`](frontend/app/posiedzenie/[number]/page.tsx) fed by [`getSittingView`](frontend/lib/db/sittings.ts) — verified live on term 10 sittings **56** and **57**. 404 on unknown numbers.
- Mock at `/posiedzenie/mockup` stays as the design control. Same 12 sections, same look, fed by the unchanged hardcoded `MOCK` const (only the type keys were renamed).
- Section components moved from `mockup/_components/` to shared `_components/` and refactored to accept `data: SittingView` props. New `SittingViewClient` owns `activeDay` state and is used by both routes.

## What the loader stitches together
- `proceedings` + `proceeding_days` → header, days[], date-based status (`done/live/planned`)
- `agenda_items` → ord/title (+ `shortTitle` derived from first ~100 chars)
- `agenda_item_prints` + `agenda_item_processes` → druk/proces chips
- `statement_print_links.agenda_item_id` → per-point statement aggregation (count, distinct speakers, tone histogram, topic union)
- `votings` → matched per-point via the `^Pkt\.\s+(\d+)` title heuristic from migration 0092; `votes` + `club_ref` → `byClub` tally; result derived from yes/no + motion_polarity
- `viral_quote_events_v` → top 5 `topQuotes` + per-point `viralQuote` (uses `payload.agenda_point_title` to resolve ord)
- `proceeding_statements` aggregated by mp_id → `topSpeakers` (minutes via end−start, dominant tone, best viral quote per MP)
- DB tone enum (`konfrontacyjny/merytoryczny/populistyczny/emocjonalny/techniczny/proceduralny`) mapped to the frontend Tone palette so `ToneBadge` + `TONE_INK` keep working

## Naming pass
All source files and exported TS symbols are now English-only (per repo convention). Polish stays only in:
- the user-visible route segment `/posiedzenie/[number]`
- UI strings inside JSX
- data values inside `MOCK`

Renames in the shared type: `ProceedingMock → SittingView`, `Starcie → Clash`, `PlannedCard → PlannedAgendaPoint`. Fields: `punkty → agendaPoints`, `starcia → clashes`, `renegaci → rebels`, `jutro → tomorrow`, `wypowiedzi/glosowania/mowcy → statements/votes/speakers`, `procesy → processes`, `punktOrd/Short/Time → pointOrd/Short/Time`, `za/przeciw/wstrzym/nieob → yes/no/abstain/absent`.

## Empty states
Clashes, rebels, and tomorrow render copy-led empty states when the DB has nothing to surface — Friction + Tomorrow sections show muted explanatory text instead of going blank. Moment of Day + Top Quotes + Top Speakers also handle the "enrichment not run yet" case.

## Per-point time fallback
When `statement_print_links` has no rows for an agenda_item (pure-debate items or backfill gap), the timeStart/timeEnd fall back to (a) any matching `votings.date`, (b) the viral statement's `start_datetime`. `durMin` stays 0 in fallback mode since the gap isn't a real statement duration.

## Test plan
- [x] `/posiedzenie/mockup` renders identically to before — design control intact
- [x] `/posiedzenie/56` renders real DB data (25 punktów, 689 wypowiedzi, 39 głosowań, 216 mówców; 3 days "done")
- [x] `/posiedzenie/57` renders real DB data with day 4 (today) marked "TRWA"; remaining future days "planned"
- [x] `/posiedzenie/9999` → 404
- [x] Top quotes render with club resolution (Matecki/PiS, Sójka/PiS, Macierewicz/PiS, …)
- [x] Friction + Tomorrow empty states show on 56
- [ ] Visual review of the full page (preview tool screenshot timed out on 24k-px-tall pages — text-snapshot verification used instead)

## Notes for the reviewer
- Pre-existing unrelated compile errors in `lib/db/prints.ts` exist on `main` (duplicate `matchRows`/`aipRows`); they don't affect the new route. Not touched in this PR.
- Unrelated `frontend/components/tygodnik/CitationLink.tsx` modification + `lewica_postulates.json` staging present locally on `main` — both left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full sitting detail page: agenda, votes, timeline, key quotes, top speakers, controversies, and “tomorrow” preview with dynamic SEO/social metadata.
  * Client-side orchestration for day selection and consistent page rendering.

* **Improvements**
  * All sections now consume real sitting data with sensible empty states and clearer vote/statistics labels.
  * Mock content replaced by live-driven data models and safer metadata/revalidation for fresher pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miskibin/tygodnik-sejmowy/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->