### PR TITLE
feat(seo): expose office-expense total in MP hero + metadata

### DIFF
--- a/frontend/app/posel/[mpId]/page.tsx
+++ b/frontend/app/posel/[mpId]/page.tsx
@@ -41,7 +41,8 @@ export async function generateMetadata({
     getMpOfficeExpenseSummary(mpId).catch(() => null),
   ]);
   const baseRole = guessRoleLabel(mp.firstLastName);
-  const role = mp.active ? `${baseRole} X kadencji` : `By${baseRole === "Posłanka" ? "ła posłanka" : "ły poseł"}`;
+  const isFemale = baseRole === "Posłanka";
+  const role = mp.active ? `${baseRole} X kadencji` : `By${isFemale ? "ła posłanka" : "ły poseł"}`;
   const club = clubName ?? mp.clubRef ?? "klub bezpartyjny";
   const district = mp.districtNum ? ` · okręg ${mp.districtNum}` : "";
 
@@ -50,12 +51,15 @@ export async function generateMetadata({
   // along the lines of "ile wydał poseł", "wydatki biura X", "sprawozdanie
   // ryczałtowe" then surface this page with the number visible in SERP.
   const isVerifiedExp = expSummary && expSummary.dataConfidence === "verified";
+  const verb = isFemale ? "Wydała" : "Wydał";
   const expClause = isVerifiedExp
-    ? `Wydał ${PLN_INT.format(expSummary!.totalSpent)} na biuro poselskie w ${expSummary!.year} r. `
+    ? `${verb} ${PLN_INT.format(expSummary!.totalSpent)} na biuro poselskie w ${expSummary!.year} r. `
     : "";
+  // Inactive-MP suffix matches the MP's gender (Polish requires it).
+  const inactiveSuffix = isFemale ? "(była posłanka)" : "(były poseł)";
   const titleSuffix = isVerifiedExp
     ? `${PLN_INT.format(expSummary!.totalSpent)} wydatków biura ${expSummary!.year}`
-    : `${baseRole} ${mp.active ? "X kadencji" : "(były)"}`;
+    : `${baseRole} ${mp.active ? "X kadencji" : inactiveSuffix}`;
   const desc =
     `${expClause}${role} · ${club}${district}. ` +
     "Frekwencja, głosowania, interpelacje, wystąpienia, obietnice vs głosy, " +
@@ -258,13 +262,18 @@ export default async function MpPage({ params }: { params: Promise<{ mpId: strin
     ];
   }
 
+  // Escape `<` so a stray `</script>` in any string field (MP name from DB,
+  // club name, …) can't break out of the script element. Same defensive
+  // pattern as app/jak-powstaje-ustawa/page.tsx.
+  const ldJsonHtml = JSON.stringify(ldJson).replace(/</g, "\\u003c");
+
   return (
     <div className="bg-background text-foreground font-serif pb-16 sm:pb-20 min-w-0 overflow-x-hidden">
       {/* JSON-LD structured data for the MP profile + (if verified) the
           year's expense total. Surfaced in SERPs and Knowledge Graph. */}
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(ldJson) }}
+        dangerouslySetInnerHTML={{ __html: ldJsonHtml }}
       />
 
       {/* Breadcrumb */}

--- a/frontend/app/posel/[mpId]/page.tsx
+++ b/frontend/app/posel/[mpId]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { getMp, getClubName, getMpStats } from "@/lib/db/mps";
+import { getMpOfficeExpenseSummary } from "@/lib/db/posel-tabs";
 import { PoselTabs } from "./_components/PoselTabs";
 import {
   TydzienAsync,
@@ -19,6 +20,12 @@ import { NotFoundPage } from "@/components/chrome/NotFoundPage";
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
 
 
+const PLN_INT = new Intl.NumberFormat("pl-PL", {
+  style: "currency",
+  currency: "PLN",
+  maximumFractionDigits: 0,
+});
+
 export async function generateMetadata({
   params,
 }: { params: Promise<{ mpId: string }> }): Promise<Metadata> {
@@ -27,19 +34,58 @@ export async function generateMetadata({
   if (!Number.isFinite(mpId)) return {};
   const mp = await getMp(mpId);
   if (!mp) return {};
-  const clubName = await getClubName(mp.clubRef);
+  // Fetch expenses summary in parallel — adds one cheap query but materially
+  // improves SEO for "ile wydał poseł X" search intent.
+  const [clubName, expSummary] = await Promise.all([
+    getClubName(mp.clubRef),
+    getMpOfficeExpenseSummary(mpId).catch(() => null),
+  ]);
   const baseRole = guessRoleLabel(mp.firstLastName);
   const role = mp.active ? `${baseRole} X kadencji` : `By${baseRole === "Posłanka" ? "ła posłanka" : "ły poseł"}`;
   const club = clubName ?? mp.clubRef ?? "klub bezpartyjny";
   const district = mp.districtNum ? ` · okręg ${mp.districtNum}` : "";
-  const desc = `${role} · ${club}${district}. Frekwencja, głosowania, interpelacje, wystąpienia, obietnice vs głosy.`;
+
+  // SEO: when we have verified expense data, lead the description with the
+  // amount + year ("wydał X zł na biuro w 2025"). Polish search queries
+  // along the lines of "ile wydał poseł", "wydatki biura X", "sprawozdanie
+  // ryczałtowe" then surface this page with the number visible in SERP.
+  const isVerifiedExp = expSummary && expSummary.dataConfidence === "verified";
+  const expClause = isVerifiedExp
+    ? `Wydał ${PLN_INT.format(expSummary!.totalSpent)} na biuro poselskie w ${expSummary!.year} r. `
+    : "";
+  const titleSuffix = isVerifiedExp
+    ? `${PLN_INT.format(expSummary!.totalSpent)} wydatków biura ${expSummary!.year}`
+    : `${baseRole} ${mp.active ? "X kadencji" : "(były)"}`;
+  const desc =
+    `${expClause}${role} · ${club}${district}. ` +
+    "Frekwencja, głosowania, interpelacje, wystąpienia, obietnice vs głosy, " +
+    "sprawozdanie wydatków biura poselskiego.";
+
   const path = `/posel/${mpId}`;
+  const fullTitle = `${mp.firstLastName} — ${titleSuffix}`;
+
+  // Keyword string is mostly cosmetic for Google but still indexed by a few
+  // engines (Bing, Yandex, DuckDuckGo). Cheap to ship.
+  const keywords = [
+    mp.firstLastName,
+    `${mp.firstLastName} wydatki`,
+    `${mp.firstLastName} biuro poselskie`,
+    `${mp.firstLastName} sprawozdanie`,
+    `${mp.firstLastName} ryczałt`,
+    `ile wydaje poseł ${mp.firstLastName}`,
+    "sprawozdania wydatków biur poselskich",
+    "ryczałt biuro poselskie 2025",
+    "wydatki posłów Sejm X kadencja",
+    club,
+  ].filter(Boolean) as string[];
+
   return {
-    title: mp.firstLastName,
+    title: fullTitle,
     description: desc,
+    keywords,
     alternates: { canonical: path },
     openGraph: {
-      title: `${mp.firstLastName} — ${role}`,
+      title: fullTitle,
       description: desc,
       url: path,
       type: "profile",
@@ -47,7 +93,7 @@ export async function generateMetadata({
     },
     twitter: {
       card: "summary_large_image",
-      title: `${mp.firstLastName} — ${role}`,
+      title: fullTitle,
       description: desc,
       images: mp.photoUrl ? [mp.photoUrl] : undefined,
     },
@@ -98,10 +144,12 @@ export default async function MpPage({ params }: { params: Promise<{ mpId: strin
 
   let clubName: string | null = null;
   let stats: Awaited<ReturnType<typeof getMpStats>>;
+  let expSummary: Awaited<ReturnType<typeof getMpOfficeExpenseSummary>> = null;
   try {
-    [clubName, stats] = await Promise.all([
+    [clubName, stats, expSummary] = await Promise.all([
       getClubName(mp.clubRef),
       getMpStats(mpId),
+      getMpOfficeExpenseSummary(mpId).catch(() => null),
     ]);
   } catch (err) {
     console.error("[/posel/[mpId]] club/stats failed", { mpId, err });
@@ -115,6 +163,7 @@ export default async function MpPage({ params }: { params: Promise<{ mpId: strin
       questionCount: 0,
       statementCount: 0,
     };
+    expSummary = null;
   }
 
   const roleLabel = guessRoleLabel(mp.firstLastName);
@@ -181,8 +230,43 @@ export default async function MpPage({ params }: { params: Promise<{ mpId: strin
     { id: "profil", label: "Profil" },
   ];
 
+  // Schema.org Person + the year's office-expense total exposed as
+  // additionalProperty. Google/Bing pick this up for the Knowledge Graph
+  // and for richer SERP snippets — letting "ile wydał poseł X" queries
+  // hit our page with the actual number visible.
+  const ldJson: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: mp.firstLastName,
+    jobTitle: mp.active ? `${roleLabel} X kadencji Sejmu RP` : "Były poseł / była posłanka",
+    affiliation: clubName
+      ? { "@type": "Organization", name: clubName }
+      : undefined,
+    image: mp.photoUrl ?? undefined,
+    url: `https://tygodniksejmowy.pl/posel/${mpId}`,
+    nationality: "PL",
+  };
+  if (expSummary && expSummary.dataConfidence === "verified") {
+    ldJson.additionalProperty = [
+      {
+        "@type": "PropertyValue",
+        name: `Wydatki biura poselskiego ${expSummary.year}`,
+        value: expSummary.totalSpent,
+        unitText: "PLN",
+        description: `Łączne wydatki z ryczałtu na prowadzenie biura poselskiego w ${expSummary.year} r., wg sprawozdania zatwierdzonego przez Prezydium Sejmu.`,
+      },
+    ];
+  }
+
   return (
     <div className="bg-background text-foreground font-serif pb-16 sm:pb-20 min-w-0 overflow-x-hidden">
+      {/* JSON-LD structured data for the MP profile + (if verified) the
+          year's expense total. Surfaced in SERPs and Knowledge Graph. */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(ldJson) }}
+      />
+
       {/* Breadcrumb */}
       <div className="max-w-[1100px] mx-auto px-4 md:px-8 lg:px-14 pt-6 sm:pt-8">
         <PageBreadcrumb
@@ -283,6 +367,34 @@ export default async function MpPage({ params }: { params: Promise<{ mpId: strin
       <Suspense fallback={null}>
         <HeroLedeBand mpId={mpId} firstLastName={mp.firstLastName} />
       </Suspense>
+
+      {/* Office-expense headline — surfaces the year's spend total and links
+          to the detailed tab. Heavily SEO-relevant: matches Polish search
+          intent "ile wydał poseł X" with the keyword phrase visible. Skipped
+          when we have no verified report for the MP. */}
+      {expSummary && expSummary.dataConfidence === "verified" && (
+        <div className="max-w-[1100px] mx-auto px-4 md:px-8 lg:px-14 pt-6">
+          <a
+            href="#wydatki"
+            className="block group border border-border bg-muted/40 hover:bg-muted/70 transition-colors py-4 px-4 sm:px-5"
+          >
+            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span className="font-mono text-[10px] sm:text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                Wydatki biura poselskiego w {expSummary.year} r.
+              </span>
+              <span
+                className="font-serif font-medium tabular-nums tracking-[-0.02em] text-foreground"
+                style={{ fontSize: "clamp(1.4rem, 3.2vw, 2.1rem)" }}
+              >
+                {PLN_INT.format(expSummary.totalSpent)}
+              </span>
+              <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-destructive ml-auto group-hover:translate-x-0.5 transition-transform">
+                Zobacz rozbicie →
+              </span>
+            </div>
+          </a>
+        </div>
+      )}
 
       {/* STATS STRIP — single edge-to-edge band of cells */}
       <div className="max-w-[1100px] mx-auto px-4 md:px-8 lg:px-14 pt-6 pb-2">

--- a/frontend/app/posel/[mpId]/page.tsx
+++ b/frontend/app/posel/[mpId]/page.tsx
@@ -347,6 +347,25 @@ export default async function MpPage({ params }: { params: Promise<{ mpId: strin
 
           {/* Action stack — mobile drops to full-width row below */}
           <div className="col-span-2 md:col-span-1 flex md:flex-col w-full min-w-0 gap-2 mt-2 md:mt-0">
+            {expSummary && expSummary.dataConfidence === "verified" && (
+              <a
+                href="#wydatki"
+                className="block group text-center md:text-right shrink-0 flex-1 md:flex-none"
+              >
+                <span className="block font-mono text-[9.5px] sm:text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                  Wydał w {expSummary.year}
+                </span>
+                <span
+                  className="block font-serif font-medium tabular-nums tracking-[-0.03em] text-foreground group-hover:text-destructive transition-colors leading-[0.95] mt-0.5"
+                  style={{ fontSize: "clamp(1.9rem, 4.4vw, 2.9rem)" }}
+                >
+                  {PLN_INT.format(expSummary.totalSpent)}
+                </span>
+                <span className="block font-mono text-[9.5px] uppercase tracking-[0.14em] text-muted-foreground group-hover:text-destructive mt-0.5">
+                  na biuro poselskie →
+                </span>
+              </a>
+            )}
             {mp.email ? (
               <a
                 href={`mailto:${mp.email}`}
@@ -367,34 +386,6 @@ export default async function MpPage({ params }: { params: Promise<{ mpId: strin
       <Suspense fallback={null}>
         <HeroLedeBand mpId={mpId} firstLastName={mp.firstLastName} />
       </Suspense>
-
-      {/* Office-expense headline — surfaces the year's spend total and links
-          to the detailed tab. Heavily SEO-relevant: matches Polish search
-          intent "ile wydał poseł X" with the keyword phrase visible. Skipped
-          when we have no verified report for the MP. */}
-      {expSummary && expSummary.dataConfidence === "verified" && (
-        <div className="max-w-[1100px] mx-auto px-4 md:px-8 lg:px-14 pt-6">
-          <a
-            href="#wydatki"
-            className="block group border border-border bg-muted/40 hover:bg-muted/70 transition-colors py-4 px-4 sm:px-5"
-          >
-            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-              <span className="font-mono text-[10px] sm:text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                Wydatki biura poselskiego w {expSummary.year} r.
-              </span>
-              <span
-                className="font-serif font-medium tabular-nums tracking-[-0.02em] text-foreground"
-                style={{ fontSize: "clamp(1.4rem, 3.2vw, 2.1rem)" }}
-              >
-                {PLN_INT.format(expSummary.totalSpent)}
-              </span>
-              <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-destructive ml-auto group-hover:translate-x-0.5 transition-transform">
-                Zobacz rozbicie →
-              </span>
-            </div>
-          </a>
-        </div>
-      )}
 
       {/* STATS STRIP — single edge-to-edge band of cells */}
       <div className="max-w-[1100px] mx-auto px-4 md:px-8 lg:px-14 pt-6 pb-2">

--- a/frontend/components/chrome/TabStrip.tsx
+++ b/frontend/components/chrome/TabStrip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useState, useEffect, useRef, type ReactNode } from "react";
 
 export type TabStripItem = { id: string; label: string; count?: number | null };
 
@@ -10,6 +10,11 @@ export type TabStripItem = { id: string; label: string; count?: number | null };
 // container's padding — callers pass `edgeBleedClass` matching their
 // outer horizontal padding (e.g. "-mx-4 md:-mx-8 lg:-mx-14") and the
 // inner scroller re-applies the same padding via `edgePadClass`.
+//
+// Active tab is also synced with `location.hash` so deep links like
+// /posel/426#wydatki open directly on that tab — useful for SEO snippets
+// and for in-page anchors like the "Wydatki biura → Zobacz rozbicie" CTA
+// in the MP profile hero.
 export function TabStrip({
   tabs,
   panels,
@@ -25,10 +30,50 @@ export function TabStrip({
   panelClassName?: string;
   initialTabId?: string;
 }) {
+  const tabIds = tabs.map((t) => t.id);
   const [active, setActive] = useState(initialTabId ?? tabs[0]?.id ?? "");
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Sync from hash on mount + on hashchange. We only switch when the hash
+  // matches a known tab id — strangers (e.g. fragment from another section)
+  // don't reset the panel. On hashchange (external navigation, e.g. an
+  // in-page anchor like the "Wydatki biura → Zobacz rozbicie" CTA in the
+  // hero), also scroll the tab strip into view so the user lands on the
+  // newly-activated tab instead of staring at the page top. Internal
+  // select() uses replaceState which doesn't fire hashchange, so tab clicks
+  // never re-scroll.
+  useEffect(() => {
+    const apply = (scroll: boolean) => {
+      const h = (typeof window !== "undefined" ? window.location.hash : "").replace(/^#/, "");
+      if (h && tabIds.includes(h)) {
+        setActive(h);
+        if (scroll && rootRef.current) {
+          // Defer one frame so the panel content can mount before we scroll.
+          requestAnimationFrame(() => {
+            rootRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+          });
+        }
+      }
+    };
+    apply(false);
+    const onHashChange = () => apply(true);
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const select = (id: string) => {
+    setActive(id);
+    if (typeof window !== "undefined") {
+      // Replace (not push) so back-button still leaves the page rather than
+      // walking through every tab switch.
+      const url = `${window.location.pathname}${window.location.search}#${id}`;
+      window.history.replaceState(null, "", url);
+    }
+  };
 
   return (
-    <div className="min-w-0">
+    <div className="min-w-0" ref={rootRef}>
       <div className={`relative ${edgeBleedClass} min-w-0`}>
         <div
           className={`border-b border-border flex gap-0 font-sans text-[12px] sm:text-[13px] overflow-x-auto overscroll-x-contain ${edgePadClass} no-scrollbar`}
@@ -40,7 +85,7 @@ export function TabStrip({
               <button
                 key={t.id}
                 type="button"
-                onClick={() => setActive(t.id)}
+                onClick={() => select(t.id)}
                 className="cursor-pointer flex items-baseline gap-1.5 sm:gap-2 shrink-0 whitespace-nowrap rounded-none px-3 py-2.5 sm:px-[18px] sm:py-[14px]"
                 style={{
                   color: on ? "var(--destructive)" : "var(--secondary-foreground)",

--- a/frontend/lib/db/posel-tabs.ts
+++ b/frontend/lib/db/posel-tabs.ts
@@ -872,3 +872,59 @@ export async function getMpOfficeExpenses(
     dataConfidence: r.data_confidence ?? "unverified",
   };
 }
+
+// Lightweight summary used by hero/metadata — single round-trip, no items.
+// Returns the most recent year's total spent + confidence flag, so the MP
+// profile can surface "wydał X zł na biuro w 2025" without paying the cost
+// of fetching all 23 line items.
+export type MpOfficeExpenseSummary = {
+  year: number;
+  totalSpent: number;
+  dataConfidence: "verified" | "unverified";
+};
+
+export async function getMpOfficeExpenseSummary(
+  mpId: number,
+  term = DEFAULT_TERM,
+): Promise<MpOfficeExpenseSummary | null> {
+  const sb = supabase();
+  const r = await sb
+    .from("mp_office_expense_reports")
+    .select("id, year, funds_spent, data_confidence")
+    .eq("term", term)
+    .eq("mp_id", mpId)
+    .order("year", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (r.error) throw r.error;
+  if (!r.data) return null;
+  const row = r.data as unknown as {
+    id: number;
+    year: number;
+    funds_spent: number | string | null;
+    data_confidence: "verified" | "unverified";
+  };
+  // Prefer funds_spent from PDF (Razem). For jakglosuja-style reports where
+  // funds_spent is null but items exist, sum items inline. Hero/metadata
+  // both need a number; if neither is available, return null and the UI
+  // hides the tile.
+  let totalSpent = toNum(row.funds_spent);
+  if (totalSpent == null) {
+    const items = await sb
+      .from("mp_office_expense_items")
+      .select("amount")
+      .eq("report_id", row.id)
+      .limit(50);
+    if (items.error) throw items.error;
+    totalSpent = (items.data ?? []).reduce(
+      (acc, it) => acc + (toNum((it as { amount: number | string }).amount) ?? 0),
+      0,
+    );
+  }
+  if (totalSpent == null || totalSpent <= 0) return null;
+  return {
+    year: row.year,
+    totalSpent,
+    dataConfidence: row.data_confidence ?? "unverified",
+  };
+}

--- a/frontend/lib/db/posel-tabs.ts
+++ b/frontend/lib/db/posel-tabs.ts
@@ -888,11 +888,15 @@ export async function getMpOfficeExpenseSummary(
   term = DEFAULT_TERM,
 ): Promise<MpOfficeExpenseSummary | null> {
   const sb = supabase();
+  // Only consider verified reports — both metadata and hero hide the amount
+  // for 'unverified' rows, so returning one would just be wasted work. If the
+  // MP has unverified 2025 but verified 2024, we surface the older year.
   const r = await sb
     .from("mp_office_expense_reports")
     .select("id, year, funds_spent, data_confidence")
     .eq("term", term)
     .eq("mp_id", mpId)
+    .eq("data_confidence", "verified")
     .order("year", { ascending: false })
     .limit(1)
     .maybeSingle();


### PR DESCRIPTION
Follow-up to #60. Two commits surfacing the office-expense total to Google + readers.

## Why

People googling "ile wydał poseł X" / "X wydatki biura poselskiego" should land on our page and see the answer immediately, both in the SERP snippet and on the rendered profile.

## Backend

`getMpOfficeExpenseSummary(mpId)` in `frontend/lib/db/posel-tabs.ts` — lightweight summary (no items) used by both `generateMetadata` and the hero render. Single round-trip, paid once per request via `Promise.all` alongside `getMpStats`. Returns `{ year, totalSpent, dataConfidence }` or `null`.

## SEO (`generateMetadata`)

For MPs with **verified** expense data:

- **Title** leads with the amount:
  `Adrian Witczak — 412 120 zł wydatków biura 2025 · Tygodnik Sejmowy`
- **Description** starts with the spend so SERPs render the number even when truncated:
  `Wydał 412 120 zł na biuro poselskie w 2025 r. Poseł X kadencji · …`
- **Keywords** cover MP-name variants (`X wydatki`, `X biuro poselskie`, `X sprawozdanie`, `X ryczałt`, `ile wydaje poseł X`) plus topical long-tails (`sprawozdania wydatków biur poselskich`, `ryczałt biuro poselskie 2025`).

## Page (`page.tsx`)

- **JSON-LD `Person`** with the year's total as an `additionalProperty` `PropertyValue` (PLN, unitText). Picked up by Google for rich snippets and Knowledge Graph.
- **Hero action column** now shows the amount directly above the "Napisz e-mail" button — large tabular-nums currency (clamp 1.9–2.9rem) with small uppercase context labels (`WYDAŁ W 2025` above, `NA BIURO POSELSKIE →` below). No card, no border, no background. Whole block links to `#wydatki`; hover turns red.

## TabStrip (`components/chrome/TabStrip.tsx`)

- Active tab now syncs with `location.hash`. Deep links like `/posel/426#wydatki` open directly on the Wydatki tab.
- `hashchange` handler also scrolls the strip into view, so the hero amount click both switches the tab AND lands the user on it.
- Tab clicks use `history.replaceState` (no extra back-button entries) and don't fire the listener, so they never re-scroll.

Only renders for the 327 / 460 MPs with `data_confidence='verified'` — for unverified or missing reports the hero stays as it was.

## Test plan

- [ ] `pnpm exec tsc --noEmit` — clean
- [ ] `/posel/426` SERP-ready: title, description, keywords, JSON-LD all populated
- [ ] `/posel/426#wydatki` lands on Wydatki tab on initial load
- [ ] Hero amount click scrolls to + activates Wydatki tab
- [ ] MP without verified expense data (e.g. `/posel/1`) shows no amount in hero, falls back to original title/description
- [ ] Mobile: hero action column stacks correctly, amount above email button

https://claude.ai/code/session_013Bci1DuJtSoPswaAPL818j

---
_Generated by [Claude Code](https://claude.ai/code/session_013Bci1DuJtSoPswaAPL818j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Office-expense totals appear on MP profile pages with enhanced SEO (localized PLN formatting, richer keywords) and a conditional "Wydał w {year}" annual spending link when totals are verified.
  * Tab navigation supports deep-linking via URL hash and restores visible tab focus when anchor-activated.

* **Bug Fixes**
  * Embedded structured data is safely escaped to prevent script injection/breaking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miskibin/tygodnik-sejmowy/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->