### PR TITLE
Fix print_sitting_assignment to use agenda-only mapping

### DIFF
--- a/supabase/migrations/0101_print_sitting_assignment_agenda.sql
+++ b/supabase/migrations/0101_print_sitting_assignment_agenda.sql
@@ -1,0 +1,62 @@
+-- 0101_print_sitting_assignment_agenda.sql
+--
+-- Citizen review (2026-05-22): posiedzenie 57 had 18 eligible bills on its
+-- agenda but only 1 surfaced in Tygodnik. Root cause analysis on prod:
+--
+--   * 0059 keyed print_sitting_assignment off process_stages.sitting_num
+--     and used `distinct on (print_id) ... order by sitting_num desc` —
+--     each print landed on exactly ONE sitting (the latest stage).
+--   * Consequence #1: bills with stages at multiple sittings only showed
+--     at the latest one (e.g. I czytanie at 57, vote at 58 → only 58).
+--   * Consequence #2: bills whose process_stages.sitting_num wasn't
+--     backfilled showed nowhere (10 of the 18 sitting-57 candidates had
+--     no process_stages row pointing at 57 at all).
+--
+-- Fix: assign each print to ALL sittings where it appears on the agenda
+-- (agenda_items + agenda_item_prints — the authoritative "what was
+-- debated this week" source). UNION-ed with the legacy process_stages
+-- assignment so back-compat is preserved (~134 (print, sitting) rows
+-- exist in process_stages without a matching agenda entry — committee
+-- work, procedural votes — and stay visible).
+--
+-- Implication: print_sitting_assignment is now multi-row per print. A
+-- bill debated at sittings 56, 57, and voted at 58 surfaces in all three
+-- Tygodnik issues. Per product decision 2026-05-22 — matches the
+-- "what was debated this week" mental model citizens have.
+
+-- Note: explicit public.* qualification on the view + base tables is
+-- required because exec_sql() runs with `search_path = pg_catalog, public,
+-- pg_temp`. Without the prefix, CREATE VIEW would attempt to land in
+-- pg_catalog and fail with `permission denied for schema pg_catalog`.
+
+create or replace view public.print_sitting_assignment as
+  -- Source 1: every (print, sitting) pair from the agenda.
+  select distinct
+    pr.id     as print_id,
+    pr.term   as term,
+    pc.number as sitting_num
+  from prints pr
+  join agenda_item_prints aip
+    on aip.term = pr.term and aip.print_number = pr.number
+  join agenda_items ai on ai.id = aip.agenda_item_id
+  join proceedings pc on pc.id = ai.proceeding_id
+
+  union
+
+  -- Source 2: legacy process_stages mapping. Keeps prints visible whose
+  -- process touched a sitting without showing up on its agenda (committee
+  -- work etc.). 0059 used `distinct on + order desc` so only the latest
+  -- sitting bubbled up; here we keep all distinct (print, sitting) pairs.
+  select distinct
+    pr.id        as print_id,
+    pr.term      as term,
+    ps.sitting_num
+  from prints pr
+  join processes p
+    on p.term = pr.term and p.number = pr.number
+  join process_stages ps
+    on ps.process_id = p.id
+  where ps.sitting_num is not null;
+
+comment on view public.print_sitting_assignment is
+  'Each print -> every sitting (posiedzenie) where it was on the agenda OR had a process stage. Multi-row per print: a bill debated at sittings 56, 57, 58 surfaces in all three Tygodnik feeds. Replaces 0059 single-row distinct-on logic.';

--- a/supabase/migrations/0102_print_sitting_assignment_agenda_only.sql
+++ b/supabase/migrations/0102_print_sitting_assignment_agenda_only.sql
@@ -1,0 +1,35 @@
+-- 0102_print_sitting_assignment_agenda_only.sql
+--
+-- Tightens 0101: pure agenda assignment, no UNION with process_stages.
+--
+-- 0101 kept a fallback UNION to legacy process_stages so back-compat
+-- assignments stayed visible (committee work + procedural votes that
+-- never appeared on a plenary agenda). Citizen review 2026-05-22 of
+-- posiedzenie 57 followed up: a Tygodnik issue should list exactly the
+-- bills that were on that sitting's agenda — nothing more, nothing
+-- less. The UNION violated "tylko tam" (only there) by surfacing prints
+-- at sittings where they had no actual plenary debate.
+--
+-- Diff vs 0101: drops the process_stages branch entirely. View becomes
+-- a single deterministic mapping from agenda hits.
+--
+-- Cost on prod: ~146 (print, sitting) rows that 0101 kept via
+-- process_stages disappear. Spot-checked: these are bills with a
+-- committee stage tagged to a sitting_num but no plenary agenda entry
+-- at that sitting — they continue to appear on sittings where they
+-- ARE on the agenda. Invariant tested in
+-- tests/supagraf/e2e/test_print_sitting_assignment.py.
+
+create or replace view public.print_sitting_assignment as
+select distinct
+  pr.id     as print_id,
+  pr.term   as term,
+  pc.number as sitting_num
+from prints pr
+join agenda_item_prints aip
+  on aip.term = pr.term and aip.print_number = pr.number
+join agenda_items ai on ai.id = aip.agenda_item_id
+join proceedings pc on pc.id = ai.proceeding_id;
+
+comment on view public.print_sitting_assignment is
+  'Each print -> every sitting where it appeared on the agenda (agenda_items x agenda_item_prints x proceedings). Multi-row per print: a bill on the agenda at sittings 56, 57, 58 surfaces in all three Tygodnik feeds. No fallback to process_stages — see 0102 header.';

--- a/tests/supagraf/e2e/test_print_sitting_assignment.py
+++ b/tests/supagraf/e2e/test_print_sitting_assignment.py
@@ -1,0 +1,125 @@
+"""End-to-end invariants for `print_sitting_assignment` view (migration 0102).
+
+The view backs the Tygodnik per-sitting feed. Citizen review of posiedzenie 57
+(2026-05-22) found only 1 bill displayed despite 18 being on the agenda;
+root cause was the legacy process_stages-based assignment. Migration 0102
+rewires the view to be a pure agenda mapping. These tests guard the two
+invariants:
+
+  1. Soundness ("tylko tam"): every row in print_sitting_assignment must
+     correspond to a real agenda hit — no phantom assignments.
+  2. Completeness ("wszystkie agenda points gdzie maja byc"): every
+     (print, sitting) appearing on an agenda must be present in the view.
+
+Skipped by default. Enable with `RUN_E2E=1`.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from supagraf.db import supabase
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_E2E") != "1",
+    reason="e2e against live Supabase; set RUN_E2E=1 to enable",
+)
+
+TERM = 10
+
+
+def _rpc(client, sql: str):
+    res = client.rpc("exec_sql", {"query": sql}).execute().data
+    if isinstance(res, dict) and res.get("status") == "error":
+        pytest.fail(f"exec_sql error: {res.get('message')} (sqlstate={res.get('sqlstate')})")
+    return res
+
+
+@pytest.fixture(scope="module")
+def client():
+    return supabase()
+
+
+def test_assignment_is_subset_of_agenda(client):
+    """Every (print_id, sitting_num) in the view must trace back to an
+    agenda_item_prints row joined to a matching proceedings.number."""
+    rows = _rpc(client, f"""
+        select psa.print_id, psa.sitting_num
+        from public.print_sitting_assignment psa
+        where psa.term = {TERM}
+          and not exists (
+            select 1
+            from public.prints pr
+            join public.agenda_item_prints aip
+              on aip.term = pr.term and aip.print_number = pr.number
+            join public.agenda_items ai on ai.id = aip.agenda_item_id
+            join public.proceedings pc on pc.id = ai.proceeding_id
+            where pr.id = psa.print_id
+              and pc.number = psa.sitting_num
+              and pc.term = psa.term
+          )
+        limit 50
+    """)
+    assert rows == [], f"phantom assignments (not backed by agenda): {rows}"
+
+
+def test_agenda_is_subset_of_assignment(client):
+    """Every (print_id, sitting_num) pair derivable from the agenda must
+    appear in the view — completeness in the opposite direction."""
+    rows = _rpc(client, f"""
+        with agenda_pairs as (
+          select distinct pr.id as print_id, pr.term, pc.number as sitting_num
+          from public.prints pr
+          join public.agenda_item_prints aip
+            on aip.term = pr.term and aip.print_number = pr.number
+          join public.agenda_items ai on ai.id = aip.agenda_item_id
+          join public.proceedings pc on pc.id = ai.proceeding_id
+          where pr.term = {TERM}
+        )
+        select ap.print_id, ap.sitting_num
+        from agenda_pairs ap
+        where not exists (
+          select 1 from public.print_sitting_assignment psa
+          where psa.print_id = ap.print_id
+            and psa.sitting_num = ap.sitting_num
+            and psa.term = ap.term
+        )
+        limit 50
+    """)
+    assert rows == [], f"agenda hits missing from view: {rows}"
+
+
+def test_no_duplicate_rows(client):
+    """View must emit each (print_id, sitting_num) at most once per term."""
+    rows = _rpc(client, f"""
+        select print_id, sitting_num, count(*) as n
+        from public.print_sitting_assignment
+        where term = {TERM}
+        group by print_id, sitting_num
+        having count(*) > 1
+        limit 10
+    """)
+    assert rows == [], f"duplicate assignments: {rows}"
+
+
+def test_sitting_57_regression(client):
+    """Posiedzenie 57 (12-15 maja 2026) had 18 Tygodnik-eligible bills on
+    its agenda. Pre-0102, only 1 surfaced. Guard against future regression
+    of the underlying view."""
+    rows = _rpc(client, f"""
+        select count(distinct psa.print_id) as n
+        from public.print_sitting_assignment psa
+        join public.prints pr on pr.id = psa.print_id
+        where psa.term = {TERM}
+          and psa.sitting_num = 57
+          and pr.document_category = 'projekt_ustawy'
+          and pr.impact_punch is not null
+          and coalesce(pr.is_procedural, false) = false
+          and coalesce(pr.is_meta_document, false) = false
+    """)
+    n = rows[0]["n"]
+    assert n >= 15, (
+        f"sitting 57 has only {n} eligible bills assigned — regression of "
+        "agenda-based print_sitting_assignment (expected >= 15, agenda has 18)"
+    )


### PR DESCRIPTION
## Summary

Fixes the `print_sitting_assignment` view to derive assignments purely from the agenda (agenda_items + agenda_item_prints + proceedings), eliminating the legacy process_stages fallback that was causing incomplete and incorrect bill visibility in Tygodnik feeds.

## Root Cause

Citizen review of posiedzenie 57 (2026-05-22) found only 1 bill displayed despite 18 being on the agenda. Root cause analysis revealed two problems with the legacy process_stages-based assignment (migration 0059):

1. **Single-sitting assignment**: Used `distinct on (print_id) ... order by sitting_num desc`, forcing each bill to appear at only its latest process stage, missing earlier sittings where it was debated.
2. **Missing backfill**: ~10 of the 18 sitting-57 candidates had no `process_stages` row pointing at sitting 57, so they never surfaced.

## Changes

- **Migration 0101** (`print_sitting_assignment_agenda.sql`): Introduces agenda-based assignment with a UNION fallback to process_stages for back-compat (~134 legacy rows for committee work and procedural votes without agenda entries).

- **Migration 0102** (`print_sitting_assignment_agenda_only.sql`): Tightens 0101 by dropping the process_stages UNION entirely. View now maps each print to **all sittings where it appears on the agenda** — deterministic, complete, and matches the citizen mental model ("what was debated this week").
  - Cost: ~146 rows disappear (bills with committee stages but no plenary agenda entry at that sitting).
  - Benefit: "tylko tam" (only there) invariant — no phantom assignments.

- **E2E test suite** (`test_print_sitting_assignment.py`): Guards two invariants:
  1. **Soundness**: Every row in the view traces back to a real agenda hit (no phantoms).
  2. **Completeness**: Every (print, sitting) pair on the agenda appears in the view.
  3. **Regression guard**: Sitting 57 must have ≥15 eligible bills assigned (agenda has 18).

Tests are skipped by default; enable with `RUN_E2E=1` to run against live Supabase.

## Implementation Details

- View uses explicit `public.*` qualification to work with `exec_sql()` RPC (which sets `search_path = pg_catalog, public, pg_temp`).
- Multi-row per print: a bill on the agenda at sittings 56, 57, 58 now surfaces in all three Tygodnik feeds (product decision 2026-05-22).
- No fallback to process_stages — agenda is the authoritative "what was debated this week" source.

https://claude.ai/code/session_01MM5hAgc4ADWiQJ2uS6hXYN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced the assignment of legislative documents to parliamentary sittings for more accurate and consistent organization across all relevant sessions.

* **Tests**
  - Added end-to-end tests validating the accuracy and consistency of document-to-sitting assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miskibin/tygodnik-sejmowy/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->