### PR TITLE
Refactor sitting display: defer sidebar to 2xl, improve query logic

### DIFF
--- a/frontend/app/tygodnik/_components/BriefList.tsx
+++ b/frontend/app/tygodnik/_components/BriefList.tsx
@@ -933,8 +933,10 @@ export function BriefList({
         </div>
       </div>
 
-      {/* Sections */}
-      <div className="px-4 md:px-8 lg:px-14 max-w-[1240px] mx-auto">
+      {/* Sections — widen at 2xl so the print rows can host their
+          right-side vote/quote sidebar without compressing the main
+          column. Below 2xl the sidebar is hidden entirely. */}
+      <div className="px-4 md:px-8 lg:px-14 max-w-[1240px] 2xl:max-w-[1640px] mx-auto">
         {filteredPrints.length > 0 && (
           <>
             <SectionHeader num={1} label="Nowe projekty" count={filteredPrints.length} />

--- a/frontend/components/tygodnik/NumberedRow.tsx
+++ b/frontend/components/tygodnik/NumberedRow.tsx
@@ -62,11 +62,11 @@ export function NumberedRow({
   const linkClass =
     `block ${padClass} border-b border-border transition-colors hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-destructive ${className ?? ""}`.trim();
 
-  // 2-col when there's no right card; promote to 3-col when an editorial
-  // sidebar (vote/quote summary) needs to sit next to the body on desktop.
-  const gridCols = rightCard
-    ? "grid-cols-1 md:grid-cols-[140px_1fr_320px] xl:grid-cols-[180px_1fr_360px]"
-    : "grid-cols-1 md:grid-cols-[140px_1fr] xl:grid-cols-[180px_1fr]";
+  // Grid layout stays 2-col (aside | body) on every breakpoint so the
+  // main body keeps its full width regardless of whether a rightCard is
+  // present. The card itself lives inside the body cell and only
+  // unmasks on xl as a floating sidebar — see comment below.
+  const gridCols = "grid-cols-1 md:grid-cols-[140px_1fr] xl:grid-cols-[180px_1fr]";
 
   const inner = (
     <div className={`grid gap-4 md:gap-8 ${gridCols}`}>
@@ -93,8 +93,19 @@ export function NumberedRow({
           )}
         </div>
       </aside>
-      <div className={rightCard ? "min-w-0" : "min-w-0 max-w-[820px]"}>{children}</div>
-      {rightCard && <div className="min-w-0">{rightCard}</div>}
+      <div className="min-w-0 2xl:flex 2xl:items-start 2xl:gap-8">
+        {/* Body content keeps its long-form max-width so the prose
+            column doesn't dilate when a sidebar appears next to it. */}
+        <div className="min-w-0 max-w-[820px] 2xl:flex-1">{children}</div>
+        {/* Sidebar (vote/quote summary): only on 2xl desktops (≥1536px)
+            so the main column never has to shrink to host it.
+            Container widens at 2xl too — see BriefList sections wrap. */}
+        {rightCard && (
+          <div className="hidden 2xl:block 2xl:w-[320px] 2xl:shrink-0">
+            {rightCard}
+          </div>
+        )}
+      </div>
     </div>
   );
 

--- a/frontend/components/tygodnik/NumberedRow.tsx
+++ b/frontend/components/tygodnik/NumberedRow.tsx
@@ -65,7 +65,7 @@ export function NumberedRow({
   // Grid layout stays 2-col (aside | body) on every breakpoint so the
   // main body keeps its full width regardless of whether a rightCard is
   // present. The card itself lives inside the body cell and only
-  // unmasks on xl as a floating sidebar — see comment below.
+  // unmasks at 2xl (≥1536 px) as a floating sidebar — see comment below.
   const gridCols = "grid-cols-1 md:grid-cols-[140px_1fr] xl:grid-cols-[180px_1fr]";
 
   const inner = (

--- a/frontend/lib/db/events.ts
+++ b/frontend/lib/db/events.ts
@@ -48,28 +48,66 @@ export function getSittingsIndex(term = 10): Promise<SittingInfo[]> {
   )();
 }
 
+type TygodnikSittingRow = {
+  term: number;
+  sitting_num: number;
+  sitting_title: string | null;
+  first_date: string | null;
+  last_date: string | null;
+  print_count: number | null;
+  event_count: number | null;
+  top_topics: string[] | null;
+};
+
+function mapTygodnikSittingRow(row: TygodnikSittingRow): SittingInfo {
+  return {
+    term: row.term,
+    sittingNum: row.sitting_num,
+    title: row.sitting_title ?? "",
+    firstDate: row.first_date ?? "",
+    lastDate: row.last_date ?? "",
+    printCount: row.print_count ?? 0,
+    eventCount: row.event_count ?? 0,
+    topTopics: topicsFromDb(row.top_topics),
+  };
+}
+
 async function loadLatestSittingWithEvents(term: number): Promise<SittingInfo | null> {
   const sb = supabase();
-  const { data, error } = await sb
+  const today = warsawToday();
+  const cols =
+    "term, sitting_num, sitting_title, first_date, last_date, print_count, event_count, top_topics";
+
+  // Prefer the most recent sitting whose final day is already behind us —
+  // that's the latest week with actually-finished items (votes wrapped,
+  // floor quotes ingested) rather than a queued-but-not-yet-debated
+  // future agenda. Print events alone (event_count > 0) aren't enough
+  // because Sejm publishes drafts days before the sitting opens.
+  const finishedRes = await sb
     .from("tygodnik_sittings")
-    .select("term, sitting_num, sitting_title, first_date, last_date, print_count, event_count, top_topics")
+    .select(cols)
+    .eq("term", term)
+    .gt("event_count", 0)
+    .lt("last_date", today)
+    .order("sitting_num", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (finishedRes.error) throw finishedRes.error;
+  if (finishedRes.data) return mapTygodnikSittingRow(finishedRes.data as TygodnikSittingRow);
+
+  // Fallback for the very start of a term when no sitting has wrapped
+  // yet — better to show the upcoming sitting than nothing at all.
+  const fallbackRes = await sb
+    .from("tygodnik_sittings")
+    .select(cols)
     .eq("term", term)
     .gt("event_count", 0)
     .order("sitting_num", { ascending: false })
     .limit(1)
     .maybeSingle();
-  if (error) throw error;
-  if (!data) return null;
-  return {
-    term: data.term as number,
-    sittingNum: data.sitting_num as number,
-    title: (data.sitting_title as string) ?? "",
-    firstDate: (data.first_date as string) ?? "",
-    lastDate: (data.last_date as string) ?? "",
-    printCount: (data.print_count as number) ?? 0,
-    eventCount: (data.event_count as number) ?? 0,
-    topTopics: topicsFromDb(data.top_topics as string[] | null),
-  };
+  if (fallbackRes.error) throw fallbackRes.error;
+  if (!fallbackRes.data) return null;
+  return mapTygodnikSittingRow(fallbackRes.data as TygodnikSittingRow);
 }
 
 export function getLatestSittingWithEvents(term = 10): Promise<SittingInfo | null> {


### PR DESCRIPTION
## Summary
Improves the Tygodnik sitting display by deferring the editorial sidebar (vote/quote summary) to 2xl+ breakpoints and refactoring the sitting query logic to prefer finished sittings over queued ones.

## Key Changes

- **Events query logic (`loadLatestSittingWithEvents`):**
  - Added two-tier query strategy: first tries to fetch the most recent sitting whose final day has passed (`last_date < today`), then falls back to any sitting with events if none have finished yet
  - Extracted type definition `TygodnikSittingRow` and mapping function `mapTygodnikSittingRow` to reduce duplication and improve type safety
  - Clarified intent with comments explaining why finished sittings are preferred (votes wrapped, floor quotes ingested) over draft-only queued agendas

- **Layout refactor (`NumberedRow.tsx`):**
  - Removed responsive grid column switching based on `rightCard` presence
  - Grid now stays at 2-col (aside | body) on all breakpoints, keeping the main body at full width
  - Sidebar now lives inside the body cell and only unmasks on 2xl as a floating sidebar using flexbox
  - Body content retains its 820px max-width to prevent prose column dilation when sidebar appears

- **Container width (`BriefList.tsx`):**
  - Widened max-width from 1240px to 1640px at 2xl breakpoint to accommodate the floating sidebar without compressing the main column
  - Added clarifying comment about the 2xl breakpoint strategy

## Implementation Details
The sidebar deferral ensures the main content column never shrinks to host the sidebar on smaller screens, improving readability on tablets and desktops below 1536px. The sitting query improvement prioritizes user-facing content (finished debates with ingested quotes/votes) over procedural drafts, reducing confusion at term starts when no sitting has wrapped yet.

https://claude.ai/code/session_01QyBvoPuTNjQ47s4t3DRtE4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted wide-screen layout constraints to prevent the main column from compressing and allow a sidebar to fit on very large displays.
  * Consolidated component grid/layout behavior so index and body consistently maintain a two-column structure across breakpoints while the optional sidebar only appears on extra-wide screens.
  * Reworked sitting-selection logic to be timezone-aware, prefer finished sittings, and fall back when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miskibin/tygodnik-sejmowy/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->