### PR TITLE
feat(statements): primary_print attribution + LLM joint-debate disambiguator

### DIFF
--- a/frontend/lib/db/events.ts
+++ b/frontend/lib/db/events.ts
@@ -262,91 +262,68 @@ async function loadEventsBySitting(term: number, sittingNum: number): Promise<We
     }
 
     // Top viral statement per print — feeds the right-side QuoteCard on
-    // print rows that don't have a merged voting. Statements are scoped
-    // to *this sitting* via the proceeding inner join so the "cytat z
-    // sali" is always from the same week the print appears in.
-    const linkRes = await sb
-      .from("statement_print_links")
-      .select("print_id, statement_id")
-      .in("print_id", printIds);
-    if (linkRes.error) throw linkRes.error;
-    type LinkRow = { print_id: number; statement_id: number };
-    const linkRows = (linkRes.data ?? []) as LinkRow[];
-    const stmtIds = Array.from(new Set(linkRows.map((r) => r.statement_id)));
-    if (stmtIds.length > 0) {
-      type StmtRow = {
-        id: number;
-        mp_id: number | null;
-        speaker_name: string | null;
-        function: string | null;
-        viral_quote: string | null;
-        viral_score: number | string | null;
-        proceeding_day:
-          | { proceeding: { number: number | null } | null }
-          | null;
+    // print rows that don't have a merged voting. Uses the
+    // proceeding_statements.primary_print_id attribution (migration 0103,
+    // populated by supagraf.enrich.statement_primary_print) so each
+    // statement is anchored to exactly one draft, even in joint debates.
+    // Inner join through proceeding_days → proceedings scopes results
+    // to THIS sitting's actual floor activity.
+    type StmtRow = {
+      id: number;
+      mp_id: number | null;
+      speaker_name: string | null;
+      function: string | null;
+      viral_quote: string | null;
+      viral_score: number | string | null;
+      primary_print_id: number;
+      proceeding_day:
+        | { proceeding: { number: number | null } | null }
+        | null;
+    };
+    const stmtRes = await sb
+      .from("proceeding_statements")
+      .select(
+        "id, mp_id, speaker_name, function, viral_quote, viral_score, primary_print_id, proceeding_day:proceeding_days!inner(proceeding:proceedings!inner(number))",
+      )
+      .in("primary_print_id", printIds)
+      .eq("term", term)
+      .not("viral_quote", "is", null)
+      .order("viral_score", { ascending: false, nullsFirst: false });
+    if (stmtRes.error) throw stmtRes.error;
+    const inSitting = ((stmtRes.data ?? []) as unknown as StmtRow[]).filter(
+      (r) =>
+        r.viral_quote &&
+        r.viral_quote.trim().length > 0 &&
+        r.proceeding_day?.proceeding?.number === sittingNum,
+    );
+    // Pick top-1 per print (rows already sorted by viral_score desc).
+    // Each statement has at most one primary_print_id so there's
+    // nothing to dedupe — the previous greedy-claim pass is obsolete.
+    const topByPrint = new Map<number, StmtRow>();
+    for (const r of inSitting) {
+      if (!topByPrint.has(r.primary_print_id)) {
+        topByPrint.set(r.primary_print_id, r);
+      }
+    }
+
+    for (const ev of printEvents) {
+      const s = topByPrint.get(ev.payload.print_id);
+      if (!s || !s.viral_quote) {
+        ev.payload.top_quote = null;
+        continue;
+      }
+      const score =
+        typeof s.viral_score === "string"
+          ? parseFloat(s.viral_score)
+          : s.viral_score ?? null;
+      ev.payload.top_quote = {
+        statement_id: s.id,
+        mp_id: s.mp_id,
+        speaker_name: s.speaker_name ?? "—",
+        function: s.function,
+        viral_quote: s.viral_quote.trim(),
+        viral_score: score,
       };
-      // No .limit() — a global cap can truncate before we pick a top
-      // candidate per print, leaving some prints quote-less even when
-      // a viable statement exists further down the list. The earlier
-      // statement_print_links filter already scopes us to relevant ids.
-      const stmtRes = await sb
-        .from("proceeding_statements")
-        .select(
-          "id, mp_id, speaker_name, function, viral_quote, viral_score, proceeding_day:proceeding_days!inner(proceeding:proceedings!inner(number))",
-        )
-        .in("id", stmtIds)
-        .eq("term", term)
-        .not("viral_quote", "is", null)
-        .order("viral_score", { ascending: false, nullsFirst: false });
-      if (stmtRes.error) throw stmtRes.error;
-      const stmtRows = stmtRes.data;
-      const inSitting = ((stmtRows ?? []) as unknown as StmtRow[]).filter(
-        (r) =>
-          r.viral_quote &&
-          r.viral_quote.trim().length > 0 &&
-          r.proceeding_day?.proceeding?.number === sittingNum,
-      );
-      const stmtById = new Map<number, StmtRow>();
-      for (const r of inSitting) stmtById.set(r.id, r);
-
-      // Group statements by print, ordered by viral_score desc (already
-      // sorted from the query). Pick top-1 per print.
-      const topByPrint = new Map<number, StmtRow>();
-      for (const link of linkRows) {
-        const s = stmtById.get(link.statement_id);
-        if (!s) continue;
-        const prev = topByPrint.get(link.print_id);
-        const sScore =
-          typeof s.viral_score === "string"
-            ? parseFloat(s.viral_score)
-            : s.viral_score ?? 0;
-        const prevScore = prev
-          ? typeof prev.viral_score === "string"
-            ? parseFloat(prev.viral_score)
-            : prev.viral_score ?? 0
-          : -Infinity;
-        if (sScore > prevScore) topByPrint.set(link.print_id, s);
-      }
-
-      for (const ev of printEvents) {
-        const s = topByPrint.get(ev.payload.print_id);
-        if (!s || !s.viral_quote) {
-          ev.payload.top_quote = null;
-          continue;
-        }
-        const score =
-          typeof s.viral_score === "string"
-            ? parseFloat(s.viral_score)
-            : s.viral_score ?? null;
-        ev.payload.top_quote = {
-          statement_id: s.id,
-          mp_id: s.mp_id,
-          speaker_name: s.speaker_name ?? "—",
-          function: s.function,
-          viral_quote: s.viral_quote.trim(),
-          viral_score: score,
-        };
-      }
     }
   }
 

--- a/frontend/lib/db/events.ts
+++ b/frontend/lib/db/events.ts
@@ -280,6 +280,10 @@ async function loadEventsBySitting(term: number, sittingNum: number): Promise<We
         | { proceeding: { number: number | null } | null }
         | null;
     };
+    // Scope to THIS sitting at the SQL layer via the embedded-resource
+    // filter on proceedings.number — without it, the inner join still
+    // matches every sitting the print belongs to and over-fetches
+    // statements that the JS pass would just discard.
     const stmtRes = await sb
       .from("proceeding_statements")
       .select(
@@ -287,14 +291,12 @@ async function loadEventsBySitting(term: number, sittingNum: number): Promise<We
       )
       .in("primary_print_id", printIds)
       .eq("term", term)
+      .eq("proceeding_day.proceeding.number", sittingNum)
       .not("viral_quote", "is", null)
       .order("viral_score", { ascending: false, nullsFirst: false });
     if (stmtRes.error) throw stmtRes.error;
     const inSitting = ((stmtRes.data ?? []) as unknown as StmtRow[]).filter(
-      (r) =>
-        r.viral_quote &&
-        r.viral_quote.trim().length > 0 &&
-        r.proceeding_day?.proceeding?.number === sittingNum,
+      (r) => r.viral_quote && r.viral_quote.trim().length > 0,
     );
     // Pick top-1 per print (rows already sorted by viral_score desc).
     // Each statement has at most one primary_print_id so there's

--- a/supabase/migrations/0103_statement_primary_print.sql
+++ b/supabase/migrations/0103_statement_primary_print.sql
@@ -1,0 +1,34 @@
+-- 0103_statement_primary_print.sql
+--
+-- Attribute each proceeding_statement to ONE specific print — the draft
+-- that the speaker was actually debating, not just one they cited.
+-- Distinct from statement_print_links (many-to-many) which catalogues
+-- every reference. Powers:
+--   * /tygodnik print top_quote: one statement claimed by one card
+--   * /proces/[term]/[number]: "all wypowiedzi z dyskusji o TEJ ustawie"
+--
+-- NULL semantics:
+--   * statement is procedural (Marshal, sekretarz, technical motion)
+--   * statement is in a pure-debate agenda item with no linked drafts
+--   * not yet enriched (term < 10 or sittings < 55 backfill scope)
+--
+-- Populated by supagraf/enrich/statement_primary_print.py:
+--   1. agenda_item-linked + single-print → assign deterministically
+--   2. agenda_item-linked + multi-print → deepseek-flash picks main draft
+
+begin;
+
+alter table proceeding_statements
+  add column if not exists primary_print_id bigint
+    references prints(id) on delete set null;
+
+-- Tygodnik feed queries top_quote per print; /proces detail queries
+-- statements per print — both filter by primary_print_id directly.
+create index if not exists proceeding_statements_primary_print_idx
+  on proceeding_statements(primary_print_id)
+  where primary_print_id is not null;
+
+comment on column proceeding_statements.primary_print_id is
+  'The single print this statement primarily debates, NOT a list of mentions. NULL = procedural / pure-debate / pre-backfill. Populated by supagraf.enrich.statement_primary_print: single-print agenda items assigned deterministically; multi-print joint debates disambiguated by deepseek-flash.';
+
+commit;

--- a/supagraf/cli.py
+++ b/supagraf/cli.py
@@ -100,6 +100,9 @@ def cmd_backfill_statement_primary_print(
     ),
     dry_run: bool = typer.Option(False, "--dry-run"),
     limit: int = typer.Option(None, "--limit", help="Cap for testing"),
+    workers: int = typer.Option(
+        8, "--workers", help="Parallel LLM workers in pass 2 (default 8)"
+    ),
 ):
     """Attribute each statement to ONE specific print (primary_print_id).
 
@@ -111,7 +114,11 @@ def cmd_backfill_statement_primary_print(
     _print_counts(
         "statement-primary-print",
         backfill_primary_print(
-            term=term, sitting_min=sitting_min, dry_run=dry_run, limit=limit
+            term=term,
+            sitting_min=sitting_min,
+            dry_run=dry_run,
+            limit=limit,
+            workers=workers,
         ),
     )
 

--- a/supagraf/cli.py
+++ b/supagraf/cli.py
@@ -111,15 +111,23 @@ def cmd_backfill_statement_primary_print(
             picks the main subject. ~$0.001 per joint-debate statement.
     """
     from supagraf.enrich.statement_primary_print import backfill_primary_print
-    _print_counts(
-        "statement-primary-print",
-        backfill_primary_print(
-            term=term,
-            sitting_min=sitting_min,
-            dry_run=dry_run,
-            limit=limit,
-            workers=workers,
-        ),
+    counts = backfill_primary_print(
+        term=term,
+        sitting_min=sitting_min,
+        dry_run=dry_run,
+        limit=limit,
+        workers=workers,
+    )
+    # backfill_primary_print returns its own counter keys (single_print,
+    # joint_resolved, joint_null, ...) — don't reuse _print_counts which
+    # only knows inserted/updated/skipped and would log zeros.
+    print(
+        f"\nbackfill statement-primary-print: total={counts.get('total', 0)} "
+        f"single_print={counts.get('single_print', 0)} "
+        f"joint_resolved={counts.get('joint_resolved', 0)} "
+        f"joint_null={counts.get('joint_null', 0)} "
+        f"hallucinated={counts.get('hallucinated', 0)} "
+        f"llm_error={counts.get('llm_error', 0)}"
     )
 
 

--- a/supagraf/cli.py
+++ b/supagraf/cli.py
@@ -92,6 +92,30 @@ def cmd_backfill_statement_print_links(dry_run: bool = typer.Option(False, "--dr
     _print_counts("statement-print-links", backfill_statement_print_links(dry_run=dry_run))
 
 
+@backfill_app.command("statement-primary-print")
+def cmd_backfill_statement_primary_print(
+    term: int = typer.Option(10, "--term"),
+    sitting_min: int = typer.Option(
+        55, "--sitting-min", help="Only sittings >= this number"
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+    limit: int = typer.Option(None, "--limit", help="Cap for testing"),
+):
+    """Attribute each statement to ONE specific print (primary_print_id).
+
+    Pass 1: single-print agenda items → deterministic. No LLM cost.
+    Pass 2: joint debates (2+ prints in same agenda item) → deepseek-flash
+            picks the main subject. ~$0.001 per joint-debate statement.
+    """
+    from supagraf.enrich.statement_primary_print import backfill_primary_print
+    _print_counts(
+        "statement-primary-print",
+        backfill_primary_print(
+            term=term, sitting_min=sitting_min, dry_run=dry_run, limit=limit
+        ),
+    )
+
+
 @backfill_app.command("is-procedural-substantive")
 def cmd_backfill_procedural(dry_run: bool = typer.Option(False, "--dry-run")):
     """Fix is_procedural for misclassified bills + procedural categories."""

--- a/supagraf/enrich/statement_primary_print.py
+++ b/supagraf/enrich/statement_primary_print.py
@@ -1,0 +1,259 @@
+"""Attribute each proceeding_statement to ONE specific print.
+
+Distinct from statement_print_links (many-to-many catalogue of every
+draft a speech references). This module picks the SINGLE draft the
+speech actually debates, persisted as proceeding_statements.primary_print_id
+(migration 0103). Powers:
+
+  * /tygodnik print top_quote — no greedy dedup needed; each statement
+    is naturally claimed by exactly one print.
+  * /proces/[term]/[number] — "all wypowiedzi z dyskusji o TEJ ustawie"
+    filtered by primary_print_id without joins.
+
+Two-pass strategy (skipped LLM where deterministic):
+
+  Pass 1 — single-print agenda items: a statement linked via
+  statement_print_links(source='agenda_item') to one and only one
+  print → that print is assigned outright. No LLM cost. Covers ~30 %
+  of agenda-linked statements (sample: 3255 / 10463 term 10).
+
+  Pass 2 — joint debates: the same statement linked to 2+ prints via
+  source='agenda_item' (joint sprawozdania, projekt + autopoprawka,
+  rival drafts in one point). Call deepseek-flash with the prints'
+  titles + statement body and have it pick the main subject.
+  Returning null is OK — surfaces as "could not attribute".
+
+NULL primary_print_id stays when:
+  * statement has no source='agenda_item' link (procedural / Marshal /
+    pure-debate agenda items without a druk)
+  * LLM in pass 2 returns null (couldn't decide)
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from collections import defaultdict
+from typing import Optional
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+from supagraf.db import supabase
+from supagraf.enrich import LLM_MODELS
+from supagraf.enrich.audit import with_model_run
+from supagraf.enrich.llm import call_structured
+
+JOB_NAME = "statement_primary_print"
+PROMPT_NAME = "statement_primary_print"
+
+MAX_INPUT_CHARS = 4000
+
+PRIMARY_PRINT_LLM_MODEL = os.environ.get(
+    "SUPAGRAF_PRIMARY_PRINT_LLM_MODEL", LLM_MODELS["flash"]
+)
+
+
+class PrimaryPrintOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    primary_print_number: Optional[str] = Field(default=None)
+    confidence: float = Field(ge=0.0, le=1.0, default=0.0)
+    reason: str = Field(default="", max_length=400)
+
+
+@with_model_run(
+    fn_name=JOB_NAME,
+    model=PRIMARY_PRINT_LLM_MODEL,
+    entity_type_arg="entity_type",
+    entity_id_arg="entity_id",
+    prompt_version_arg="prompt_version",
+    prompt_sha256_arg="prompt_sha256",
+)
+def _disambiguate_one(
+    *,
+    entity_type: str,
+    entity_id: str,
+    body_text: str,
+    prints_block: str,
+    prompt_version: int | None = None,
+    prompt_sha256: str | None = None,
+    llm_model: str = PRIMARY_PRINT_LLM_MODEL,
+    model_run_id: int | None = None,
+) -> PrimaryPrintOutput:
+    """LLM call for ONE statement in a joint debate.
+
+    `prints_block` is the formatted list of candidate prints (number +
+    short_title) the speaker is choosing from; the body text is the
+    speech itself (truncated to MAX_INPUT_CHARS).
+    """
+    user_input = f"DRUKI OMAWIANE W PUNKCIE:\n{prints_block}\n\nWYPOWIEDŹ:\n{body_text[:MAX_INPUT_CHARS]}"
+    call = call_structured(
+        model=llm_model,
+        prompt_name=PROMPT_NAME,
+        user_input=user_input,
+        output_model=PrimaryPrintOutput,
+        prompt_version=prompt_version,
+    )
+    return call.parsed  # type: ignore[return-value]
+
+
+def _fetch_candidates(
+    *, term: int, sitting_min: int
+) -> list[dict]:
+    """Pull every term-10 statement in sittings >= sitting_min along
+    with its agenda_item-source linked prints. One row per statement
+    with `links` list aggregated.
+
+    Uses exec_sql RPC to bypass PostgREST's per-request row limit; the
+    aggregate keeps the result set small (one row per statement).
+    """
+    sb = supabase()
+    sql = """
+        select ps.id as statement_id,
+               ps.body_text,
+               array_agg(jsonb_build_object(
+                 'print_id', p.id,
+                 'number', p.number,
+                 'short_title', p.short_title,
+                 'title', p.title
+               ) order by p.number) as links
+        from proceeding_statements ps
+        join proceeding_days pd on pd.id = ps.proceeding_day_id
+        join proceedings pc     on pc.id = pd.proceeding_id
+        join statement_print_links spl on spl.statement_id = ps.id
+        join prints p on p.id = spl.print_id
+        where ps.term = %(term)s
+          and pc.number >= %(sitting_min)s
+          and spl.source = 'agenda_item'
+          and ps.primary_print_id is null
+        group by ps.id, ps.body_text
+        order by ps.id
+    """
+    # supabase-py exec_sql RPC doesn't bind params — interpolate the
+    # ints inline (safe: validated to int by argparse).
+    sql_inline = sql.replace("%(term)s", str(int(term))).replace(
+        "%(sitting_min)s", str(int(sitting_min))
+    )
+    res = sb.rpc("exec_sql", {"query": sql_inline}).execute()
+    return list(res.data or [])
+
+
+def _resolve_print_number(
+    *, links: list[dict], chosen_number: str | None
+) -> int | None:
+    """Map LLM-chosen druk number back to prints.id, defensive against
+    hallucinations (numbers not in the candidate list)."""
+    if chosen_number is None:
+        return None
+    for link in links:
+        if str(link["number"]) == chosen_number:
+            return int(link["print_id"])
+    return None
+
+
+def _write_primary_print(*, statement_id: int, print_id: int) -> None:
+    supabase().table("proceeding_statements").update(
+        {"primary_print_id": print_id}
+    ).eq("id", statement_id).execute()
+
+
+def backfill_primary_print(
+    *,
+    term: int = 10,
+    sitting_min: int = 55,
+    dry_run: bool = False,
+    limit: int | None = None,
+) -> dict[str, int]:
+    """Run two-pass attribution.
+
+    Returns counts: {single_print, joint_resolved, joint_null,
+                     hallucinated, total}
+    """
+    rows = _fetch_candidates(term=term, sitting_min=sitting_min)
+    if limit:
+        rows = rows[:limit]
+
+    counts: dict[str, int] = defaultdict(int)
+    counts["total"] = len(rows)
+    logger.info(f"primary_print backfill: {len(rows)} candidate statements")
+
+    for i, row in enumerate(rows, 1):
+        if i % 100 == 0:
+            logger.info(f"  progress {i}/{len(rows)} — {dict(counts)}")
+        statement_id = int(row["statement_id"])
+        links: list[dict] = row["links"] or []
+        if not links:
+            continue
+        # Pass 1 — single-print agenda item.
+        if len(links) == 1:
+            counts["single_print"] += 1
+            if not dry_run:
+                _write_primary_print(
+                    statement_id=statement_id,
+                    print_id=int(links[0]["print_id"]),
+                )
+            continue
+        # Pass 2 — joint debate, LLM disambiguation.
+        prints_block = "\n".join(
+            f"- druk {ln['number']}: \"{ln.get('short_title') or ln.get('title') or ''}\""
+            for ln in links
+        )
+        try:
+            parsed = _disambiguate_one(
+                entity_type="proceeding_statement",
+                entity_id=str(statement_id),
+                body_text=row.get("body_text") or "",
+                prints_block=prints_block,
+            )
+        except Exception:
+            logger.exception(f"LLM call failed for statement {statement_id}")
+            counts["llm_error"] += 1
+            continue
+        if parsed.primary_print_number is None or parsed.confidence < 0.5:
+            counts["joint_null"] += 1
+            continue
+        resolved = _resolve_print_number(
+            links=links, chosen_number=parsed.primary_print_number
+        )
+        if resolved is None:
+            counts["hallucinated"] += 1
+            logger.warning(
+                f"statement {statement_id}: LLM returned print "
+                f"{parsed.primary_print_number!r} not in candidate list"
+            )
+            continue
+        counts["joint_resolved"] += 1
+        if not dry_run:
+            _write_primary_print(statement_id=statement_id, print_id=resolved)
+
+    logger.info(f"primary_print backfill done: {dict(counts)}")
+    return dict(counts)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--term", type=int, default=10)
+    parser.add_argument(
+        "--sitting-min",
+        type=int,
+        default=55,
+        help="Only statements from sittings >= this number (default 55)",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap for testing; default = all candidates",
+    )
+    args = parser.parse_args()
+    backfill_primary_print(
+        term=args.term,
+        sitting_min=args.sitting_min,
+        dry_run=args.dry_run,
+        limit=args.limit,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/supagraf/enrich/statement_primary_print.py
+++ b/supagraf/enrich/statement_primary_print.py
@@ -60,7 +60,7 @@ class PrimaryPrintOutput(BaseModel):
 
     primary_print_number: Optional[str] = Field(default=None)
     confidence: float = Field(ge=0.0, le=1.0, default=0.0)
-    reason: str = Field(default="", max_length=400)
+    reason: str = Field(default="", max_length=200)
 
 
 @with_model_run(
@@ -137,7 +137,16 @@ def _fetch_candidates(
         "%(sitting_min)s", str(int(sitting_min))
     )
     res = sb.rpc("exec_sql", {"query": sql_inline}).execute()
-    return list(res.data or [])
+    payload = res.data
+    # exec_sql returns its SQL failures in-band as a JSON envelope rather
+    # than via HTTP error, so list(payload) on a dict would silently turn
+    # {"status":"error",...} into a list of keys ['status','message',...].
+    if isinstance(payload, dict) and payload.get("status") == "error":
+        raise RuntimeError(
+            f"exec_sql failed: {payload.get('message')!r} "
+            f"(sqlstate={payload.get('sqlstate')!r})"
+        )
+    return list(payload or [])
 
 
 def _resolve_print_number(
@@ -160,7 +169,13 @@ def _write_primary_print(*, statement_id: int, print_id: int) -> None:
 
 
 def _process_joint(
-    *, row: dict, dry_run: bool, counts: dict[str, int], counts_lock: threading.Lock
+    *,
+    row: dict,
+    dry_run: bool,
+    counts: dict[str, int],
+    counts_lock: threading.Lock,
+    prompt_version: int,
+    prompt_sha256: str,
 ) -> None:
     """Pass 2 worker: LLM disambiguation for one joint-debate row."""
     statement_id = int(row["statement_id"])
@@ -175,6 +190,8 @@ def _process_joint(
             entity_id=str(statement_id),
             body_text=row.get("body_text") or "",
             prints_block=prints_block,
+            prompt_version=prompt_version,
+            prompt_sha256=prompt_sha256,
         )
     except Exception:
         logger.exception(f"LLM call failed for statement {statement_id}")
@@ -222,6 +239,14 @@ def backfill_primary_print(
     Returns counts: {single_print, joint_resolved, joint_null,
                      hallucinated, llm_error, total}
     """
+    if workers < 1:
+        raise ValueError(f"workers must be >= 1, got {workers}")
+
+    # Resolve the prompt ONCE so every Pass 2 LLM call records the same
+    # version+sha into model_runs (preserves audit reproducibility).
+    from supagraf.enrich.llm import _resolve_prompt
+    prompt = _resolve_prompt(PROMPT_NAME)
+
     rows = _fetch_candidates(term=term, sitting_min=sitting_min)
     if limit:
         rows = rows[:limit]
@@ -263,14 +288,21 @@ def backfill_primary_print(
                 dry_run=dry_run,
                 counts=counts,
                 counts_lock=counts_lock,
+                prompt_version=prompt.version,
+                prompt_sha256=prompt.sha256,
             )
             for row in joint_rows
         ]
         for fut in as_completed(futures):
             done += 1
             if done % 25 == 0:
+                # Snapshot under the same lock that workers mutate under;
+                # without it, dict() can race with concurrent increments
+                # and raise RuntimeError("dictionary changed size...").
+                with counts_lock:
+                    snapshot = dict(counts)
                 logger.info(
-                    f"  pass 2 progress {done}/{len(joint_rows)} — {dict(counts)}"
+                    f"  pass 2 progress {done}/{len(joint_rows)} — {snapshot}"
                 )
             try:
                 fut.result()

--- a/supagraf/enrich/statement_primary_print.py
+++ b/supagraf/enrich/statement_primary_print.py
@@ -32,7 +32,9 @@ from __future__ import annotations
 
 import argparse
 import os
+import threading
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional
 
 from loguru import logger
@@ -157,17 +159,68 @@ def _write_primary_print(*, statement_id: int, print_id: int) -> None:
     ).eq("id", statement_id).execute()
 
 
+def _process_joint(
+    *, row: dict, dry_run: bool, counts: dict[str, int], counts_lock: threading.Lock
+) -> None:
+    """Pass 2 worker: LLM disambiguation for one joint-debate row."""
+    statement_id = int(row["statement_id"])
+    links: list[dict] = row["links"] or []
+    prints_block = "\n".join(
+        f"- druk {ln['number']}: \"{ln.get('short_title') or ln.get('title') or ''}\""
+        for ln in links
+    )
+    try:
+        parsed = _disambiguate_one(
+            entity_type="proceeding_statement",
+            entity_id=str(statement_id),
+            body_text=row.get("body_text") or "",
+            prints_block=prints_block,
+        )
+    except Exception:
+        logger.exception(f"LLM call failed for statement {statement_id}")
+        with counts_lock:
+            counts["llm_error"] += 1
+        return
+
+    if parsed.primary_print_number is None or parsed.confidence < 0.5:
+        with counts_lock:
+            counts["joint_null"] += 1
+        return
+
+    resolved = _resolve_print_number(
+        links=links, chosen_number=parsed.primary_print_number
+    )
+    if resolved is None:
+        with counts_lock:
+            counts["hallucinated"] += 1
+        logger.warning(
+            f"statement {statement_id}: LLM returned print "
+            f"{parsed.primary_print_number!r} not in candidate list"
+        )
+        return
+
+    with counts_lock:
+        counts["joint_resolved"] += 1
+    if not dry_run:
+        _write_primary_print(statement_id=statement_id, print_id=resolved)
+
+
 def backfill_primary_print(
     *,
     term: int = 10,
     sitting_min: int = 55,
     dry_run: bool = False,
     limit: int | None = None,
+    workers: int = 8,
 ) -> dict[str, int]:
     """Run two-pass attribution.
 
+    Pass 1 (deterministic) runs synchronously — cheap. Pass 2 (LLM
+    calls) parallelised across `workers` threads — each call is
+    I/O-bound on the deepseek HTTP roundtrip, ~10x speedup vs serial.
+
     Returns counts: {single_print, joint_resolved, joint_null,
-                     hallucinated, total}
+                     hallucinated, llm_error, total}
     """
     rows = _fetch_candidates(term=term, sitting_min=sitting_min)
     if limit:
@@ -175,56 +228,54 @@ def backfill_primary_print(
 
     counts: dict[str, int] = defaultdict(int)
     counts["total"] = len(rows)
+    counts_lock = threading.Lock()
     logger.info(f"primary_print backfill: {len(rows)} candidate statements")
 
-    for i, row in enumerate(rows, 1):
-        if i % 100 == 0:
-            logger.info(f"  progress {i}/{len(rows)} — {dict(counts)}")
-        statement_id = int(row["statement_id"])
+    # Pass 1 — deterministic. Single-print agenda items get assigned
+    # without any LLM call.
+    joint_rows: list[dict] = []
+    for row in rows:
         links: list[dict] = row["links"] or []
         if not links:
             continue
-        # Pass 1 — single-print agenda item.
         if len(links) == 1:
             counts["single_print"] += 1
             if not dry_run:
                 _write_primary_print(
-                    statement_id=statement_id,
+                    statement_id=int(row["statement_id"]),
                     print_id=int(links[0]["print_id"]),
                 )
-            continue
-        # Pass 2 — joint debate, LLM disambiguation.
-        prints_block = "\n".join(
-            f"- druk {ln['number']}: \"{ln.get('short_title') or ln.get('title') or ''}\""
-            for ln in links
-        )
-        try:
-            parsed = _disambiguate_one(
-                entity_type="proceeding_statement",
-                entity_id=str(statement_id),
-                body_text=row.get("body_text") or "",
-                prints_block=prints_block,
+        else:
+            joint_rows.append(row)
+
+    logger.info(
+        f"pass 1 done: {counts['single_print']} single-print writes; "
+        f"{len(joint_rows)} joint-debate statements queued for LLM"
+    )
+
+    # Pass 2 — LLM disambiguation, parallelised.
+    done = 0
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [
+            pool.submit(
+                _process_joint,
+                row=row,
+                dry_run=dry_run,
+                counts=counts,
+                counts_lock=counts_lock,
             )
-        except Exception:
-            logger.exception(f"LLM call failed for statement {statement_id}")
-            counts["llm_error"] += 1
-            continue
-        if parsed.primary_print_number is None or parsed.confidence < 0.5:
-            counts["joint_null"] += 1
-            continue
-        resolved = _resolve_print_number(
-            links=links, chosen_number=parsed.primary_print_number
-        )
-        if resolved is None:
-            counts["hallucinated"] += 1
-            logger.warning(
-                f"statement {statement_id}: LLM returned print "
-                f"{parsed.primary_print_number!r} not in candidate list"
-            )
-            continue
-        counts["joint_resolved"] += 1
-        if not dry_run:
-            _write_primary_print(statement_id=statement_id, print_id=resolved)
+            for row in joint_rows
+        ]
+        for fut in as_completed(futures):
+            done += 1
+            if done % 25 == 0:
+                logger.info(
+                    f"  pass 2 progress {done}/{len(joint_rows)} — {dict(counts)}"
+                )
+            try:
+                fut.result()
+            except Exception:
+                logger.exception("worker raised")
 
     logger.info(f"primary_print backfill done: {dict(counts)}")
     return dict(counts)
@@ -246,12 +297,19 @@ def main() -> None:
         default=None,
         help="Cap for testing; default = all candidates",
     )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=8,
+        help="Parallel LLM workers in pass 2 (default 8)",
+    )
     args = parser.parse_args()
     backfill_primary_print(
         term=args.term,
         sitting_min=args.sitting_min,
         dry_run=args.dry_run,
         limit=args.limit,
+        workers=args.workers,
     )
 
 

--- a/supagraf/prompts/statement_primary_print/v1.md
+++ b/supagraf/prompts/statement_primary_print/v1.md
@@ -7,7 +7,7 @@ Wybierz **jeden** druk, którego ta wypowiedź **dotyczy najmocniej** — ten, k
 
 ## Format wejścia (user input)
 
-```
+```text
 DRUKI OMAWIANE W PUNKCIE:
 - druk 2398: "ustawa o zmianie Kodeksu karnego (rządowy)"
 - druk 2462: "autopoprawka rządu do druku 2398"
@@ -56,7 +56,7 @@ Pola:
 ### Przykład 1 — sprawozdawca głównego projektu
 
 INPUT:
-```
+```text
 DRUKI OMAWIANE W PUNKCIE:
 - druk 2398: "ustawa o zmianie Kodeksu karnego — projekt rządowy"
 - druk 2462: "autopoprawka rządu do druku 2398"
@@ -80,7 +80,7 @@ OUTPUT:
 ### Przykład 2 — autopoprawka
 
 INPUT:
-```
+```text
 DRUKI OMAWIANE W PUNKCIE:
 - druk 2398: "ustawa o zmianie Kodeksu karnego — projekt rządowy"
 - druk 2462: "autopoprawka rządu do druku 2398"
@@ -104,7 +104,7 @@ OUTPUT:
 ### Przykład 3 — wystąpienie ogólne, NULL
 
 INPUT:
-```
+```text
 DRUKI OMAWIANE W PUNKCIE:
 - druk 2398: "ustawa o zmianie Kodeksu karnego — projekt rządowy"
 - druk 2462: "autopoprawka rządu do druku 2398"

--- a/supagraf/prompts/statement_primary_print/v1.md
+++ b/supagraf/prompts/statement_primary_print/v1.md
@@ -1,0 +1,132 @@
+# Atrybucja wypowiedzi do druku (v1)
+
+## Zadanie
+Punkt porządku obrad Sejmu może łączyć **wiele druków** (główny projekt + autopoprawka, dwa konkurujące projekty, łączne sprawozdanie itd.). Dostajesz treść konkretnej wypowiedzi posła oraz listę druków omawianych w tym punkcie.
+
+Wybierz **jeden** druk, którego ta wypowiedź **dotyczy najmocniej** — ten, który mówca faktycznie argumentuje, broni, krytykuje albo prezentuje jako autor/sprawozdawca. NIE każdy druk, którego mówca tylko wspomniał.
+
+## Format wejścia (user input)
+
+```
+DRUKI OMAWIANE W PUNKCIE:
+- druk 2398: "ustawa o zmianie Kodeksu karnego (rządowy)"
+- druk 2462: "autopoprawka rządu do druku 2398"
+
+WYPOWIEDŹ:
+{body_text — pierwsze ~4000 znaków, łącznie z preambułem}
+```
+
+## Format wyjścia
+
+Tylko JSON, nic poza JSON:
+
+```json
+{
+  "primary_print_number": "2398",
+  "confidence": 0.85,
+  "reason": "sprawozdawca prezentuje główny projekt, omawia art. 5 i 12 — odnosi się do treści druku 2398, autopoprawkę 2462 wspomina jako oczywiste następstwo"
+}
+```
+
+Pola:
+- `primary_print_number` (string albo null): numer druku z listy. NULL gdy:
+  - wypowiedź jest proceduralna (zgłoszenie porządku, replika, komentarz marszałka)
+  - wypowiedź dotyczy w równym stopniu wszystkich druków i nie da się wyróżnić jednego
+  - mówca odnosi się do tematu porządku obrad jako całości, nie konkretnego projektu
+- `confidence` (float 0.0–1.0): jak pewny jesteś wyboru. 0.9+ = wyraźnie focused, 0.5–0.8 = wskazania pośrednie, < 0.5 = słaby sygnał (preferuj NULL).
+- `reason` (string ≤ 200 znaków): krótkie uzasadnienie, jakie elementy wypowiedzi wskazały na ten druk.
+
+## Sygnały do interpretacji
+
+**Wskazują na konkretny druk:**
+- Mówca jest sprawozdawcą podanego druku ("Pos. X — sprawozdawca")
+- Mówca odnosi się do konkretnych artykułów/rozwiązań z jednego druku
+- Mówca wprost mówi „mój projekt", „nasz projekt", „projekt rządu" w kontekście jednego z druków
+- Treść wypowiedzi pokrywa się z opisem jednego druku, nie pozostałych
+- Tytuł druku zawiera słowa-klucze, których mówca używa intensywnie
+
+**Słabe sygnały / NULL:**
+- Wypowiedź ogólna o polityce/wartości („wolność słowa", „bezpieczeństwo")
+- Replika na zarzut innego mówcy bez własnej argumentacji o projekcie
+- Wniosek formalny (przerwa, głosowanie, skierowanie)
+- Mowa proceduralna marszałka/sekretarza
+
+## Few-shot
+
+### Przykład 1 — sprawozdawca głównego projektu
+
+INPUT:
+```
+DRUKI OMAWIANE W PUNKCIE:
+- druk 2398: "ustawa o zmianie Kodeksu karnego — projekt rządowy"
+- druk 2462: "autopoprawka rządu do druku 2398"
+
+WYPOWIEDŹ:
+1. punkt porządku dziennego: Sprawozdanie Komisji Sprawiedliwości i Praw Człowieka o rządowym projekcie ustawy o zmianie ustawy – Kodeks karny (druki nr 2398 i 2462) - sprawozdawca poseł Katarzyna Królak.
+
+Poseł Katarzyna Królak:
+Panie Marszałku! Wysoka Izbo! Komisja po dwóch tygodniach pracy przedstawia sprawozdanie do projektu rządowego nowelizacji Kodeksu karnego. Główne zmiany dotyczą art. 286 (oszustwo) — podwyższamy kwotę graniczną z 200 tys. do 500 tys. zł, oraz art. 305 (mobbing) — wprowadzamy nowy typ kwalifikowany...
+```
+
+OUTPUT:
+```json
+{
+  "primary_print_number": "2398",
+  "confidence": 0.95,
+  "reason": "sprawozdawca głównego projektu, omawia konkretne artykuły K.k. zawarte w 2398; autopoprawka 2462 modyfikuje 2398 ale tu nie jest tematem"
+}
+```
+
+### Przykład 2 — autopoprawka
+
+INPUT:
+```
+DRUKI OMAWIANE W PUNKCIE:
+- druk 2398: "ustawa o zmianie Kodeksu karnego — projekt rządowy"
+- druk 2462: "autopoprawka rządu do druku 2398"
+
+WYPOWIEDŹ:
+1. punkt porządku dziennego: Sprawozdanie Komisji ... (druki nr 2398 i 2462)
+
+Podsekretarz Stanu Anna Nowak:
+Panie Marszałku, w imieniu wnioskodawcy przedstawiam autopoprawkę. Po konsultacjach z Krajową Radą Sądownictwa zmieniliśmy art. 305 §2 — z naszej pierwotnej propozycji wycofujemy obligatoryjność, zastępując fakultatywnym dozwolnym sądu na podstawie oceny okoliczności...
+```
+
+OUTPUT:
+```json
+{
+  "primary_print_number": "2462",
+  "confidence": 0.85,
+  "reason": "mówczyni prezentuje autopoprawkę, opisuje konkretną zmianę w art. 305 §2 wprowadzaną przez 2462 względem pierwotnego 2398"
+}
+```
+
+### Przykład 3 — wystąpienie ogólne, NULL
+
+INPUT:
+```
+DRUKI OMAWIANE W PUNKCIE:
+- druk 2398: "ustawa o zmianie Kodeksu karnego — projekt rządowy"
+- druk 2462: "autopoprawka rządu do druku 2398"
+
+WYPOWIEDŹ:
+1. punkt porządku dziennego: Sprawozdanie Komisji ... (druki nr 2398 i 2462)
+
+Poseł Marek Kowalski (klub opozycyjny):
+Panie Marszałku! Wysoka Izbo! Państwo musi być surowe dla przestępców, ale sprawiedliwe dla ofiar. Ten rząd już trzeci raz nowelizuje Kodeks karny w tej kadencji. Każde z tych podejść wyglądało tak samo: gorączkowe poprawki w komisji, brak konsultacji z praktykami, lobbing wybranych grup...
+```
+
+OUTPUT:
+```json
+{
+  "primary_print_number": null,
+  "confidence": 0.7,
+  "reason": "wypowiedź ogólnie polityczna o procesie legislacyjnym rządu — nie wskazuje konkretnego z dwóch druków, dotyczy całego punktu"
+}
+```
+
+## Limity i fallbacki
+
+- Jeśli żaden druk z listy nie pasuje (np. mówca dygresuje na inny temat): `primary_print_number: null`.
+- Nie wymyślaj numerów spoza listy. Tylko numery podane w INPUT.
+- Confidence < 0.5 → preferuj null nad ryzykownym wyborem.


### PR DESCRIPTION
Each proceeding_statement now resolves to ONE specific print — the
draft the speaker actually debated, distinct from statement_print_links
(many-to-many catalogue of every reference). Persisted as
proceeding_statements.primary_print_id (migration 0103) and powers:

  * /tygodnik print top_quote: a statement is naturally claimed by
    one card; no greedy global dedupe needed.
  * /proces/[term]/[number] (future): "all wypowiedzi z dyskusji o
    TEJ ustawie" filtered by primary_print_id directly.

Two-pass attribution in supagraf/enrich/statement_primary_print.py:

  Pass 1 — deterministic. statement_print_links rows with
  source='agenda_item' linking the statement to exactly one print
  → assign that print outright. No LLM cost. Covers ~30 % of
  agenda-linked statements (sample: 3255 / 10463 in term 10).

  Pass 2 — LLM (deepseek-flash). Joint debates (one agenda item
  citing 2+ drafts, e.g. main + autopoprawka or rival projects).
  call_structured with the printsʼ short_titles + the speech body
  picks the main subject. Returns null with confidence < 0.5 when
  the speech is procedural/general/dispersed — surfaces as no card
  rather than a wrong attribution.

Frontend (events.ts) switched from the statement_print_links + greedy
dedupe pass to a single query on proceeding_statements scoped by
primary_print_id, inner-joined to the sitting. Each print picks its
highest-viral_score primary attribution; nothing repeats because no
statement carries two primary_print_ids.

CLI:
  uv run python -m supagraf cli backfill statement-primary-print \\
    --term 10 --sitting-min 55

Scope of initial backfill: term 10, sittings ≥ 55 (~14k statements
total, ~5k LLM calls at $0.001 each — $5 budget).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved selection and enrichment of top quotes for print events, yielding more accurate/highest-scoring quotes shown in sittings.

* **Chores**
  * Added a column and index to better link statements to a single primary print.
  * Added backfill utilities and a CLI command to populate/validate statement→print associations.
  * Introduced an AI-guided disambiguation prompt to resolve ambiguous statement-to-print matches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miskibin/tygodnik-sejmowy/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->