### PR TITLE
Re-fetch stale process details when changeDate advances

### DIFF
--- a/supagraf/fixtures/sources/sejm.py
+++ b/supagraf/fixtures/sources/sejm.py
@@ -109,6 +109,43 @@ async def _maybe_save_json(
     return data
 
 
+def _list_change_date(item: Any) -> Optional[str]:
+    """ISO `changeDate` string from a list-endpoint item, when present."""
+    if isinstance(item, dict):
+        v = item.get("changeDate")
+        if isinstance(v, str) and v:
+            return v
+    return None
+
+
+def _detail_stale(dest: Path, list_change_date: Optional[str]) -> bool:
+    """True when the cached detail fixture is missing or older than upstream.
+
+    The `/processes` list carries a per-process `changeDate` that bumps
+    whenever a stage is appended upstream. The detail fixture (the full
+    `stages` array) is otherwise cached forever under `refresh=False`, which
+    freezes an *open* process at whatever stage it had when first captured —
+    a bill stuck at "I czytanie pending" long after the reading happened.
+    Comparing ISO timestamps lexicographically (zero-padded, so string order
+    == chronological order) lets us re-fetch only the processes that actually
+    moved, instead of refreshing every detail every day.
+    """
+    if not exists(dest):
+        return True
+    if not list_change_date:
+        return False
+    from ..storage import load_json
+
+    try:
+        cached = load_json(dest)
+    except Exception:
+        return True
+    cached_cd = _list_change_date(cached)
+    if not cached_cd:
+        return True
+    return list_change_date > cached_cd
+
+
 async def _maybe_save_binary(
     client: SejmClient, path: str, dest: Path, refresh: bool
 ) -> bool:
@@ -579,7 +616,13 @@ async def capture_processes(
         sid = _safe_id(num)
         captured.append(sid)
         dest = dest_dir / f"{sid}.json"
-        detail = await _maybe_save_json(client, f"{base}/processes/{num}", dest, refresh)
+        # Re-fetch the detail when upstream advanced past the cached fixture.
+        # Without this, an open process's stages stay frozen at first capture
+        # under refresh=False — the timeline lags the real legislative stage
+        # (e.g. quotes from a first-reading debate while the path still shows
+        # "I czytanie pending").
+        eff_refresh = refresh or _detail_stale(dest, _list_change_date(p))
+        detail = await _maybe_save_json(client, f"{base}/processes/{num}", dest, eff_refresh)
         # natural_id for _stage_processes is `process.number`.
         _fire(on_record, str(num), detail, _rel(dest, out_root))
         if not no_binaries and isinstance(detail, dict) and _take("processes"):

--- a/tests/supagraf/unit/test_capture_on_record.py
+++ b/tests/supagraf/unit/test_capture_on_record.py
@@ -134,6 +134,73 @@ def test_capture_processes_natural_id_is_process_number(tmp_path: Path):
     ]
 
 
+def test_capture_processes_refetches_detail_when_changedate_advances(tmp_path: Path):
+    """An open process that gained a stage upstream must re-fetch its detail.
+
+    The detail fixture is cached forever under refresh=False; comparing the
+    list-endpoint `changeDate` against the cached fixture's `changeDate` is
+    what unsticks a frozen timeline (e.g. a bill stuck at "I czytanie
+    pending" after the reading already happened). Regression for the
+    /proces/10/2453 stale-timeline report.
+    """
+    base = "/sejm/term10"
+    processes_dir = tmp_path / "sejm" / "processes"
+    processes_dir.mkdir(parents=True)
+    # Pre-seed a stale cached fixture: only the early referral stage.
+    from supagraf.fixtures.storage import write_json
+
+    write_json(
+        processes_dir / "2453.json",
+        {"number": "2453", "changeDate": "2026-04-17T12:00:00", "stages": [{"stageType": "Start"}]},
+    )
+
+    fresh_detail = {
+        "number": "2453",
+        "changeDate": "2026-05-15T15:31:16",
+        "stages": [{"stageType": "Start"}, {"stageType": "SejmReading"}],
+    }
+    client = _StubClient({
+        # List carries the bumped changeDate signalling a new stage.
+        f"{base}/processes": [{"number": "2453", "changeDate": "2026-05-15T15:31:16"}],
+        f"{base}/processes/2453": fresh_detail,
+    })
+    recorded, cb = _collector()
+    _run(sejm_src.capture_processes(
+        client, tmp_path, term=10, year=2026,
+        refresh=False, no_binaries=True, limit=None, on_record=cb,
+    ))
+
+    # Detail endpoint must have been hit despite the cached fixture existing.
+    assert f"{base}/processes/2453" in client.calls
+    # The streamed payload is the fresh detail (2 stages), not the stale cache.
+    assert recorded[0][1] == fresh_detail
+
+
+def test_capture_processes_reuses_cache_when_changedate_unchanged(tmp_path: Path):
+    """An unchanged process must NOT re-fetch — keeps the daily run cheap."""
+    base = "/sejm/term10"
+    processes_dir = tmp_path / "sejm" / "processes"
+    processes_dir.mkdir(parents=True)
+    from supagraf.fixtures.storage import write_json
+
+    cached = {"number": "100", "changeDate": "2026-03-01T09:00:00", "stages": []}
+    write_json(processes_dir / "100.json", cached)
+
+    client = _StubClient({
+        f"{base}/processes": [{"number": "100", "changeDate": "2026-03-01T09:00:00"}],
+        # If the detail were fetched it would return this — but it must not be.
+        f"{base}/processes/100": {"number": "100", "changeDate": "9999-01-01", "stages": ["x"]},
+    })
+    recorded, cb = _collector()
+    _run(sejm_src.capture_processes(
+        client, tmp_path, term=10, year=2026,
+        refresh=False, no_binaries=True, limit=None, on_record=cb,
+    ))
+
+    assert f"{base}/processes/100" not in client.calls
+    assert recorded[0][1] == cached
+
+
 def test_capture_videos_natural_id_is_unid(tmp_path: Path):
     base = "/sejm/term10"
     client = _StubClient({


### PR DESCRIPTION
## Summary

Fixes a regression where open legislative processes would remain frozen at their initial capture stage when `refresh=False`, even after new stages were added upstream. The detail fixture is now intelligently re-fetched only when the list endpoint's `changeDate` indicates the process has advanced.

## Changes

- **Added `_list_change_date()` helper** — Extracts the ISO `changeDate` string from list-endpoint items for comparison.

- **Added `_detail_stale()` function** — Determines whether a cached detail fixture needs re-fetching by comparing the list endpoint's `changeDate` against the cached fixture's `changeDate`. Uses lexicographic string comparison (ISO 8601 format is zero-padded, so string order == chronological order). Returns `True` if:
  - The cached fixture doesn't exist, or
  - The list carries no `changeDate`, or
  - The cached fixture has no `changeDate`, or
  - The list's `changeDate` is newer than the cached fixture's

- **Modified `capture_processes()` logic** — Computes `eff_refresh` by ORing the user's `refresh` flag with `_detail_stale()`. This ensures detail endpoints are hit only when upstream actually changed, keeping daily runs cheap while fixing stale timelines.

## Implementation Details

- The fix targets the specific regression reported for `/proces/10/2453`: a bill stuck at "I czytanie pending" long after the reading already happened.
- Under `refresh=False`, the detail fixture is otherwise cached forever, which freezes an open process at whatever stage it had when first captured.
- Two new test cases validate the behavior:
  - `test_capture_processes_refetches_detail_when_changedate_advances` — Confirms re-fetch occurs when `changeDate` bumps.
  - `test_capture_processes_reuses_cache_when_changedate_unchanged` — Confirms the detail endpoint is NOT hit when `changeDate` is unchanged, preserving efficiency.

https://claude.ai/code/session_01JtXoCeDjmXJQAYuCjpdzP5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache validation to detect when cached process data is stale by comparing change timestamps, automatically triggering a fresh data fetch even when auto-refresh is disabled.

* **Tests**
  * Added unit tests validating cache refresh behavior for updated and unchanged process data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miskibin/tygodnik-sejmowy/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->