### PR TITLE
Adjust highlight color palette across light/dark themes

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -78,7 +78,7 @@
   --input:                #cdc4b1;
   --ring:                 #2a2520;
   --rule:                 #1a1612;
-  --highlight:            #f1d98a;
+  --highlight:            #ecddba;
   --success:              #3d6b3d;
   --success-foreground:   #f4efe4;
   --warning:              #8a6a1a;
@@ -121,7 +121,7 @@
   --input:                #3a322a;
   --ring:                 #d8cfb8;
   --rule:                 #d8cfb8;
-  --highlight:            #5a4810;
+  --highlight:            #4d4630;
   --success:              #6fa56f;
   --success-foreground:   #161310;
   --warning:              #c19a3a;
@@ -164,7 +164,7 @@
   --input:                #d1d5db;
   --ring:                 #374151;
   --rule:                 #1f2937;
-  --highlight:            #fde68a;
+  --highlight:            #f0e6c8;
   --success:              #15803d;
   --success-foreground:   #f5f6f8;
   --warning:              #b45309;


### PR DESCRIPTION
## Summary
Updated the `--highlight` CSS custom property values across all three theme variants (light, dark, and default) to use more muted, desaturated color tones that better integrate with the overall design palette.

## Changes
- **Light theme**: Changed `--highlight` from `#f1d98a` to `#ecddba` — a softer, less saturated yellow
- **Dark theme**: Changed `--highlight` from `#5a4810` to `#4d4630` — a lighter, more neutral brown
- **Default theme**: Changed `--highlight` from `#fde68a` to `#f0e6c8` — a warmer, more subdued cream tone

All three adjustments move away from bright, high-contrast yellows toward more harmonious, desaturated tones that maintain visual hierarchy while reducing visual strain.

https://claude.ai/code/session_01CDxhtdcocQN1J5xgqpQoer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated highlight color values across default, dark, and slate themes to improve visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miskibin/tygodnik-sejmowy/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->