### PR TITLE
Password-gated ETL runs dashboard at /admin/etl

### DIFF
--- a/deploy/mixvm/docker-compose.frontend.yml
+++ b/deploy/mixvm/docker-compose.frontend.yml
@@ -11,6 +11,10 @@
 #                             v* tag publish
 #   - OLLAMA_BASE_URL       — optional, defaults to internal compose alias
 #   - PATRONITE_TOKEN       — optional
+#   - ETL_DASHBOARD_PASSWORD — optional, shared password for the operator ETL
+#                             dashboard at /admin/etl. Unset or empty = the
+#                             route 404s, so an undeployed config cannot leak
+#                             the run ledger. Changing it logs everyone out.
 #
 # Port 3001 chosen because 3000 is reserved for any future Next dev session
 # and 80/443 are owned by something else on the host. Cloudflare Tunnel
@@ -31,6 +35,7 @@ services:
       SUPABASE_KEY: ${SUPABASE_KEY}
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://sejmograf-ollama:11434}
       PATRONITE_TOKEN: ${PATRONITE_TOKEN:-}
+      ETL_DASHBOARD_PASSWORD: ${ETL_DASHBOARD_PASSWORD:-}
       NODE_ENV: production
     mem_limit: 1g
     cpus: 1.0

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -196,6 +196,21 @@ one-shot. Keep `SUPAGRAF_LOAD_DIRECT_DSN` set there — `load_votes`,
 timeout when they run through PostgREST. The `fixtures/` bind mount is no
 longer needed by the daily.
 
+## Dashboard
+
+`etl_runs` / `etl_cursors` are also readable from the frontend at
+[`/admin/etl`](../frontend/app/admin/etl/page.tsx) — the last run and its
+status, a duration strip, one expandable row per run with the full per-step
+breakdown (status, duration, counters, error text) plus the run `args`, and a
+card listing the delta cursors. Filters `?kind=daily|sync` and
+`?limit=25|50|100`.
+
+The page is gated by a single shared password in the frontend's
+`ETL_DASHBOARD_PASSWORD` env var (Portainer stack var, see
+`deploy/mixvm/docker-compose.frontend.yml`). Unset or empty and the route
+404s, so an undeployed config cannot expose the ledger. It reads through the
+anon key like the rest of the site — strictly read-only.
+
 ## First live runs (2026-09-07)
 
 Prod had not completed a daily since 2026-07-28. The rewrite's first pass

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,22 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Panel ETL (`/admin/etl`)
+
+Operator view over the updater's run ledger (`etl_runs` / `etl_cursors`, see
+[`docs/updater.md`](../docs/updater.md)): per-run status, duration, commit,
+host and an expandable per-step breakdown with counters and errors.
+
+Gated by a single shared password in `ETL_DASHBOARD_PASSWORD`:
+
+- unset or empty → the route returns 404, so an undeployed config can never
+  expose the ledger;
+- a correct password sets an httpOnly `etl_session` cookie (30 days, scoped to
+  `/admin`) holding an HMAC-SHA256 of a fixed subject keyed by the password —
+  the password itself is never stored client-side, and rotating it invalidates
+  every existing cookie.
+
+Local run: `ETL_DASHBOARD_PASSWORD=... pnpm dev`, then open
+<http://localhost:3000/admin/etl>. The page is `force-dynamic` and `noindex`,
+and `/admin/` is disallowed in `robots.txt`.

--- a/frontend/app/admin/etl/_components/CursorsCard.tsx
+++ b/frontend/app/admin/etl/_components/CursorsCard.tsx
@@ -1,0 +1,38 @@
+import type { EtlCursor } from "@/lib/db/etl";
+import { fmtDateTime } from "./format";
+
+export function CursorsCard({ cursors }: { cursors: EtlCursor[] }) {
+  return (
+    <section className="border border-border">
+      <div className="border-b border-border bg-muted/60 px-3 py-2 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+        Kursory · etl_cursors
+      </div>
+      {cursors.length === 0 ? (
+        <p className="px-3 py-4 text-sm text-muted-foreground">Brak kursorów.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border text-left font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                <th className="px-3 py-1.5 font-normal">nazwa</th>
+                <th className="px-3 py-1.5 font-normal">wartość</th>
+                <th className="px-3 py-1.5 font-normal">aktualizacja</th>
+              </tr>
+            </thead>
+            <tbody>
+              {cursors.map((c) => (
+                <tr key={c.name} className="border-b border-border/60 last:border-0">
+                  <td className="px-3 py-2 font-mono text-[12px] whitespace-nowrap">{c.name}</td>
+                  <td className="px-3 py-2 font-mono text-[12px] whitespace-nowrap">{c.value}</td>
+                  <td className="px-3 py-2 font-mono text-[12px] whitespace-nowrap text-muted-foreground tabular-nums">
+                    {fmtDateTime(c.updated_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/admin/etl/_components/DurationStrip.tsx
+++ b/frontend/app/admin/etl/_components/DurationStrip.tsx
@@ -1,0 +1,39 @@
+import type { EtlRun } from "@/lib/db/etl";
+import { elapsedSeconds, fmtDuration, statusFill } from "./format";
+
+const MAX_BARS = 30;
+const MIN_BAR_PCT = 6;
+
+// Deliberately not recharts: a bar per run with a status tint is the whole
+// chart, and a plain div strip keeps this page free of client-side JS.
+export function DurationStrip({ runs }: { runs: EtlRun[] }) {
+  const bars = runs
+    .slice(0, MAX_BARS)
+    .map((r) => ({
+      run: r,
+      seconds: elapsedSeconds(r.started_at, r.finished_at) ?? 0,
+    }))
+    .reverse();
+
+  if (bars.length < 2) return null;
+
+  const max = Math.max(...bars.map((b) => b.seconds), 1);
+
+  return (
+    <section className="mt-6">
+      <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground mb-2">
+        Czas trwania · {bars.length} ostatnich przebiegów (max {fmtDuration(max)})
+      </div>
+      <div className="flex h-16 items-end gap-1 border-b border-border">
+        {bars.map(({ run, seconds }) => (
+          <div
+            key={run.id}
+            title={`#${run.id} · ${run.kind} · ${run.status} · ${fmtDuration(seconds)}`}
+            className={`min-w-[6px] flex-1 rounded-t-sm ${statusFill(run.status)}`}
+            style={{ height: `${Math.max(MIN_BAR_PCT, (seconds / max) * 100)}%` }}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/admin/etl/_components/Filters.tsx
+++ b/frontend/app/admin/etl/_components/Filters.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { RotateCwIcon } from "lucide-react";
+
+import { logoutAction } from "../actions";
+
+export const KINDS = ["daily", "sync"] as const;
+export const LIMITS = [25, 50, 100] as const;
+
+function href(kind: string | null, limit: number): string {
+  const p = new URLSearchParams();
+  if (kind) p.set("kind", kind);
+  if (limit !== LIMITS[1]) p.set("limit", String(limit));
+  const qs = p.toString();
+  return qs ? `/admin/etl?${qs}` : "/admin/etl";
+}
+
+function Chip({
+  active,
+  children,
+  ...rest
+}: { active: boolean; children: React.ReactNode; href: string }) {
+  return (
+    <Link
+      {...rest}
+      className={`rounded px-2 py-1 font-mono text-[11px] transition-colors ${
+        active
+          ? "bg-foreground text-background"
+          : "bg-muted text-muted-foreground hover:text-foreground"
+      }`}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export function Filters({
+  kind,
+  limit,
+}: {
+  kind: string | null;
+  limit: number;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+      <div className="flex items-center gap-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+          rodzaj
+        </span>
+        <Chip href={href(null, limit)} active={kind === null}>
+          wszystkie
+        </Chip>
+        {KINDS.map((k) => (
+          <Chip key={k} href={href(k, limit)} active={kind === k}>
+            {k}
+          </Chip>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+          limit
+        </span>
+        {LIMITS.map((l) => (
+          <Chip key={l} href={href(kind, l)} active={limit === l}>
+            {l}
+          </Chip>
+        ))}
+      </div>
+
+      <div className="ml-auto flex items-center gap-2">
+        {/* Plain anchor: a full reload is the point — a soft nav to the
+            current route can serve the RSC payload already in memory. */}
+        <a
+          href={href(kind, limit)}
+          className="inline-flex items-center gap-1 rounded bg-muted px-2 py-1 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <RotateCwIcon className="size-3" aria-hidden="true" />
+          Odśwież
+        </a>
+        <form action={logoutAction}>
+          <button
+            type="submit"
+            className="rounded bg-muted px-2 py-1 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Wyloguj
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/admin/etl/_components/LoginForm.tsx
+++ b/frontend/app/admin/etl/_components/LoginForm.tsx
@@ -1,0 +1,50 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { loginAction } from "../actions";
+
+export function LoginForm({ error }: { error?: boolean }) {
+  return (
+    <div className="max-w-sm">
+      <div className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground mb-2">
+        Panel ETL
+      </div>
+      <h1 className="font-heading text-2xl font-medium mb-1">Dostęp chroniony</h1>
+      <p className="text-sm text-muted-foreground mb-6">
+        Podaj hasło, żeby zobaczyć historię przebiegów aktualizacji danych.
+      </p>
+
+      <form action={loginAction} className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="etl-password" className="text-sm font-medium">
+            Hasło
+          </label>
+          <Input
+            id="etl-password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            required
+            autoFocus
+            aria-invalid={error || undefined}
+            aria-describedby={error ? "etl-password-error" : undefined}
+          />
+        </div>
+
+        {error && (
+          <p
+            id="etl-password-error"
+            role="alert"
+            className="text-sm"
+            style={{ color: "var(--destructive)" }}
+          >
+            Nieprawidłowe hasło.
+          </p>
+        )}
+
+        <Button type="submit" className="w-fit">
+          Zaloguj
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/app/admin/etl/_components/RunsTable.tsx
+++ b/frontend/app/admin/etl/_components/RunsTable.tsx
@@ -1,0 +1,180 @@
+import { ChevronRightIcon } from "lucide-react";
+
+import type { EtlRun, EtlStep } from "@/lib/db/etl";
+import {
+  KeyValueChips,
+  StatusBadge,
+  elapsedSeconds,
+  fmtDateTime,
+  fmtDuration,
+} from "./format";
+
+// One shared column template so the header strip and every <summary> line up.
+const COLS = [
+  "w-24 shrink-0", // status
+  "w-14 shrink-0", // id
+  "w-20 shrink-0", // kind
+  "w-14 shrink-0", // term
+  "w-44 shrink-0", // started
+  "w-28 shrink-0", // duration
+  "w-24 shrink-0", // git sha
+  "w-24 shrink-0", // host
+  "min-w-0 flex-1", // failed steps
+];
+
+const HEADERS = [
+  "status",
+  "id",
+  "rodzaj",
+  "kad.",
+  "start",
+  "czas",
+  "commit",
+  "host",
+  "kroki z błędem",
+];
+
+function ErrorBlock({ text }: { text: string }) {
+  return (
+    <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all rounded bg-red-500/5 p-2 font-mono text-[11px] leading-snug text-red-700 dark:bg-red-400/10 dark:text-red-300">
+      {text}
+    </pre>
+  );
+}
+
+function StepsTable({ steps }: { steps: EtlStep[] }) {
+  if (steps.length === 0) {
+    return <p className="text-sm text-muted-foreground italic">Brak zapisanych kroków.</p>;
+  }
+  return (
+    <table className="w-full border-collapse text-sm">
+      <thead>
+        <tr className="border-b border-border text-left font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+          <th className="py-1.5 pr-3 font-normal">krok</th>
+          <th className="py-1.5 pr-3 font-normal">status</th>
+          <th className="py-1.5 pr-3 font-normal">czas</th>
+          <th className="py-1.5 font-normal">liczniki</th>
+        </tr>
+      </thead>
+      <tbody>
+        {steps.map((step) => (
+          <tr key={step.name} className="border-b border-border/60 align-top last:border-0">
+            <td className="py-2 pr-3 font-mono text-[12px] whitespace-nowrap">{step.name}</td>
+            <td className="py-2 pr-3">
+              <StatusBadge status={step.status} />
+            </td>
+            <td className="py-2 pr-3 font-mono text-[12px] whitespace-nowrap tabular-nums">
+              {fmtDuration(step.duration_s)}
+            </td>
+            <td className="py-2 min-w-0">
+              <KeyValueChips entries={Object.entries(step.counts ?? {})} empty="—" />
+              {step.error && (
+                <div className="mt-2">
+                  <ErrorBlock text={step.error} />
+                </div>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function RunRow({ run }: { run: EtlRun }) {
+  const failed = run.steps.filter((s) => s.status === "failed");
+  const duration = run.finished_at
+    ? fmtDuration(elapsedSeconds(run.started_at, run.finished_at))
+    : "w toku";
+
+  return (
+    <details className="group border-b border-border last:border-0 open:bg-muted/30">
+      <summary className="flex cursor-pointer list-none items-center gap-2 px-2 py-2 hover:bg-muted/50 [&::-webkit-details-marker]:hidden">
+        <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
+        <span className={COLS[0]}>
+          <StatusBadge status={run.status} />
+        </span>
+        <span className={`${COLS[1]} font-mono text-[12px] tabular-nums`}>#{run.id}</span>
+        <span className={`${COLS[2]} font-mono text-[12px]`}>{run.kind}</span>
+        <span className={`${COLS[3]} font-mono text-[12px] tabular-nums`}>
+          {run.term ?? "—"}
+        </span>
+        <span className={`${COLS[4]} font-mono text-[12px] tabular-nums`}>
+          {fmtDateTime(run.started_at)}
+        </span>
+        <span className={`${COLS[5]} font-mono text-[12px] tabular-nums`}>{duration}</span>
+        <span className={`${COLS[6]} font-mono text-[12px]`}>{run.git_sha ?? "—"}</span>
+        <span className={`${COLS[7]} font-mono text-[12px] truncate`}>{run.host ?? "—"}</span>
+        <span className={`${COLS[8]} truncate font-mono text-[12px]`}>
+          {failed.length === 0 ? (
+            <span className="text-muted-foreground">—</span>
+          ) : (
+            <span className="text-red-700 dark:text-red-300">
+              {failed.length}: {failed.map((s) => s.name).join(", ")}
+            </span>
+          )}
+        </span>
+      </summary>
+
+      <div className="space-y-4 border-t border-border/60 px-2 py-4 sm:px-8">
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">
+            Argumenty
+          </div>
+          <KeyValueChips entries={Object.entries(run.args ?? {})} empty="brak" />
+        </div>
+
+        {run.errors.length > 0 && (
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">
+              Błędy przebiegu ({run.errors.length})
+            </div>
+            <div className="space-y-2">
+              {run.errors.map((e, i) => (
+                <div key={`${e.step}-${i}`}>
+                  <div className="font-mono text-[11px] mb-1">{e.step}</div>
+                  <ErrorBlock text={e.error} />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">
+            Kroki ({run.steps.length})
+          </div>
+          <StepsTable steps={run.steps} />
+        </div>
+      </div>
+    </details>
+  );
+}
+
+export function RunsTable({ runs }: { runs: EtlRun[] }) {
+  if (runs.length === 0) {
+    return (
+      <div className="border border-border p-6 text-sm text-muted-foreground">
+        Brak przebiegów dla wybranych filtrów.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto border border-border">
+      <div className="min-w-[980px]">
+        <div className="flex items-center gap-2 border-b border-border bg-muted/60 px-2 py-1.5 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+          <span className="size-3.5 shrink-0" />
+          {HEADERS.map((h, i) => (
+            <span key={h} className={COLS[i]}>
+              {h}
+            </span>
+          ))}
+        </div>
+        {runs.map((run) => (
+          <RunRow key={run.id} run={run} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/admin/etl/_components/SummaryStrip.tsx
+++ b/frontend/app/admin/etl/_components/SummaryStrip.tsx
@@ -1,0 +1,89 @@
+import type { EtlRun } from "@/lib/db/etl";
+import {
+  StatusBadge,
+  elapsedSeconds,
+  fmtDateTime,
+  fmtDuration,
+  statusClass,
+} from "./format";
+
+const SUMMARY_WINDOW = 30;
+const STATUS_ORDER = ["ok", "partial", "failed", "running"] as const;
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <div className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-0.5 text-sm break-words">{children}</div>
+    </div>
+  );
+}
+
+export function SummaryStrip({ runs }: { runs: EtlRun[] }) {
+  const last = runs[0];
+  const window = runs.slice(0, SUMMARY_WINDOW);
+  const running = runs.find((r) => r.status === "running" && !r.finished_at);
+
+  const counts = new Map<string, number>();
+  for (const r of window) counts.set(r.status, (counts.get(r.status) ?? 0) + 1);
+
+  if (!last) {
+    return (
+      <div className="border border-border bg-muted/40 p-4 sm:p-5 text-sm text-muted-foreground">
+        Brak przebiegów w rejestrze <code className="font-mono">etl_runs</code>.
+      </div>
+    );
+  }
+
+  const lastDuration = elapsedSeconds(last.started_at, last.finished_at);
+
+  return (
+    <section className="border border-border bg-muted/40">
+      <div className="grid gap-4 p-4 sm:p-5 sm:grid-cols-2 lg:grid-cols-4">
+        <Field label="Ostatni przebieg">
+          <span className="flex flex-wrap items-center gap-2">
+            <StatusBadge status={last.status} />
+            <span className="font-mono text-[12px]">
+              #{last.id} · {last.kind}
+              {last.term !== null ? ` · kad. ${last.term}` : ""}
+            </span>
+          </span>
+        </Field>
+        <Field label="Start / czas">
+          <span className="font-mono text-[12px]">
+            {fmtDateTime(last.started_at)}
+            {" · "}
+            {last.finished_at ? fmtDuration(lastDuration) : "w toku"}
+          </span>
+        </Field>
+        <Field label="Wersja / host">
+          <span className="font-mono text-[12px]">
+            {last.git_sha ?? "—"} @ {last.host ?? "—"}
+          </span>
+        </Field>
+        <Field label={`Statusy (ostatnie ${window.length})`}>
+          <span className="flex flex-wrap gap-1.5">
+            {STATUS_ORDER.filter((s) => counts.has(s)).map((s) => (
+              <span
+                key={s}
+                className={`rounded px-1.5 py-0.5 font-mono text-[11px] ${statusClass(s)}`}
+              >
+                {s} {counts.get(s)}
+              </span>
+            ))}
+          </span>
+        </Field>
+      </div>
+
+      {running && (
+        <div className="border-t border-border px-4 sm:px-5 py-2.5 font-mono text-[12px] text-blue-700 dark:text-blue-300">
+          Trwa przebieg #{running.id} ({running.kind}) — od{" "}
+          {fmtDateTime(running.started_at)}, już{" "}
+          {fmtDuration(elapsedSeconds(running.started_at, null))}.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/admin/etl/_components/format.tsx
+++ b/frontend/app/admin/etl/_components/format.tsx
@@ -1,0 +1,128 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+const PL_DATETIME = new Intl.DateTimeFormat("pl-PL", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  timeZone: "Europe/Warsaw",
+});
+
+export function fmtDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return PL_DATETIME.format(d);
+}
+
+/** Elapsed seconds between two timestamps, or null when either is unusable. */
+export function elapsedSeconds(from: string, to: string | null): number | null {
+  const start = new Date(from).getTime();
+  const end = to ? new Date(to).getTime() : Date.now();
+  if (Number.isNaN(start) || Number.isNaN(end)) return null;
+  return (end - start) / 1000;
+}
+
+export function fmtDuration(seconds: number | null): string {
+  if (seconds === null || !Number.isFinite(seconds)) return "—";
+  if (seconds < 60) return `${seconds.toFixed(1).replace(".", ",")} s`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  if (m < 60) return `${m} min ${s} s`;
+  return `${Math.floor(m / 60)} h ${m % 60} min`;
+}
+
+// Tailwind palette rather than the site's --success/--warning tokens: these
+// need a tinted background as well as a foreground, and both halves have to
+// stay legible in the dark theme.
+const STATUS_CLASS: Record<string, string> = {
+  ok: "bg-emerald-500/10 text-emerald-700 dark:bg-emerald-400/15 dark:text-emerald-300",
+  partial: "bg-amber-500/15 text-amber-800 dark:bg-amber-400/15 dark:text-amber-300",
+  failed: "bg-red-500/10 text-red-700 dark:bg-red-400/15 dark:text-red-300",
+  running: "bg-blue-500/10 text-blue-700 dark:bg-blue-400/15 dark:text-blue-300",
+  skipped: "bg-muted text-muted-foreground",
+};
+
+export const STATUS_LABEL: Record<string, string> = {
+  ok: "ok",
+  partial: "częściowo",
+  failed: "błąd",
+  running: "w toku",
+  skipped: "pominięty",
+};
+
+export function statusClass(status: string): string {
+  return STATUS_CLASS[status] ?? "bg-muted text-muted-foreground";
+}
+
+// Solid fills for the duration bars — the badge classes carry a tinted
+// background plus a dark foreground, which reads as mud at full opacity.
+const STATUS_FILL: Record<string, string> = {
+  ok: "bg-emerald-600 dark:bg-emerald-400",
+  partial: "bg-amber-500 dark:bg-amber-400",
+  failed: "bg-red-600 dark:bg-red-400",
+  running: "bg-blue-600 dark:bg-blue-400",
+};
+
+export function statusFill(status: string): string {
+  return STATUS_FILL[status] ?? "bg-muted-foreground/40";
+}
+
+export function StatusBadge({
+  status,
+  className,
+}: {
+  status: string;
+  className?: string;
+}) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "border-transparent font-mono text-[11px] tracking-wide",
+        statusClass(status),
+        className
+      )}
+    >
+      {STATUS_LABEL[status] ?? status}
+    </Badge>
+  );
+}
+
+/** Compact `key=value` rendering; nested values fall back to JSON. */
+export function formatCountValue(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "number") return value.toLocaleString("pl-PL");
+  if (typeof value === "boolean") return value ? "tak" : "nie";
+  if (typeof value === "string") return value;
+  const json = JSON.stringify(value);
+  return json.length > 160 ? `${json.slice(0, 157)}…` : json;
+}
+
+export function KeyValueChips({
+  entries,
+  empty = "brak",
+}: {
+  entries: Array<[string, unknown]>;
+  empty?: string;
+}) {
+  if (entries.length === 0) {
+    return <span className="font-mono text-[11px] text-muted-foreground italic">{empty}</span>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {entries.map(([k, v]) => (
+        <span
+          key={k}
+          className="inline-flex max-w-full items-baseline gap-1 rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] leading-tight"
+        >
+          <span className="text-muted-foreground">{k}</span>
+          <span className="break-all">{formatCountValue(v)}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/admin/etl/actions.ts
+++ b/frontend/app/admin/etl/actions.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import {
+  checkPassword,
+  clearEtlSession,
+  etlPassword,
+  setEtlSession,
+} from "@/lib/admin-auth";
+
+// Server Actions are reachable by direct POST, so both actions re-check the
+// deployment flag themselves instead of trusting the page that rendered them.
+
+export async function loginAction(formData: FormData): Promise<void> {
+  const configured = etlPassword();
+  if (!configured) redirect("/admin/etl");
+
+  const submitted = String(formData.get("password") ?? "");
+  if (!checkPassword(submitted)) redirect("/admin/etl?blad=1");
+
+  await setEtlSession(configured);
+  redirect("/admin/etl");
+}
+
+export async function logoutAction(): Promise<void> {
+  await clearEtlSession();
+  redirect("/admin/etl");
+}

--- a/frontend/app/admin/etl/page.tsx
+++ b/frontend/app/admin/etl/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
+import { etlPassword, hasEtlSession } from "@/lib/admin-auth";
+import { getEtlCursors, getEtlRuns } from "@/lib/db/etl";
+import { CursorsCard } from "./_components/CursorsCard";
+import { DurationStrip } from "./_components/DurationStrip";
+import { Filters, KINDS, LIMITS } from "./_components/Filters";
+import { LoginForm } from "./_components/LoginForm";
+import { RunsTable } from "./_components/RunsTable";
+import { SummaryStrip } from "./_components/SummaryStrip";
+
+// Operator view over the updater's ledger — always the live table, never a
+// cached snapshot, and never indexed.
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: { absolute: "ETL — Tygodnik Sejmowy" },
+  robots: { index: false, follow: false },
+};
+
+type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>;
+
+async function safe<T>(p: Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await p;
+  } catch {
+    return fallback;
+  }
+}
+
+function one(v: string | string[] | undefined): string | null {
+  if (Array.isArray(v)) return v[0] ?? null;
+  return v ?? null;
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="bg-background text-foreground px-3 sm:px-8 md:px-14 pt-8 sm:pt-12 pb-12 sm:pb-16 min-w-0">
+      <div className="max-w-[1280px] mx-auto min-w-0">{children}</div>
+    </main>
+  );
+}
+
+export default async function EtlDashboardPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  // Not configured = not deployed. 404 before touching anything else so a
+  // missing env var can never leak the ledger.
+  if (!etlPassword()) notFound();
+
+  const sp = await searchParams;
+
+  if (!(await hasEtlSession())) {
+    return (
+      <Shell>
+        <LoginForm error={one(sp.blad) === "1"} />
+      </Shell>
+    );
+  }
+
+  const kindParam = one(sp.kind);
+  const kind = (KINDS as readonly string[]).includes(kindParam ?? "") ? kindParam : null;
+  const limitParam = Number(one(sp.limit));
+  const limit = (LIMITS as readonly number[]).includes(limitParam) ? limitParam : LIMITS[1];
+
+  const [runs, cursors] = await Promise.all([
+    safe(getEtlRuns({ limit, kind: kind ?? undefined }), []),
+    safe(getEtlCursors(), []),
+  ]);
+
+  return (
+    <Shell>
+      <PageBreadcrumb
+        items={[{ label: "Panel" }, { label: "ETL" }]}
+        subtitle={`Rejestr przebiegów aktualizacji · ${runs.length} wczytanych`}
+      />
+
+      <div className="mb-6">
+        <Filters kind={kind} limit={limit} />
+      </div>
+
+      <SummaryStrip runs={runs} />
+      <DurationStrip runs={runs} />
+
+      <section className="mt-8">
+        <h2 className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground mb-2">
+          Przebiegi · etl_runs
+        </h2>
+        <RunsTable runs={runs} />
+      </section>
+
+      <div className="mt-8">
+        <CursorsCard cursors={cursors} />
+      </div>
+    </Shell>
+  );
+}

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -2,16 +2,16 @@ import type { MetadataRoute } from "next";
 
 const SITE_URL = "https://tygodniksejmowy.pl";
 
-// Block crawlers from API endpoints (no SEO value, save crawl budget) but
-// allow everything user-facing. AdsBot still indexes API routes by default
-// in Google so explicit Disallow is the right call.
+// Block crawlers from API endpoints (no SEO value, save crawl budget) and the
+// operator panel, but allow everything user-facing. AdsBot still indexes API
+// routes by default in Google so explicit Disallow is the right call.
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
         userAgent: "*",
         allow: "/",
-        disallow: ["/api/", "/_next/"],
+        disallow: ["/api/", "/_next/", "/admin/"],
       },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,

--- a/frontend/lib/admin-auth.ts
+++ b/frontend/lib/admin-auth.ts
@@ -1,0 +1,70 @@
+import "server-only";
+
+import { createHmac, createHash, timingSafeEqual } from "node:crypto";
+import { cookies } from "next/headers";
+
+// Minimal shared-password gate for /admin/*. No accounts, no session store:
+// the cookie carries an HMAC of a fixed subject keyed by the password, so the
+// password itself never leaves the server and a leaked cookie cannot be turned
+// back into it. Rotating ETL_DASHBOARD_PASSWORD invalidates every cookie.
+
+export const ETL_COOKIE_NAME = "etl_session";
+export const ETL_COOKIE_PATH = "/admin";
+const ETL_COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+const TOKEN_SUBJECT = "tygodnik-sejmowy:etl-dashboard:v1";
+
+/** Configured dashboard password, or null when the feature is not deployed. */
+export function etlPassword(): string | null {
+  const raw = process.env.ETL_DASHBOARD_PASSWORD;
+  if (!raw || raw.trim() === "") return null;
+  return raw;
+}
+
+/** Cookie value for a password: hex HMAC-SHA256(TOKEN_SUBJECT) keyed by it. */
+function sessionToken(password: string): string {
+  return createHmac("sha256", password).update(TOKEN_SUBJECT).digest("hex");
+}
+
+// Compare via fixed-length digests so timingSafeEqual never sees mismatched
+// buffer lengths (it throws) and the length itself leaks nothing.
+function constantTimeEquals(a: string, b: string): boolean {
+  const da = createHash("sha256").update(a).digest();
+  const db = createHash("sha256").update(b).digest();
+  return timingSafeEqual(da, db);
+}
+
+export function checkPassword(submitted: string): boolean {
+  const expected = etlPassword();
+  if (!expected) return false;
+  return constantTimeEquals(submitted, expected);
+}
+
+/** True when the request carries a cookie matching the current password. */
+export async function hasEtlSession(): Promise<boolean> {
+  const expected = etlPassword();
+  if (!expected) return false;
+  const cookie = (await cookies()).get(ETL_COOKIE_NAME)?.value;
+  if (!cookie) return false;
+  return constantTimeEquals(cookie, sessionToken(expected));
+}
+
+export async function setEtlSession(password: string): Promise<void> {
+  (await cookies()).set(ETL_COOKIE_NAME, sessionToken(password), {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: ETL_COOKIE_PATH,
+    maxAge: ETL_COOKIE_MAX_AGE,
+  });
+}
+
+export async function clearEtlSession(): Promise<void> {
+  (await cookies()).set(ETL_COOKIE_NAME, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: ETL_COOKIE_PATH,
+    maxAge: 0,
+  });
+}

--- a/frontend/lib/db/etl.ts
+++ b/frontend/lib/db/etl.ts
@@ -1,0 +1,131 @@
+import "server-only";
+
+import { supabase } from "@/lib/supabase";
+
+// Reader for the updater's run ledger (migration 0105): `python -m supagraf
+// daily` writes one etl_runs row per run with per-step timings/counters as
+// jsonb, and etl_cursors holds the delta high-water marks. Read-only.
+
+export type EtlRunStatus = "running" | "ok" | "partial" | "failed";
+export type EtlStepStatus = "running" | "ok" | "failed" | "skipped";
+
+export type EtlStep = {
+  name: string;
+  status: EtlStepStatus | string;
+  duration_s: number | null;
+  /** Arbitrary per-step counters; values may be nested objects/arrays. */
+  counts: Record<string, unknown> | null;
+  error: string | null;
+};
+
+export type EtlRunError = { step: string; error: string };
+
+export type EtlRun = {
+  id: number;
+  kind: string;
+  term: number | null;
+  status: EtlRunStatus | string;
+  started_at: string;
+  finished_at: string | null;
+  args: Record<string, unknown> | null;
+  steps: EtlStep[];
+  errors: EtlRunError[];
+  host: string | null;
+  git_sha: string | null;
+};
+
+export type EtlCursor = {
+  name: string;
+  value: string;
+  updated_at: string;
+};
+
+type RawRun = {
+  id: number;
+  kind: string | null;
+  term: number | null;
+  status: string | null;
+  started_at: string;
+  finished_at: string | null;
+  args: unknown;
+  steps: unknown;
+  errors: unknown;
+  host: string | null;
+  git_sha: string | null;
+};
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// Key order is preserved as delivered by the API. Note that Postgres `jsonb`
+// normalises object keys (by length, then bytewise), so this is a stable order
+// but not the updater's execution order — that is lost at write time.
+function parseSteps(raw: unknown): EtlStep[] {
+  if (!isRecord(raw)) return [];
+  return Object.entries(raw).map(([name, value]) => {
+    const step = isRecord(value) ? value : {};
+    const counts = isRecord(step.counts) ? step.counts : null;
+    return {
+      name,
+      status: typeof step.status === "string" ? step.status : "unknown",
+      duration_s: typeof step.duration_s === "number" ? step.duration_s : null,
+      counts,
+      error: typeof step.error === "string" ? step.error : null,
+    };
+  });
+}
+
+function parseErrors(raw: unknown): EtlRunError[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    if (!isRecord(entry)) return [];
+    return [
+      {
+        step: typeof entry.step === "string" ? entry.step : "?",
+        error: typeof entry.error === "string" ? entry.error : String(entry.error ?? ""),
+      },
+    ];
+  });
+}
+
+function toRun(row: RawRun): EtlRun {
+  return {
+    id: row.id,
+    kind: row.kind ?? "?",
+    term: row.term,
+    status: row.status ?? "unknown",
+    started_at: row.started_at,
+    finished_at: row.finished_at,
+    args: isRecord(row.args) ? row.args : null,
+    steps: parseSteps(row.steps),
+    errors: parseErrors(row.errors),
+    host: row.host,
+    git_sha: row.git_sha,
+  };
+}
+
+export async function getEtlRuns({
+  limit = 50,
+  kind,
+}: { limit?: number; kind?: string } = {}): Promise<EtlRun[]> {
+  let q = supabase()
+    .from("etl_runs")
+    .select("id,kind,term,status,started_at,finished_at,args,steps,errors,host,git_sha")
+    .order("started_at", { ascending: false })
+    .limit(limit);
+  if (kind) q = q.eq("kind", kind);
+
+  const { data, error } = await q;
+  if (error) throw new Error(`etl_runs: ${error.message}`);
+  return (data as RawRun[] | null)?.map(toRun) ?? [];
+}
+
+export async function getEtlCursors(): Promise<EtlCursor[]> {
+  const { data, error } = await supabase()
+    .from("etl_cursors")
+    .select("name,value,updated_at")
+    .order("name", { ascending: true });
+  if (error) throw new Error(`etl_cursors: ${error.message}`);
+  return (data as EtlCursor[] | null) ?? [];
+}

--- a/frontend/lib/db/etl.ts
+++ b/frontend/lib/db/etl.ts
@@ -63,8 +63,14 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 // but not the updater's execution order — that is lost at write time.
 function parseSteps(raw: unknown): EtlStep[] {
   if (!isRecord(raw)) return [];
-  return Object.entries(raw).map(([name, value]) => {
+  // jsonb normalises key order, so the writer stamps each step with `seq`
+  // (its execution index). Rows from before that stamp keep API order.
+  const entries = Object.entries(raw).map(([name, value], i) => {
     const step = isRecord(value) ? value : {};
+    return { name, step, seq: typeof step.seq === "number" ? step.seq : i };
+  });
+  entries.sort((a, b) => a.seq - b.seq);
+  return entries.map(({ name, step }) => {
     const counts = isRecord(step.counts) ? step.counts : null;
     return {
       name,

--- a/supagraf/sync/runlog.py
+++ b/supagraf/sync/runlog.py
@@ -98,12 +98,16 @@ class RunLedger:
                 supabase().table("etl_runs").update({
                     "status": self.status,
                     "finished_at": datetime.now(timezone.utc).isoformat(),
-                    "steps": {s.name: s.to_dict() for s in self.steps},
+                    "steps": self._steps_json(),
                     "errors": [{"step": s.name, "error": s.error} for s in self.steps if s.error],
                 }).eq("id", self.run_id).execute()
             except APIError as e:
                 logger.error("etl_runs finish failed: {}", e)
         return self.summary()
+
+    def _steps_json(self) -> dict[str, dict]:
+        # jsonb re-orders object keys, so each step carries its execution index.
+        return {s.name: {**s.to_dict(), "seq": i} for i, s in enumerate(self.steps)}
 
     @contextmanager
     def step(self, name: str, *, fatal: bool = False) -> Iterator[StepResult]:
@@ -145,4 +149,4 @@ class RunLedger:
     def summary(self) -> dict:
         return {"run_id": self.run_id, "kind": self.kind, "term": self.term, "status": self.status,
                 "duration_s": round(time.monotonic() - self._t0, 1),
-                "steps": {s.name: s.to_dict() for s in self.steps}}
+                "steps": self._steps_json()}

--- a/tests/supagraf/unit/sync/test_runlog_cursors_loaders.py
+++ b/tests/supagraf/unit/sync/test_runlog_cursors_loaders.py
@@ -20,6 +20,7 @@ def test_ledger_records_ok_failed_skipped_and_exit_code():
     summ = led.summary()
     assert summ["steps"]["a"]["counts"] == {"n": 1}
     assert "nope" in summ["steps"]["b"]["error"]
+    assert [summ["steps"][k]["seq"] for k in ("a", "b", "c")] == [0, 1, 2]
 
 
 def test_ledger_all_ok_exit_zero_and_fatal_reraises():


### PR DESCRIPTION
## Summary

Adds an operator page at `/admin/etl` on the frontend that renders the updater's `etl_runs` ledger and `etl_cursors`.

- **Gate**: shared password from `ETL_DASHBOARD_PASSWORD`. When the variable is unset the route returns 404, so an undeployed config never exposes the page. Login sets an httpOnly `etl_session` cookie (HMAC-SHA256 of a fixed subject keyed by the password, `path=/admin`, 30 days, `secure` in production); verification is constant-time. Rotating the password invalidates every cookie. "Wyloguj" clears it.
- **Dashboard**: summary strip (last run, status counts, running indicator), duration strip of the last 30 runs, runs table with expandable per-step details (status, duration, counts as chips, error block, args), cursors card, `?kind=` / `?limit=` filters. Server-rendered, `force-dynamic`, `noindex` plus `/admin/` in `robots.ts`.
- **Ledger fix**: jsonb re-orders object keys, so each step in `etl_runs.steps` now carries `seq` and the dashboard sorts by it.
- **Deploy**: `ETL_DASHBOARD_PASSWORD` plumbed through `deploy/mixvm/docker-compose.frontend.yml`; documented in `frontend/README.md` and `docs/updater.md`.

## Verification

- `pnpm lint` unchanged from baseline (all pre-existing warnings/errors in other files), `pnpm build` ok, `tsc --noEmit` clean.
- Local `pnpm start` against prod (read-only): 404 without the env var, login form with no data leak without a cookie, dashboard with all 9 real runs with a valid cookie, wrong password shows the error and sets no cookie, logout clears the cookie. Filters fall back to defaults on invalid values.
- Python: sync unit tests pass (`seq` asserted), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR)_