### PR TITLE
Open the ETL panel when no password is configured

### DIFF
--- a/deploy/mixvm/docker-compose.frontend.yml
+++ b/deploy/mixvm/docker-compose.frontend.yml
@@ -13,8 +13,8 @@
 #   - PATRONITE_TOKEN       — optional
 #   - ETL_DASHBOARD_PASSWORD — optional, shared password for the operator ETL
 #                             dashboard at /admin/etl. Unset or empty = the
-#                             route 404s, so an undeployed config cannot leak
-#                             the run ledger. Changing it logs everyone out.
+#                             panel is open without a login. Changing it
+#                             logs everyone out.
 #
 # Port 3001 chosen because 3000 is reserved for any future Next dev session
 # and 80/443 are owned by something else on the host. Cloudflare Tunnel

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -207,8 +207,8 @@ card listing the delta cursors. Filters `?kind=daily|sync` and
 
 The page is gated by a single shared password in the frontend's
 `ETL_DASHBOARD_PASSWORD` env var (Portainer stack var, see
-`deploy/mixvm/docker-compose.frontend.yml`). Unset or empty and the route
-404s, so an undeployed config cannot expose the ledger. It reads through the
+`deploy/mixvm/docker-compose.frontend.yml`). Unset or empty and the panel is
+open without a login (the ledger holds nothing secret). It reads through the
 anon key like the rest of the site — strictly read-only.
 
 ## First live runs (2026-09-07)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -43,8 +43,8 @@ host and an expandable per-step breakdown with counters and errors.
 
 Gated by a single shared password in `ETL_DASHBOARD_PASSWORD`:
 
-- unset or empty → the route returns 404, so an undeployed config can never
-  expose the ledger;
+- unset or empty → the panel is open (no login); the ledger holds only run
+  timings, counters and error strings;
 - a correct password sets an httpOnly `etl_session` cookie (30 days, scoped to
   `/admin`) holding an HMAC-SHA256 of a fixed subject keyed by the password —
   the password itself is never stored client-side, and rotating it invalidates

--- a/frontend/app/admin/etl/_components/Filters.tsx
+++ b/frontend/app/admin/etl/_components/Filters.tsx
@@ -36,9 +36,11 @@ function Chip({
 export function Filters({
   kind,
   limit,
+  gated,
 }: {
   kind: string | null;
   limit: number;
+  gated: boolean;
 }) {
   return (
     <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
@@ -77,14 +79,16 @@ export function Filters({
           <RotateCwIcon className="size-3" aria-hidden="true" />
           Odśwież
         </a>
-        <form action={logoutAction}>
-          <button
-            type="submit"
-            className="rounded bg-muted px-2 py-1 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
-          >
-            Wyloguj
-          </button>
-        </form>
+        {gated && (
+          <form action={logoutAction}>
+            <button
+              type="submit"
+              className="rounded bg-muted px-2 py-1 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Wyloguj
+            </button>
+          </form>
+        )}
       </div>
     </div>
   );

--- a/frontend/app/admin/etl/page.tsx
+++ b/frontend/app/admin/etl/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
 
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
 import { etlPassword, hasEtlSession } from "@/lib/admin-auth";
@@ -48,13 +47,13 @@ export default async function EtlDashboardPage({
 }: {
   searchParams: SearchParams;
 }) {
-  // Not configured = not deployed. 404 before touching anything else so a
-  // missing env var can never leak the ledger.
-  if (!etlPassword()) notFound();
+  // No password configured = open panel (the ledger holds nothing secret).
+  // Setting ETL_DASHBOARD_PASSWORD turns the login gate on.
+  const gated = etlPassword() !== null;
 
   const sp = await searchParams;
 
-  if (!(await hasEtlSession())) {
+  if (gated && !(await hasEtlSession())) {
     return (
       <Shell>
         <LoginForm error={one(sp.blad) === "1"} />
@@ -80,7 +79,7 @@ export default async function EtlDashboardPage({
       />
 
       <div className="mb-6">
-        <Filters kind={kind} limit={limit} />
+        <Filters kind={kind} limit={limit} gated={gated} />
       </div>
 
       <SummaryStrip runs={runs} />


### PR DESCRIPTION
## Summary

`ETL_DASHBOARD_PASSWORD` now only turns the login gate on. When it is unset, `/admin/etl` renders without a login and hides the logout button. Setting the variable restores the password gate unchanged. Docs and the compose header comment updated.

## Verification

- `tsc --noEmit`, eslint on the touched files and `pnpm build` clean.
- Built app started twice against prod (read-only): without the variable the panel returns 200 with all runs and no login/logout UI; with the variable it returns the login form and no run data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The ETL dashboard is now accessible without login when no dashboard password is configured.
  * When a password is configured, the dashboard continues to require authentication and provides logout controls.

* **Documentation**
  * Updated dashboard access documentation to explain password-based and open-access behavior.
  * Clarified that the dashboard displays run timings, counters, and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->