### PR TITLE
fix(enrich): drop duplicate mention spans before the print_mentions insert

### DIFF
--- a/supagraf/enrich/print_unified.py
+++ b/supagraf/enrich/print_unified.py
@@ -380,6 +380,7 @@ def _recover_spans(mentions: list[UnifiedMention], text: str) -> list[dict]:
     """
     cursor = 0
     out: list[dict] = []
+    seen: set[tuple[str, str, int]] = set()
     for m in mentions:
         idx = text.find(m.raw_text, cursor)
         if idx == -1:
@@ -387,6 +388,12 @@ def _recover_spans(mentions: list[UnifiedMention], text: str) -> list[dict]:
             idx = text.find(m.raw_text)
         if idx == -1:
             continue
+        key = (m.mention_type, m.raw_text, idx)
+        if key in seen:
+            # The model listed the same name twice and the text has only one
+            # occurrence left — print_mentions is unique on the span.
+            continue
+        seen.add(key)
         out.append({
             "raw_text": m.raw_text,
             "mention_type": m.mention_type,

--- a/tests/supagraf/unit/test_recover_spans.py
+++ b/tests/supagraf/unit/test_recover_spans.py
@@ -1,0 +1,22 @@
+from supagraf.enrich.print_unified import UnifiedMention, _recover_spans
+
+
+def test_recover_spans_drops_duplicate_span_when_model_repeats_a_name():
+    text = "Poseł Bartłomiej Wróblewski złożył wniosek. Podpisali: Jan Nowak."
+    mentions = [
+        UnifiedMention(raw_text="Bartłomiej Wróblewski", mention_type="person"),
+        UnifiedMention(raw_text="Bartłomiej Wróblewski", mention_type="person"),
+        UnifiedMention(raw_text="Jan Nowak", mention_type="person"),
+    ]
+    rows = _recover_spans(mentions, text)
+    assert [(r["raw_text"], r["span_start"]) for r in rows] == [
+        ("Bartłomiej Wróblewski", 6),
+        ("Jan Nowak", text.index("Jan Nowak")),
+    ]
+
+
+def test_recover_spans_keeps_two_real_occurrences():
+    text = "Jan Nowak i ponownie Jan Nowak."
+    mentions = [UnifiedMention(raw_text="Jan Nowak", mention_type="person")] * 2
+    rows = _recover_spans(mentions, text)
+    assert [r["span_start"] for r in rows] == [0, text.index("Jan Nowak", 1)]


### PR DESCRIPTION
## Summary

Seen in today's live enrichment run: druk 3072 failed with `23505 duplicate key` on `print_mentions`. The model listed the same person twice while the text had only one occurrence left, so the from-start fallback in `_recover_spans` produced the same span again and the batch insert rejected the whole print.

`_recover_spans` now dedupes on (mention_type, raw_text, span_start). Genuine repeated occurrences of a name still get their own rows.

## Verification

- New unit tests `tests/supagraf/unit/test_recover_spans.py` cover the duplicate and the legitimate two-occurrence case; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR)_