### PR TITLE
fix(audit): treat an already-finished model_runs row as a successful finish

### DIFF
--- a/supagraf/enrich/audit.py
+++ b/supagraf/enrich/audit.py
@@ -105,6 +105,15 @@ def _finish_run(run_id: int, status: str, notes: dict | None = None) -> None:
             "p_status": status,
             "p_notes": notes,
         }).execute()
+    except APIError as e:
+        # The first attempt reached Postgres but the reply was lost (Server
+        # disconnected); the retry then finds the row already finished. That is
+        # success, not a reason to fail the enrichment that already persisted.
+        if getattr(e, "code", "") == "P0001" and "not in running state" in str(e):
+            logger.warning("model_run_finish({}, {}): already finished", run_id, status)
+            return
+        logger.error("model_run_finish({}, {}) failed: {!r}", run_id, status, e)
+        raise
     except Exception as e:
         # NEVER swallow this silently — leaves the row stuck at 'running' which
         # is observable. Log loud and re-raise so callers see the breakage.

--- a/tests/supagraf/unit/test_audit_decorator.py
+++ b/tests/supagraf/unit/test_audit_decorator.py
@@ -227,3 +227,26 @@ def test_finish_failure_on_success_propagates(mock_db):
 
     with pytest.raises(RuntimeError, match="finish broken"):
         f(entity_type="print", entity_id="p")
+
+
+# ---- _finish_run idempotency -------------------------------------------------
+
+def test_finish_run_treats_already_finished_row_as_success():
+    """A lost reply followed by a retry must not fail an enrichment that was
+    already persisted: P0001 'not in running state' means the first call landed."""
+    from unittest.mock import MagicMock
+
+    from postgrest.exceptions import APIError
+
+    from supagraf.enrich import audit
+
+    err = APIError({"code": "P0001", "message": "model_runs row 7 not in running state",
+                    "details": None, "hint": None})
+    sb = MagicMock()
+    sb.rpc.return_value.execute.side_effect = err
+    with patch("supagraf.enrich.audit.supabase", return_value=sb):
+        audit._finish_run(7, "ok")  # no raise
+        other = APIError({"code": "P0001", "message": "something else", "details": None, "hint": None})
+        sb.rpc.return_value.execute.side_effect = other
+        with pytest.raises(APIError):
+            audit._finish_run.retry_with(stop=audit.stop_after_attempt(1))(7, "ok")


### PR DESCRIPTION
## Summary

Seen in today's live enrichment run: PostgREST dropped the reply to `model_run_finish` after Postgres had committed it ("Server disconnected"). The tenacity retry then hit `P0001 model_runs row … not in running state` five times and the wrapper raised, so prints 2814-A and 3029-X were counted as failed although their enrichment had already been written.

`_finish_run` now treats that specific P0001 as "already finished" and returns. Any other P0001 still raises.

## Verification

- New unit test in `tests/supagraf/unit/test_audit_decorator.py` covers both the idempotent path and the still-raising path; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audit run completion handling when a retry encounters a run that has already finished.
  - Other API errors continue to be reported and raised normally.

- **Tests**
  - Added coverage for already-finished runs and verification that unrelated errors still fail as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->