### PR TITLE
fix(enrich): salvage prints when the model emits an off-list tag

### DIFF
--- a/supagraf/enrich/print_unified.py
+++ b/supagraf/enrich/print_unified.py
@@ -247,6 +247,19 @@ class UnifiedAffectedGroup(BaseModel):
         return None
 
 
+def _keep_known(v: object, taxonomy: tuple[str, ...], field: str) -> object:
+    """Salvage the print when the model invents a tag ("konsument" as a topic).
+
+    The taxonomies are our own guard; one off-list label is not worth losing
+    summary, impact and mentions for the whole print."""
+    if not isinstance(v, list):
+        return v
+    unknown = [t for t in v if t not in taxonomy]
+    if unknown:
+        logger.warning("dropping unknown {} {}", field, unknown)
+    return [t for t in v if t in taxonomy]
+
+
 class PrintUnifiedOutput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -323,16 +336,12 @@ class PrintUnifiedOutput(BaseModel):
     @field_validator("topic_tags", mode="before")
     @classmethod
     def _drop_unknown_topic_tags(cls, v: object) -> object:
-        """Salvage the print when the model invents a tag ("konsument").
+        return _keep_known(v, TOPIC_TAGS, "topic_tags")
 
-        The taxonomy is our own guard; one off-list label is not worth
-        losing summary, impact and mentions for the whole print."""
-        if not isinstance(v, list):
-            return v
-        unknown = [t for t in v if t not in TOPIC_TAGS]
-        if unknown:
-            logger.warning("dropping unknown topic_tags {}", unknown)
-        return [t for t in v if t in TOPIC_TAGS]
+    @field_validator("persona_tags", mode="before")
+    @classmethod
+    def _drop_unknown_persona_tags(cls, v: object) -> object:
+        return _keep_known(v, PERSONA_TAGS, "persona_tags")
 
     @field_validator("topic_tags", mode="after")
     @classmethod

--- a/supagraf/enrich/print_unified.py
+++ b/supagraf/enrich/print_unified.py
@@ -343,6 +343,16 @@ class PrintUnifiedOutput(BaseModel):
     def _drop_unknown_persona_tags(cls, v: object) -> object:
         return _keep_known(v, PERSONA_TAGS, "persona_tags")
 
+    @field_validator("affected_groups", mode="before")
+    @classmethod
+    def _drop_unknown_affected_groups(cls, v: object) -> object:
+        if not isinstance(v, list):
+            return v
+        unknown = [g.get("tag") for g in v if isinstance(g, dict) and g.get("tag") not in PERSONA_TAGS]
+        if unknown:
+            logger.warning("dropping affected_groups with unknown tag {}", unknown)
+        return [g for g in v if not isinstance(g, dict) or g.get("tag") in PERSONA_TAGS]
+
     @field_validator("topic_tags", mode="after")
     @classmethod
     def _trim_topic_tags_to_3(cls, v: list[str]) -> list[str]:

--- a/supagraf/enrich/print_unified.py
+++ b/supagraf/enrich/print_unified.py
@@ -320,6 +320,20 @@ class PrintUnifiedOutput(BaseModel):
         # Keep first 3 (LLM orders by relevance). Frontend gets exactly 3 max.
         return v[:3]
 
+    @field_validator("topic_tags", mode="before")
+    @classmethod
+    def _drop_unknown_topic_tags(cls, v: object) -> object:
+        """Salvage the print when the model invents a tag ("konsument").
+
+        The taxonomy is our own guard; one off-list label is not worth
+        losing summary, impact and mentions for the whole print."""
+        if not isinstance(v, list):
+            return v
+        unknown = [t for t in v if t not in TOPIC_TAGS]
+        if unknown:
+            logger.warning("dropping unknown topic_tags {}", unknown)
+        return [t for t in v if t in TOPIC_TAGS]
+
     @field_validator("topic_tags", mode="after")
     @classmethod
     def _trim_topic_tags_to_3(cls, v: list[str]) -> list[str]:

--- a/tests/supagraf/unit/test_pick_model.py
+++ b/tests/supagraf/unit/test_pick_model.py
@@ -75,3 +75,11 @@ def test_unknown_persona_tag_is_dropped_not_rejected():
 
     fn = PrintUnifiedOutput._drop_unknown_persona_tags
     assert fn(["rolnik", "zdrowie"]) == ["rolnik"]
+
+
+def test_affected_group_with_unknown_tag_is_dropped():
+    from supagraf.enrich.print_unified import PrintUnifiedOutput
+
+    fn = PrintUnifiedOutput._drop_unknown_affected_groups
+    groups = [{"tag": "mieszkaniec", "severity": "high"}, {"tag": "najemca", "severity": "low"}]
+    assert fn(groups) == [{"tag": "najemca", "severity": "low"}]

--- a/tests/supagraf/unit/test_pick_model.py
+++ b/tests/supagraf/unit/test_pick_model.py
@@ -68,3 +68,10 @@ def test_unknown_topic_tag_is_dropped_not_rejected():
     fn = PrintUnifiedOutput._drop_unknown_topic_tags
     assert fn(["zdrowie", "konsument", "transport"]) == ["zdrowie", "transport"]
     assert fn("not-a-list") == "not-a-list"
+
+
+def test_unknown_persona_tag_is_dropped_not_rejected():
+    from supagraf.enrich.print_unified import PrintUnifiedOutput
+
+    fn = PrintUnifiedOutput._drop_unknown_persona_tags
+    assert fn(["rolnik", "zdrowie"]) == ["rolnik"]

--- a/tests/supagraf/unit/test_pick_model.py
+++ b/tests/supagraf/unit/test_pick_model.py
@@ -58,3 +58,13 @@ def test_trim_body_keeps_head_and_tail_within_budget():
     assert "pominięto" in out
     assert trim_body("short", 1000) == "short"
     assert trim_body("x", 0) == ""
+
+
+def test_unknown_topic_tag_is_dropped_not_rejected():
+    """v4-flash with thinking off occasionally invents a tag ("konsument");
+    one off-list label must not discard the whole print's enrichment."""
+    from supagraf.enrich.print_unified import PrintUnifiedOutput
+
+    fn = PrintUnifiedOutput._drop_unknown_topic_tags
+    assert fn(["zdrowie", "konsument", "transport"]) == ["zdrowie", "transport"]
+    assert fn("not-a-list") == "not-a-list"


### PR DESCRIPTION
## Summary

Seen in today's live enrichment run with `deepseek-v4-flash-vision-exp` and thinking off: the model occasionally emits a label outside our taxonomies (`konsument` as a topic on 2799-002, `mieszkaniec` as a persona on 3036 and 3038). The `Literal` types then failed the whole `PrintUnifiedOutput`, and the print lost its summary, impact and mentions over one label.

Before-validators now filter unknown values with a warning, for `topic_tags`, `persona_tags` and the nested `affected_groups[].tag`. Known tags and the existing 3-tag trims are unchanged.

## Verification

- Unit tests in `tests/supagraf/unit/test_pick_model.py` for all three fields; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR)_