### PR TITLE
fix(enrich): retry the print write on transport drops

### DIFF
--- a/supagraf/enrich/audit.py
+++ b/supagraf/enrich/audit.py
@@ -34,7 +34,7 @@ ERROR_MAX_CHARS = 4000
 # Supabase via Tailscale (mixvm) sees intermittent RemoteProtocolError +
 # ReadError under concurrent load — retry transport-layer drops on top of
 # the postgrest API errors.
-_RETRY_EXC = (
+DB_RETRY_EXC = (
     APIError,
     httpx.RemoteProtocolError,
     httpx.ReadError,
@@ -55,7 +55,7 @@ def _validate_entity_type(et: str) -> None:
 
 
 @retry(
-    retry=retry_if_exception_type(_RETRY_EXC),
+    retry=retry_if_exception_type(DB_RETRY_EXC),
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=1, max=8),
     reraise=True,
@@ -75,7 +75,7 @@ def _insert_run(fn_name: str, model: str, prompt_version: str | None,
 
 
 @retry(
-    retry=retry_if_exception_type(_RETRY_EXC),
+    retry=retry_if_exception_type(DB_RETRY_EXC),
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=1, max=8),
     reraise=True,
@@ -93,7 +93,7 @@ def _record_failure(model_run_id: int, entity_type: str, entity_id: str,
 
 
 @retry(
-    retry=retry_if_exception_type(_RETRY_EXC),
+    retry=retry_if_exception_type(DB_RETRY_EXC),
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=1, max=8),
     reraise=True,

--- a/supagraf/enrich/print_unified.py
+++ b/supagraf/enrich/print_unified.py
@@ -35,10 +35,11 @@ from typing import Literal
 
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from supagraf.db import supabase
 from supagraf.enrich import DEFAULT_LLM_MODEL, LLM_MODELS, LLM_ROUTING
-from supagraf.enrich.audit import with_model_run
+from supagraf.enrich.audit import DB_RETRY_EXC, with_model_run
 from supagraf.enrich.llm import call_structured
 from supagraf.enrich.pdf import extract_pdf, extract_pdf_cover
 from supagraf.enrich.pdf_fetch import resolve_print_pdf
@@ -706,35 +707,26 @@ def _enrich_print_unified(
         # for non-meta prints. Frontend reads opinion_source for the granular
         # author when sponsor_authority='inne' on a meta-document.
         update_payload["sponsor_authority"] = sponsor_authority_override
-    supabase().table("prints").update(update_payload).eq(
-        "term", term
-    ).eq("number", entity_id).execute()
+    _persist(term, entity_id, update_payload, mention_rows, pv_str, prompt_sha, llm_model)
+    return parsed
 
-    # Replace mentions for this prompt_version: delete then insert fresh batch.
-    print_id_row = (
-        supabase().table("prints").select("id")
-        .eq("term", term).eq("number", entity_id)
-        .single().execute().data
-    )
-    print_id = print_id_row["id"]
 
-    supabase().table("print_mentions").delete().eq("print_id", print_id).eq(
-        "prompt_version", pv_str
-    ).execute()
-
+@retry(retry=retry_if_exception_type(DB_RETRY_EXC), stop=stop_after_attempt(5),
+       wait=wait_exponential(multiplier=1, min=1, max=8), reraise=True)
+def _persist(term: int, entity_id: str, update_payload: dict, mention_rows: list[dict],
+             pv_str: str, prompt_sha: str, llm_model: str) -> None:
+    """Write the enrichment; retried on transport drops so a paid LLM reply
+    is never lost to one "Server disconnected". Idempotent: same update,
+    mentions replaced wholesale for this prompt_version."""
+    sb = supabase()
+    sb.table("prints").update(update_payload).eq("term", term).eq("number", entity_id).execute()
+    print_id = (sb.table("prints").select("id").eq("term", term).eq("number", entity_id)
+                .single().execute().data["id"])
+    sb.table("print_mentions").delete().eq("print_id", print_id).eq("prompt_version", pv_str).execute()
     if mention_rows:
-        supabase().table("print_mentions").insert([
-            {
-                "print_id": print_id,
-                "mention_type": r["mention_type"],
-                "raw_text": r["raw_text"],
-                "span_start": r["span_start"],
-                "span_end": r["span_end"],
-                "prompt_version": pv_str,
-                "prompt_sha256": prompt_sha,
-                "model": llm_model,
-            }
+        sb.table("print_mentions").insert([
+            {"print_id": print_id, "mention_type": r["mention_type"], "raw_text": r["raw_text"],
+             "span_start": r["span_start"], "span_end": r["span_end"],
+             "prompt_version": pv_str, "prompt_sha256": prompt_sha, "model": llm_model}
             for r in mention_rows
         ]).execute()
-
-    return parsed

--- a/tests/supagraf/unit/test_pick_model.py
+++ b/tests/supagraf/unit/test_pick_model.py
@@ -83,3 +83,22 @@ def test_affected_group_with_unknown_tag_is_dropped():
     fn = PrintUnifiedOutput._drop_unknown_affected_groups
     groups = [{"tag": "mieszkaniec", "severity": "high"}, {"tag": "najemca", "severity": "low"}]
     assert fn(groups) == [{"tag": "najemca", "severity": "low"}]
+
+
+def test_persist_retries_transport_drop_then_writes():
+    """A paid LLM reply must survive one 'Server disconnected' on the write."""
+    from unittest.mock import MagicMock, patch
+
+    import httpx
+
+    from supagraf.enrich import print_unified
+
+    sb = MagicMock()
+    update_exec = sb.table.return_value.update.return_value.eq.return_value.eq.return_value.execute
+    update_exec.side_effect = [httpx.RemoteProtocolError("Server disconnected"), MagicMock()]
+    sb.table.return_value.select.return_value.eq.return_value.eq.return_value.single.return_value.execute.return_value.data = {"id": 1}
+    with patch("supagraf.enrich.print_unified.supabase", return_value=sb):
+        print_unified._persist.retry_with(wait=print_unified.wait_exponential(multiplier=0, max=0))(
+            10, "1", {"summary": "x"}, [], "7", "sha", "m")
+    assert update_exec.call_count == 2
+    sb.table.return_value.delete.return_value.eq.return_value.eq.return_value.execute.assert_called_once()


### PR DESCRIPTION
## Summary

Seen in today's live enrichment run: the `prints` update and `print_mentions` replace ran without any retry, so a single "Server disconnected" from PostgREST discarded a paid model reply (prints 671-008 and 1962-007).

The write now lives in `_persist`, retried with the same tenacity policy `audit.py` uses (`DB_RETRY_EXC`, now shared between the modules). The block is idempotent: same update, mentions replaced wholesale for the prompt version.

## Verification

- New unit test asserts one transport drop is retried and the write completes; existing enrich, audit and print_unified tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when saving enrichment results by retrying after temporary database or transport connection failures.
  - Preserved existing retry limits, backoff behavior, and error handling.
- **Tests**
  - Added coverage confirming that a transient connection failure is retried and the write completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->