### PR TITLE
fix(db): retry transport drops at every Supabase call site

### DIFF
--- a/supagraf/db.py
+++ b/supagraf/db.py
@@ -11,6 +11,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+import httpx
+from postgrest.exceptions import APIError
 from supabase import Client, create_client
 
 
@@ -33,6 +35,19 @@ def load_dotenv() -> None:
 
 # Back-compat alias for any internal call sites.
 _load_dotenv = load_dotenv
+
+
+# PostgREST behind Cloudflare/Kong closes idle keep-alive connections; a pooled
+# request on a dead socket surfaces as RemoteProtocolError("Server disconnected")
+# or ReadError. Every Supabase call site retries on these, not just APIError.
+DB_RETRY_EXC = (
+    APIError,
+    httpx.RemoteProtocolError,
+    httpx.ReadError,
+    httpx.ConnectError,
+    httpx.TimeoutException,
+    httpx.PoolTimeout,
+)
 
 
 @lru_cache(maxsize=1)

--- a/supagraf/enrich/audit.py
+++ b/supagraf/enrich/audit.py
@@ -22,26 +22,14 @@ from dataclasses import dataclass
 from typing import Any, Callable, ParamSpec, TypeVar
 
 from loguru import logger
-import httpx
 from postgrest.exceptions import APIError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from supagraf.db import supabase
+from supagraf.db import DB_RETRY_EXC, supabase
 from supagraf.enrich.embed import ALLOWED_ENTITY_TYPES
 
 ERROR_MAX_CHARS = 4000
 
-# Supabase via Tailscale (mixvm) sees intermittent RemoteProtocolError +
-# ReadError under concurrent load — retry transport-layer drops on top of
-# the postgrest API errors.
-DB_RETRY_EXC = (
-    APIError,
-    httpx.RemoteProtocolError,
-    httpx.ReadError,
-    httpx.ConnectError,
-    httpx.TimeoutException,
-    httpx.PoolTimeout,
-)
 
 P = ParamSpec("P")
 R = TypeVar("R")

--- a/supagraf/enrich/embed.py
+++ b/supagraf/enrich/embed.py
@@ -11,7 +11,6 @@ import os
 from dataclasses import dataclass
 
 import httpx
-from postgrest.exceptions import APIError
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -19,7 +18,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from supagraf.db import supabase
+from supagraf.db import DB_RETRY_EXC, supabase
 
 EMBED_DIM = 1024
 # qwen3-embedding:0.6b is natively 1024-d so no padding needed (vs the
@@ -127,7 +126,7 @@ def embed_text(
 
 
 @retry(
-    retry=retry_if_exception_type(APIError),
+    retry=retry_if_exception_type(DB_RETRY_EXC),
     stop=stop_after_attempt(4),
     wait=wait_exponential(multiplier=1, min=1, max=8),
     reraise=True,

--- a/supagraf/enrich/pdf.py
+++ b/supagraf/enrich/pdf.py
@@ -18,11 +18,10 @@ from pathlib import Path
 
 import fitz  # pymupdf
 from loguru import logger
-from postgrest.exceptions import APIError
 from pydantic import BaseModel
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from supagraf.db import supabase
+from supagraf.db import DB_RETRY_EXC, supabase
 
 PYMUPDF_MODEL_VERSION = f"pymupdf-{fitz.__version__}-md-primary"
 DOCX_MODEL_VERSION = "python-docx-1.2-primary"
@@ -49,7 +48,7 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-@retry(retry=retry_if_exception_type(APIError), stop=stop_after_attempt(4),
+@retry(retry=retry_if_exception_type(DB_RETRY_EXC), stop=stop_after_attempt(4),
        wait=wait_exponential(multiplier=1, min=1, max=8), reraise=True)
 def _cache_lookup(sha: str, model_version: str) -> dict | None:
     r = (supabase().table("pdf_extracts").select("text, page_count, ocr_used, char_count_per_page")
@@ -57,7 +56,7 @@ def _cache_lookup(sha: str, model_version: str) -> dict | None:
     return (r.data or [None])[0]
 
 
-@retry(retry=retry_if_exception_type(APIError), stop=stop_after_attempt(4),
+@retry(retry=retry_if_exception_type(DB_RETRY_EXC), stop=stop_after_attempt(4),
        wait=wait_exponential(multiplier=1, min=1, max=8), reraise=True)
 def _cache_insert(sha: str, model_version: str, text: str, ocr_used: bool, per_page: list[int]) -> None:
     supabase().table("pdf_extracts").upsert(

--- a/supagraf/enrich/print_unified.py
+++ b/supagraf/enrich/print_unified.py
@@ -37,9 +37,9 @@ from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from supagraf.db import supabase
+from supagraf.db import DB_RETRY_EXC, supabase
 from supagraf.enrich import DEFAULT_LLM_MODEL, LLM_MODELS, LLM_ROUTING
-from supagraf.enrich.audit import DB_RETRY_EXC, with_model_run
+from supagraf.enrich.audit import with_model_run
 from supagraf.enrich.llm import call_structured
 from supagraf.enrich.pdf import extract_pdf, extract_pdf_cover
 from supagraf.enrich.pdf_fetch import resolve_print_pdf
@@ -438,25 +438,16 @@ def _recover_spans(mentions: list[UnifiedMention], text: str) -> list[dict]:
     return out
 
 
+@retry(retry=retry_if_exception_type(DB_RETRY_EXC), stop=stop_after_attempt(4),
+       wait=wait_exponential(multiplier=1, min=1, max=8), reraise=True)
 def _fetch_meta(term: int, entity_id: str) -> dict:
-    """Single source of truth for the metadata read used by both the model
-    picker and the prompt header. Two-step select tolerates older schemas
-    that lack opinion_source / is_meta_document."""
-    select_cols = "document_category, sponsor_authority, title"
-    try:
-        return (
-            supabase().table("prints")
-            .select(select_cols + ", opinion_source, is_meta_document")
-            .eq("term", term).eq("number", entity_id)
-            .single().execute().data or {}
-        )
-    except Exception:
-        return (
-            supabase().table("prints")
-            .select(select_cols)
-            .eq("term", term).eq("number", entity_id)
-            .single().execute().data or {}
-        )
+    """Metadata read used by both the model picker and the prompt header."""
+    return (
+        supabase().table("prints")
+        .select("document_category, sponsor_authority, title, opinion_source, is_meta_document")
+        .eq("term", term).eq("number", entity_id)
+        .single().execute().data or {}
+    )
 
 
 def enrich_print_unified(

--- a/supagraf/enrich/promise_matcher.py
+++ b/supagraf/enrich/promise_matcher.py
@@ -30,11 +30,10 @@ from datetime import datetime, timezone
 from typing import Literal
 
 from loguru import logger
-from postgrest.exceptions import APIError
 from pydantic import BaseModel, ConfigDict, Field
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from supagraf.db import supabase
+from supagraf.db import DB_RETRY_EXC, supabase
 from supagraf.enrich import DEFAULT_LLM_MODEL
 from supagraf.enrich.embed import DEFAULT_EMBED_MODEL
 from supagraf.enrich.llm import call_structured
@@ -43,7 +42,7 @@ RERANK_PROMPT_NAME = "promise_match_rerank"
 
 
 @retry(
-    retry=retry_if_exception_type(APIError),
+    retry=retry_if_exception_type(DB_RETRY_EXC),
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=1, max=8),
     reraise=True,

--- a/supagraf/load/__init__.py
+++ b/supagraf/load/__init__.py
@@ -7,7 +7,7 @@ from loguru import logger
 from postgrest.exceptions import APIError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from supagraf.db import call_rpc_scalar, supabase
+from supagraf.db import DB_RETRY_EXC, call_rpc_scalar, supabase
 
 try:
     from psycopg import OperationalError as _PgOperationalError
@@ -15,7 +15,7 @@ except ImportError:  # psycopg only required on the direct-PG path
     _PgOperationalError = type("_NoPsycopg", (Exception,), {})
 
 
-_RPC_RETRY_EXC = (APIError, _PgOperationalError)
+_RPC_RETRY_EXC = (*DB_RETRY_EXC, _PgOperationalError)
 _TRANSIENT_TIMEOUT_CODE = "57014"
 
 

--- a/supagraf/stage/base.py
+++ b/supagraf/stage/base.py
@@ -15,11 +15,10 @@ from pathlib import Path
 from typing import Callable, Iterable, Type
 
 from loguru import logger
-from postgrest.exceptions import APIError
 from pydantic import BaseModel
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from supagraf.db import supabase
+from supagraf.db import DB_RETRY_EXC, supabase
 from supagraf.fixtures.storage import fixtures_root
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -108,7 +107,7 @@ def stage_resource(
 
 
 @retry(
-    retry=retry_if_exception_type(APIError),
+    retry=retry_if_exception_type(DB_RETRY_EXC),
     stop=stop_after_attempt(4),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     reraise=True,

--- a/supagraf/sync/stage.py
+++ b/supagraf/sync/stage.py
@@ -17,7 +17,7 @@ from postgrest.exceptions import APIError
 from pydantic import BaseModel, Field, ValidationError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from supagraf.db import supabase
+from supagraf.db import DB_RETRY_EXC, supabase
 
 PAGE = 1000
 BATCH = 25
@@ -69,7 +69,7 @@ def validate(model: type[BaseModel], payload: Any) -> str | None:
     return None
 
 
-@retry(retry=retry_if_exception_type(APIError), stop=stop_after_attempt(4),
+@retry(retry=retry_if_exception_type(DB_RETRY_EXC), stop=stop_after_attempt(4),
        wait=wait_exponential(multiplier=1, min=1, max=10), reraise=True)
 def _upsert(table: str, batch: list[dict], on_conflict: str) -> int:
     return len(supabase().table(table).upsert(batch, on_conflict=on_conflict).execute().data or [])


### PR DESCRIPTION
## Summary

Print 599 failed in today's second run before its model call with `RemoteProtocolError("Server disconnected")`: the `pdf_extracts` cache lookup and the prints metadata read retried only on `APIError`. PostgREST behind Cloudflare/Kong closes idle keep-alive sockets and the shared client reuses them from a thread pool, so this eventually hits every worker.

- `DB_RETRY_EXC` (APIError plus httpx transport/timeout errors) now lives in `supagraf/db.py`.
- Applied at every Supabase retry site: `audit`, `pdf`, `print_unified` (`_fetch_meta` gained a retry and lost its blind two-step fallback), `embed`, `promise_matcher`, `sync/stage`, `stage/base`, and the load RPC wrapper.

## Verification

- Full unit suite passes (377 passed, 2 skipped); ruff clean on the touched files except one pre-existing unused variable in `promise_matcher.py` that this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR)_