### PR TITLE
fix(enrich): map an off-list addressee to 'inne' and drop unknown topic tags

### DIFF
--- a/supagraf/enrich/utterance_enrich.py
+++ b/supagraf/enrich/utterance_enrich.py
@@ -14,7 +14,7 @@ versioned prompt provenance via @with_model_run.
 from __future__ import annotations
 
 import os
-from typing import Literal
+from typing import Literal, get_args
 
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -73,6 +73,9 @@ TopicTag = Literal[
     "srodowisko-klimat",
 ]
 
+ADDRESSEE_VALUES: tuple[str, ...] = get_args(Addressee)
+TOPIC_TAG_VALUES: tuple[str, ...] = get_args(TopicTag)
+
 
 class MentionedEntities(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -118,10 +121,28 @@ class UtteranceEnrichmentOutput(BaseModel):
     @field_validator("key_claims", "topic_tags", mode="before")
     @classmethod
     def _trim_lists(cls, v: object, info) -> object:
-        """v4-flash overshoots the list caps too (4 key_claims for max 3);
-        keep the head instead of discarding the whole statement."""
-        cap = MAX_KEY_CLAIMS if info.field_name == "key_claims" else MAX_TOPIC_TAGS
-        return v[:cap] if isinstance(v, list) else v
+        """v4-flash overshoots the list caps (4 key_claims for max 3) and
+        invents topic labels; keep the known head instead of discarding the
+        whole statement."""
+        if not isinstance(v, list):
+            return v
+        if info.field_name == "topic_tags":
+            unknown = [t for t in v if t not in TOPIC_TAG_VALUES]
+            if unknown:
+                logger.warning("dropping unknown topic_tags {}", unknown)
+            v = [t for t in v if t in TOPIC_TAG_VALUES]
+            return v[:MAX_TOPIC_TAGS]
+        return v[:MAX_KEY_CLAIMS]
+
+    @field_validator("addressee", mode="before")
+    @classmethod
+    def _unknown_addressee_is_inne(cls, v: object) -> object:
+        """"minister", "premier" and friends are not in the taxonomy; the
+        catch-all exists for exactly that."""
+        if isinstance(v, str) and v not in ADDRESSEE_VALUES:
+            logger.warning("addressee {!r} not in taxonomy — using 'inne'", v)
+            return "inne"
+        return v
 
     @field_validator("summary_one_line", mode="before")
     @classmethod

--- a/tests/supagraf/unit/test_utterance_enrich.py
+++ b/tests/supagraf/unit/test_utterance_enrich.py
@@ -18,3 +18,10 @@ def test_overlong_lists_are_trimmed_not_rejected():
     assert len(o.key_claims) == MAX_KEY_CLAIMS
     assert len(o.topic_tags) == MAX_TOPIC_TAGS
     assert o.key_claims == ["a", "b", "c"]
+
+
+def test_unknown_addressee_and_topic_are_salvaged():
+    """flash returned addressee='minister' (statement 2133948)."""
+    o = _out(addressee="minister", topic_tags=["zdrowie", "konsument"])
+    assert o.addressee == "inne"
+    assert o.topic_tags == ["zdrowie"]


### PR DESCRIPTION
## Summary

Statement 2133948 in today's run was rejected because `deepseek-v4-flash` returned `addressee='minister'`, which is not in the taxonomy. The taxonomy has a catch-all (`inne`), so an unknown addressee now maps to it with a warning. Unknown `topic_tags` are filtered out, matching the print enricher.

## Verification

- Unit test added to `tests/supagraf/unit/test_utterance_enrich.py`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unrecognized addressee values by assigning them to a general fallback category.
  * Removed unsupported topic tags during enrichment instead of allowing invalid values.
  * Continued limiting the number of topic tags and key claims to supported maximums.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->