### PR TITLE
feat(enrich): record DeepSeek token usage per phase in etl_runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ PaddleOCR and the GPU OCR experiments were removed in Sept 2026 (deadlocks, mult
 - **Statements (`enrich-utterances`) use `deepseek-v4-flash`** (`SUPAGRAF_UTTERANCE_LLM_MODEL`), `thinking=off`. Do NOT pass `SUPAGRAF_LLM_MODEL` to the utterance job; it clobbers the per-statement default.
 - **Thinking**: DeepSeek enables it by default and then ignores `temperature`. `call_structured(thinking="off"|"low"|"high"|"max")`; default `SUPAGRAF_LLM_THINKING=off` everywhere, including prints (`SUPAGRAF_PRINT_THINKING=low` costs ~3× per print). The body key is `thinking: {"type": ...}` + `reasoning_effort` — `reasoning.effort` is the Anthropic-format field and is ignored on this endpoint.
 - **402 Insufficient Balance / 401** raise `LLMBudgetError` and stop the whole enrich phase after one call (remaining items stay pending, nothing is counted as failed) — top up at platform.deepseek.com and re-run.
+- Token usage per enrich phase (`calls/input/cache_hit/output/reasoning`) is summed in `llm.usage_snapshot()` and lands in `etl_runs.steps.<phase>.counts.tokens` — the `/admin/etl` panel shows it; that is the cost signal.
 - 429 (concurrency throttle) and 503 are retried; empty JSON-mode content is retried; `usage.prompt_cache_hit_tokens` is logged — keep system prompt + schema first, document last, so the automatic prefix cache hits.
 - **Peak pricing** Mon–Fri 01–04 & 06–10 UTC (2× off-peak). Schedule enrichment outside it; `is_deepseek_peak_hour()` warns.
 - Enrichment concurrency `SUPAGRAF_ENRICH_WORKERS` (default 4); failure backoff 3 failures / 14 days per print.

--- a/supagraf/enrich/jobs.py
+++ b/supagraf/enrich/jobs.py
@@ -32,7 +32,7 @@ from datetime import datetime, timedelta, timezone
 from loguru import logger
 
 from supagraf.db import supabase
-from supagraf.enrich.llm import LLMBudgetError
+from supagraf.enrich.llm import LLMBudgetError, usage_since, usage_snapshot
 
 DEFAULT_WORKERS = int(os.environ.get("SUPAGRAF_ENRICH_WORKERS", "4"))
 OUTAGE_THRESHOLD = int(os.environ.get("SUPAGRAF_FETCH_OUTAGE_THRESHOLD", "8"))
@@ -56,12 +56,13 @@ class EnrichStats:
     backoff: int = 0
     aborted: bool = False
     errors: list[tuple[str, str]] = field(default_factory=list)
+    tokens: dict[str, int] = field(default_factory=dict)   # DeepSeek usage for this phase
 
     def to_dict(self) -> dict:
         return {
             "ok": self.ok, "failed": self.failed, "skipped": self.skipped,
             "backoff": self.backoff, "aborted": self.aborted,
-            "errors": self.errors[:20],
+            "errors": self.errors[:20], "tokens": self.tokens,
         }
 
 
@@ -239,6 +240,7 @@ def enrich_pending_prints(*, term: int = 10, limit: int = 0, workers: int = DEFA
     )
     outage = _Outage(OUTAGE_THRESHOLD)
     lock = threading.Lock()
+    usage0 = usage_snapshot()
     with ThreadPoolExecutor(max_workers=max(1, workers), thread_name_prefix="enrich-print") as pool:
         futures = [pool.submit(_enrich_one_print, r, outage, stats, lock) for r in todo]
         for i, fut in enumerate(as_completed(futures), 1):
@@ -251,6 +253,8 @@ def enrich_pending_prints(*, term: int = 10, limit: int = 0, workers: int = DEFA
         stats.errors.append(("phase", f"aborted: {outage.reason}"))
         logger.error("enrich prints aborted: {}; remaining prints left pending for the next run",
                      outage.reason)
+    stats.tokens = usage_since(usage0)
+    logger.info("enrich prints tokens: {}", stats.tokens)
     return stats
 
 
@@ -307,6 +311,7 @@ def enrich_pending_statements(
                 sitting, len(pending), model, workers)
     lock = threading.Lock()
     outage = _Outage(OUTAGE_THRESHOLD)
+    usage0 = usage_snapshot()
 
     def _one(r: dict) -> None:
         sid = str(r["id"])
@@ -342,6 +347,8 @@ def enrich_pending_statements(
         stats.aborted = True
         stats.errors.append(("phase", f"aborted: {outage.reason}"))
         logger.error("enrich statements aborted: {}", outage.reason)
+    stats.tokens = usage_since(usage0)
+    logger.info("enrich statements tokens: {}", stats.tokens)
     return stats
 
 

--- a/supagraf/enrich/llm.py
+++ b/supagraf/enrich/llm.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import os
 import re
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypeVar
@@ -165,7 +166,32 @@ def _chat(*, model: str, messages: list[dict], timeout_s: float, json_mode: bool
         cache_hit_tokens=u.get("prompt_cache_hit_tokens"), cache_miss_tokens=u.get("prompt_cache_miss_tokens"),
         reasoning_tokens=(u.get("completion_tokens_details") or {}).get("reasoning_tokens"),
     )
+    _count_usage(usage)
     return body["choices"][0]["message"]["content"], usage
+
+
+_usage_lock = threading.Lock()
+_usage_totals: dict[str, int] = {"calls": 0, "input": 0, "cache_hit": 0, "output": 0, "reasoning": 0}
+
+
+def _count_usage(u: TokenUsage) -> None:
+    with _usage_lock:
+        _usage_totals["calls"] += 1
+        _usage_totals["input"] += u.input_tokens or 0
+        _usage_totals["cache_hit"] += u.cache_hit_tokens or 0
+        _usage_totals["output"] += u.output_tokens or 0
+        _usage_totals["reasoning"] += u.reasoning_tokens or 0
+
+
+def usage_snapshot() -> dict[str, int]:
+    """Process-wide DeepSeek token totals so far (all models, all jobs)."""
+    with _usage_lock:
+        return dict(_usage_totals)
+
+
+def usage_since(before: dict[str, int]) -> dict[str, int]:
+    now = usage_snapshot()
+    return {k: now[k] - before.get(k, 0) for k in now}
 
 
 def _user_content(text: str, images: list[bytes] | None) -> str | list[dict]:

--- a/tests/supagraf/unit/test_llm_deepseek.py
+++ b/tests/supagraf/unit/test_llm_deepseek.py
@@ -192,3 +192,12 @@ def test_402_raises_budget_error_without_retry(monkeypatch):
     with pytest.raises(llm_mod.LLMBudgetError):
         llm_mod.call_structured(model="m", prompt_name="p", user_input="u", output_model=Out)
     assert len(calls) == 1
+
+
+def test_usage_totals_accumulate_per_call(monkeypatch):
+    _capture(monkeypatch, [_ok('{"a": 1}'), _ok('{"a": 2}')])
+    before = llm_mod.usage_snapshot()
+    llm_mod.call_structured(model="m", prompt_name="p", user_input="u", output_model=Out)
+    llm_mod.call_structured(model="m", prompt_name="p", user_input="u", output_model=Out)
+    d = llm_mod.usage_since(before)
+    assert d["calls"] == 2 and d["input"] == 200 and d["cache_hit"] == 128 and d["output"] == 10


### PR DESCRIPTION
## Summary

The statements phase never logged token usage, so the daily's real DeepSeek cost was invisible; today the only signal was the account running dry mid-run.

- `llm.py` keeps process-wide totals (`calls`, `input`, `cache_hit`, `output`, `reasoning`) updated on every chat completion, with `usage_snapshot()` / `usage_since()`.
- `EnrichStats.tokens` records each enrich phase's delta; it flows into the step counts in `etl_runs` and therefore onto the `/admin/etl` panel as chips.
- `CLAUDE.md` notes where the cost signal lives.

## Verification

- Unit test asserts totals accumulate across two calls; enrich jobs and daily tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR)_