### PR TITLE
chore(audit): log retried model_run_finish drops as warnings

### DIFF
--- a/supagraf/enrich/audit.py
+++ b/supagraf/enrich/audit.py
@@ -100,12 +100,12 @@ def _finish_run(run_id: int, status: str, notes: dict | None = None) -> None:
         if getattr(e, "code", "") == "P0001" and "not in running state" in str(e):
             logger.warning("model_run_finish({}, {}): already finished", run_id, status)
             return
-        logger.error("model_run_finish({}, {}) failed: {!r}", run_id, status, e)
+        logger.warning("model_run_finish({}, {}) failed, retrying: {!r}", run_id, status, e)
         raise
     except Exception as e:
-        # NEVER swallow this silently — leaves the row stuck at 'running' which
-        # is observable. Log loud and re-raise so callers see the breakage.
-        logger.error("model_run_finish({}, {}) failed: {!r}", run_id, status, e)
+        # Never swallow: a stuck 'running' row must stay observable. tenacity
+        # retries transport drops; the final failure surfaces to the caller.
+        logger.warning("model_run_finish({}, {}) failed, retrying: {!r}", run_id, status, e)
         raise
 
 


### PR DESCRIPTION
## Summary

Each transport drop on `model_run_finish` was logged at ERROR before tenacity retried it and the idempotent path then reported "already finished". That produced dozens of red lines per run for a non-event. The intermediate log is now a warning; the final failure still propagates to the caller unchanged.

## Verification

- Audit decorator tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgu9T9JbyPFGQZwNHoTHzR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audit error handling so API failures can be retried automatically.
  - Reduced the severity of warning logs for retryable and unexpected audit errors while preserving error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->