### PR TITLE
feat: sieć powiązań polityków i poprawki ETL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ mobile/expo-env.d.ts
 
 # Stray root node_modules (frontend/ has its own — none expected at repo root)
 /node_modules/
+.pnpm-store/
 
 # Debug / one-off screenshot dumps from quote-share + verdict overflow checks.
 # Output of scripts/quote_share_*.mjs and scripts/verdict_overflow_*.mjs.

--- a/docs/network-experiments.md
+++ b/docs/network-experiments.md
@@ -1,0 +1,95 @@
+# Sieć polityków: eksperyment odczytowy
+
+`supagraf.network.build_network()` tworzy mały, JSON-serializowalny snapshot z odczytów PostgREST. Nie zapisuje do bazy i nie zmienia ETL. Uruchomienie zapisuje podgląd do `.tmp_supagraf/network-preview.json`.
+
+```powershell
+uv run python -m supagraf.network
+```
+
+Nie przekierowuj wyniku do repozytorium. Błąd autoryzacji jest błędem konfiguracji; nie wypisuj kluczy ani pełnego obiektu błędu.
+
+## Warstwy
+
+`layers.questions.edges` to projekcja wieloautorskich interpelacji i zapytań. Każda para z pytania podpisanego przez `k` osób dostaje wagę `1/(k-1)`, aby długa lista autorów nie dominowała nad małą wspólną inicjatywą. Dowód to do pięciu linków do oficjalnego API Sejmu.
+
+`layers.votes.edges` to zgodność par posłów w maksymalnie 120 najnowszych elektronicznych głosowaniach merytorycznych. Uwzględnia tylko `YES`, `NO` i `ABSTAIN`; nieobecności, obecność bez głosu i głosy listowe są wyłączone. Krawędź wymaga 20 wspólnych głosów. `baseline_agreement` jest zgodnością większości klubów zapisanych w `votes.club_ref` w chwili głosowania, a `excess` to różnica względem tej bazy. Nie jest to miara współpracy ani prognoza.
+
+Próba wybiera jeden głos na powiązany blok druku, gdy taki blok istnieje. Payload ujawnia zakres skanu, kandydatów i wybór oraz `ballot_transport`. Karty głosowania pochodzą najpierw z surowego etapu ETL (`_stage_votings.payload`), a gdy jest niepełny — z oficjalnego API Sejmu. Snapshot powstaje tylko wtedy, gdy liczba rekordów odpowiada sumie głosujących i niegłosujących, identyfikatory posłów są unikalne, a wybory poprawne. Pomija głosowania, w których co najmniej 95% ważnych głosów było identycznych. `mp_deviations` liczy modalny głos klubu leave-one-out, bez remisów, przy co najmniej pięciu innych ważnych głosach klubowych.
+
+## Język interfejsu
+
+Używaj „współautorzy pytania”, „głosowali tak samo” i „inaczej niż większość klubu w porównywalnych głosowaniach”. Nie używaj języka sugerującego korupcję, nieformalny wpływ ani przyszłą zmianę klubu.
+
+Źródło: [API Sejmu](https://api.sejm.gov.pl/sejm.html).
+
+## Uruchomienie widoku
+
+Nowa strona: `/powiazania`, dostępna również przez Atlas i menu „Więcej”.
+Portrety pochodzą z `mps.photo_url`; brak lub błąd zdjęcia zastępują inicjały.
+Na telefonie mapa zmienia się w listę z rozwijanymi pod osobą źródłami.
+Tryb lokalnego podglądu korzysta wyłącznie z jawnie wskazanego pliku wynikowego;
+nie działa w buildzie produkcyjnym i nie wprowadza przykładowych danych do bazy.
+
+```powershell
+uv run python -m supagraf network --output .tmp_supagraf/network-preview.json
+cd frontend
+$env:SUPAGRAF_NETWORK_PREVIEW_FILE = 'D:/tygodnik-sejmowy/.tmp_supagraf/network-preview.json'
+node node_modules/next/dist/bin/next dev
+```
+
+Przy wdrożeniu należy zastosować obie nowe migracje przez zatwierdzony w tym
+repo proces direct psql na mixvm (nie przez MCP zarządzanego Supabase):
+
+- `20260910063533_politician_network_snapshots.sql`
+- `20260910063557_fix_vote_club_history.sql`
+
+Po migracji `uv run python -m supagraf network --publish` publikuje pierwszy
+wynik. Kolejne zwykłe przebiegi `daily` odświeżają sieć automatycznie. Samo
+`network --output ...` nie publikuje do bazy. Ta implementacja nie została
+jeszcze wdrożona na produkcję.
+
+Wersja eksperymentalna przelicza ograniczoną próbę po każdym poprawnym przebiegu
+ETL. Dzięki temu ponawia nieudaną publikację i usuwa dokumenty wypadające z okna
+czasu także w dni bez nowych danych. To ograniczony pełny przelicznik, nie
+inkrementalna aktualizacja każdej krawędzi. Nie wymaga nowej bazy grafowej ani
+modelu językowego. Snapshot publikuje się jednym upsertem; awaria zachowuje
+poprzedni wynik. Publiczna rola ma tylko SELECT, zapisy wykonuje ETL.
+
+## Pierwszy odczyt, 10 września 2026
+
+Odczytowa próba na rzeczywistych danych: 499 osób (także z zakończonym mandatem),
+2000 najnowszych interpelacji/zapytań z okna 180 dni, w tym 406 dokumentów
+wieloautorskich. Wszystkie 2000 miały autorów; odczytano 3881 przypisań autorstwa.
+Limit dokumentów został osiągnięty, więc nie jest to pełny zbiór z tego okresu.
+
+Z 600 najnowszych kandydatów na głosowania 491 miało kwalifikującą klasyfikację.
+Wybrano 120 głosowań z ograniczeniem powtarzających się powiązanych druków,
+a następnie pominięto niemal jednomyślne głosowania w obliczeniach.
+Odczyt tabeli `votes` zwracał 503; kompletne karty pobrano z `_stage_votings`.
+Nie opublikowano niekompletnych kart i nie zastosowano migracji w produkcji.
+
+Wynik po zachowaniu najmocniejszych relacji poszczególnych osób: 1144 krawędzie
+wspólnego autorstwa i 3429 krawędzi podobieństwa głosów. Liczba krawędzi nie jest
+liczbą statystycznie potwierdzonych nietypowych relacji. Wybór na podstawie
+najwyższej nadwyżki sam podwyższa jej rozkład w wyświetlanej próbie.
+
+Kolejne eksperymenty przed szerszymi wnioskami: stabilność w rozłącznych okresach,
+próba po całkowitym odrzuceniu głosowań bez powiązanego druku, model losowy
+zachowujący aktywność posłów i rozmiary grup autorów. Nie dodano jeszcze
+klasteryzacji, prognoz odejścia, podpisów projektów ustaw ani relacji do spółek.
+
+## Weryfikacja
+
+```powershell
+uv run pytest tests/supagraf/unit -q
+node scripts/test_network_migrations.mjs
+cd frontend
+node node_modules/typescript/bin/tsc --noEmit
+node node_modules/next/dist/bin/next build
+```
+
+Test SQL potrzebuje lokalnego `@electric-sql/pglite@0.5.8` w ignorowanym
+`.tmp_supagraf/sql-test/node_modules` (np. instalacja `pnpm --dir
+.tmp_supagraf/sql-test add @electric-sql/pglite@0.5.8`). Nie używa produkcji.
+Testy kontraktowe tego repo mogą wykonywać RPC odświeżające produkcyjne widoki;
+nie należą do lokalnej ścieżki weryfikacji tej funkcji.

--- a/frontend/app/atlas/page.tsx
+++ b/frontend/app/atlas/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   alternates: { canonical: "/atlas" },
@@ -54,6 +55,10 @@ export default async function AtlasPage() {
           subtitle={`Aktualizacja: ${formatDataUpdate(lastUpdate)} · n = ${heatmap.totalVotings.toLocaleString("pl-PL")} głosowań · Źródło: ETL sejmograf + API Sejmu RP`}
         />
 
+        <Link href="/powiazania" className="mb-10 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-muted/40 p-5 hover:bg-muted">
+          <span><span className="text-xs uppercase tracking-wider text-muted-foreground">Eksperyment</span><span className="mt-1 block text-xl font-medium">Co łączy posłów?</span></span>
+          <span className="text-sm">Odkryj mapę powiązań →</span>
+        </Link>
         <div className="grid gap-12 sm:gap-16 md:gap-20 min-w-0 [&>*]:min-w-0">
           <MapaOkregow data={mapData} />
           <HeatmapaKoalicji data={heatmap} />

--- a/frontend/app/powiazania/NetworkExplorer.tsx
+++ b/frontend/app/powiazania/NetworkExplorer.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { ArrowRight, ArrowUpRight, ChevronRight, GitBranch, Info, Search, Users, Vote } from "lucide-react";
+import { KLUB_COLORS } from "@/lib/atlas/constants";
+import { sourceUrl, type Evidence, type NetworkNode, type NetworkSnapshot, type QuestionEdge, type VoteEdge } from "@/lib/network";
+
+type Layer = "questions" | "votes";
+type Connection = { peer: NetworkNode; edge: QuestionEdge | VoteEdge; score: number };
+const date = (s: string | null) => s ? new Date(s).toLocaleDateString("pl-PL", { timeZone: "Europe/Warsaw" }) : "brak daty";
+const percent = (n: number) => `${(n * 100).toLocaleString("pl-PL", { maximumFractionDigits: 1 })}%`;
+const normalize = (s: string) => s.toLocaleLowerCase("pl").normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/ł/g, "l");
+const initials = (name: string) => name.split(" ").filter(Boolean).map(n => n[0]).slice(0, 2).join("");
+const clubColor = (node: NetworkNode) => KLUB_COLORS[node.current_club ?? ""] ?? "var(--muted-foreground)";
+function isQuestion(edge: QuestionEdge | VoteEdge): edge is QuestionEdge { return "coauthored_count" in edge; }
+
+function Avatar({ node, large = false }: { node: NetworkNode; large?: boolean }) {
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+  const photo = node.photo_url && /^https:\/\//i.test(node.photo_url) && failedUrl !== node.photo_url ? node.photo_url : null;
+  return <span aria-hidden="true" className={`relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full border-[3px] bg-background font-medium ${large ? "h-20 w-20 text-xl" : "h-14 w-14 text-sm"}`} style={{ borderColor: clubColor(node) }}>
+    {photo ? (
+      // Stored public portrait URLs, as used by the existing MP directory.
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={photo} alt="" width={large ? 80 : 56} height={large ? 80 : 56} loading="lazy" decoding="async" ref={img => { if (img?.complete && img.naturalWidth === 0) setFailedUrl(photo); }} onError={() => setFailedUrl(photo)} className="h-full w-full object-cover object-[50%_20%]" />
+    ) : initials(node.name)}
+  </span>;
+}
+
+export function NetworkExplorer({ data, stale = false }: { data: NetworkSnapshot; stale?: boolean }) {
+  const byId = useMemo(() => new Map(data.nodes.map(n => [n.mp_id, n])), [data.nodes]);
+  const startingId = useMemo(() => {
+    const degrees = new Map<number, number>();
+    for (const e of data.layers.questions.edges) {
+      const a = byId.get(e.a), b = byId.get(e.b);
+      const multiplier = a?.current_club && b?.current_club && a.current_club !== b.current_club ? 10 : 1;
+      degrees.set(e.a, (degrees.get(e.a) ?? 0) + e.weight * multiplier);
+      degrees.set(e.b, (degrees.get(e.b) ?? 0) + e.weight * multiplier);
+    }
+    return [...degrees].sort((a, b) => b[1] - a[1] || a[0] - b[0])[0]?.[0] ?? data.nodes[0]?.mp_id;
+  }, [data, byId]);
+  const [selectedId, setSelectedId] = useState(startingId);
+  const [layer, setLayer] = useState<Layer>("questions");
+  const [query, setQuery] = useState("");
+  const [outsideClub, setOutsideClub] = useState(false);
+  const [peerId, setPeerId] = useState<number | null>(null);
+  const explorerRef = useRef<HTMLElement>(null);
+  const selected = byId.get(selectedId);
+  const connections = useMemo(() => {
+    const edges = layer === "questions" ? data.layers.questions.edges : data.layers.votes.edges;
+    return edges.flatMap(edge => {
+      const id = edge.a === selectedId ? edge.b : edge.b === selectedId ? edge.a : null;
+      const peer = id === null ? undefined : byId.get(id);
+      if (!peer || (outsideClub && (!peer.current_club || !selected?.current_club || peer.current_club === selected.current_club))) return [];
+      return [{ peer, edge, score: isQuestion(edge) ? edge.weight : edge.excess }];
+    }).sort((a, b) => b.score - a.score || a.peer.mp_id - b.peer.mp_id).slice(0, 8);
+  }, [layer, data, selectedId, byId, outsideClub, selected]);
+  const focused = connections.find(c => c.peer.mp_id === peerId) ?? connections[0];
+  const searchResults = query.trim() ? data.nodes.filter(n => normalize(`${n.name} ${n.current_club ?? ""}`).includes(normalize(query.trim()))).slice(0, 12) : [];
+  const deviation = data.layers.votes.mp_deviations.find(d => d.mp_id === selectedId);
+  const selectPerson = (id: number) => {
+    setSelectedId(id); setPeerId(null); setQuery("");
+    if (window.matchMedia("(max-width: 767px)").matches) {
+      explorerRef.current?.scrollIntoView({ block: "start", behavior: "instant" });
+    }
+  };
+
+  if (!selected) return <p role="status">W tym okresie nie ma danych o posłach.</p>;
+  return (
+    <div>
+      <div className="mb-6 flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-muted-foreground sm:text-sm">
+        <span>{date(data.window.from)} — {date(data.window.to)}</span>
+        <span>{data.sampling.questions.selected.toLocaleString("pl-PL")} interpelacji i zapytań w próbie</span>
+        <span>{data.sampling.votings.selected} głosowań w próbie</span>
+        <span>Obliczono {date(data.generated_at)}{stale ? " · dane wymagają odświeżenia" : ""}</span>
+      </div>
+
+      <div className="grid items-start gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <section ref={explorerRef} className="min-w-0 scroll-mt-20 overflow-hidden rounded-2xl border border-border" aria-label="Mapa powiązań">
+          <div className="flex flex-wrap gap-3 border-b border-border bg-card p-4 sm:p-5">
+            <div className="relative min-w-0 flex-1 basis-64">
+              <label htmlFor="network-search" className="sr-only">Szukaj posła lub klubu</label>
+              <Search className="pointer-events-none absolute left-3 top-3.5 text-muted-foreground" size={17} aria-hidden="true" />
+              <input id="network-search" type="search" value={query} onChange={e => setQuery(e.target.value)} placeholder="Szukaj posła lub klubu…" autoComplete="off" aria-controls="network-search-results" className="h-11 w-full rounded-lg border border-input bg-background pl-10 pr-3 text-base outline-offset-2 focus-visible:outline-2 md:text-sm" />
+              {query.trim() && <div id="network-search-results" className="absolute inset-x-0 top-12 z-20 max-h-72 overflow-auto rounded-xl border border-border bg-popover p-1 shadow-lg" aria-label="Wyniki wyszukiwania">
+                {searchResults.length ? searchResults.map(n => <button key={n.mp_id} onClick={() => selectPerson(n.mp_id)} className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-3 text-left text-sm hover:bg-muted focus-visible:bg-muted"><span>{n.name}</span><span className="text-xs text-muted-foreground">{n.current_club ?? "brak klubu"}</span></button>) : <p className="p-3 text-sm text-muted-foreground" role="status">Nie znaleziono osoby ani klubu.</p>}
+              </div>}
+            </div>
+            <div className="flex w-full rounded-lg bg-muted p-1 sm:w-auto" aria-label="Rodzaj powiązania">
+              {([ ["questions", "Wspólne sprawy", Users], ["votes", "Głosowania", Vote] ] as const).map(([id, label, Icon]) => (
+                <button key={id} onClick={() => { setLayer(id); setPeerId(null); }} aria-pressed={layer === id} className={`inline-flex min-h-11 flex-1 items-center justify-center gap-2 rounded-md px-2 text-sm sm:flex-none sm:whitespace-nowrap sm:px-3 ${layer === id ? "bg-background font-medium shadow-sm" : "text-muted-foreground hover:text-foreground"}`}><Icon size={15} className="shrink-0" aria-hidden="true" />{label}</button>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2 px-5 pt-4 text-xs text-muted-foreground">
+            <span>Najmocniejsze dostępne relacje · do 8 osób</span>
+            <label className="flex min-h-11 cursor-pointer items-center gap-2"><input type="checkbox" checked={outsideClub} onChange={e => setOutsideClub(e.target.checked)} className="h-4 w-4 accent-foreground" />Tylko inne kluby obecnie</label>
+          </div>
+
+          <div className="relative hidden h-[530px] md:block">
+            <svg className="absolute inset-0 h-full w-full" aria-hidden="true">
+              <defs><pattern id="network-dots" width="24" height="24" patternUnits="userSpaceOnUse"><circle cx="1" cy="1" r="1" fill="var(--border)" /></pattern></defs>
+              <rect width="100%" height="100%" fill="url(#network-dots)" />
+              {connections.map((c, i) => {
+                const angle = i * Math.PI * 2 / connections.length - Math.PI / 2;
+                return <line key={c.peer.mp_id} x1="50%" y1="50%" x2={`${50 + Math.cos(angle) * 34}%`} y2={`${50 + Math.sin(angle) * 35}%`} stroke={focused?.peer.mp_id === c.peer.mp_id ? "var(--foreground)" : "var(--border)"} strokeWidth={focused?.peer.mp_id === c.peer.mp_id ? 2 : 1.5} strokeDasharray={layer === "votes" ? "5 5" : undefined} />;
+              })}
+            </svg>
+            <div className="absolute left-1/2 top-1/2 z-10 flex w-40 -translate-x-1/2 -translate-y-1/2 flex-col items-center text-center">
+              <Avatar node={selected} large />
+              <span className="mt-2 rounded bg-background px-2 text-sm font-semibold">{selected.name}</span>
+              <span className="mt-1 rounded bg-background px-2 text-xs text-muted-foreground">{selected.current_club ?? "Klub nieznany"}</span>
+            </div>
+            {connections.map((c, i) => {
+              const angle = i * Math.PI * 2 / connections.length - Math.PI / 2;
+              return <button key={c.peer.mp_id} aria-pressed={focused?.peer.mp_id === c.peer.mp_id} aria-label={`Pokaż relację: ${selected.name} i ${c.peer.name}`} onClick={() => setPeerId(c.peer.mp_id)} className={`absolute z-10 flex w-36 -translate-x-1/2 -translate-y-1/2 flex-col items-center rounded-xl p-2 text-center transition-colors hover:bg-muted focus-visible:outline-2 ${focused?.peer.mp_id === c.peer.mp_id ? "bg-muted" : ""}`} style={{ left: `${50 + Math.cos(angle) * 34}%`, top: `${50 + Math.sin(angle) * 35}%` }}>
+                <Avatar node={c.peer} /><span className="mt-1 rounded bg-background/95 px-1 text-xs font-medium">{c.peer.name}</span><span className="mt-0.5 rounded bg-background/95 px-1 text-[11px] text-muted-foreground">{c.peer.current_club ?? "Klub nieznany"}</span>
+              </button>;
+            })}
+          </div>
+
+          <div className="p-4 md:hidden"><div className="mb-4 flex items-center gap-3"><Avatar node={selected} /><div className="min-w-0"><p className="font-semibold">{selected.name}</p><p className="text-xs text-muted-foreground">{selected.current_club ?? "Klub nieznany"}</p></div></div>
+            {connections.length > 0 && <p className="mb-3 text-xs text-muted-foreground">Dotknij osoby, aby rozwinąć wspólne działania i źródła.</p>}
+            {connections.map(c => <div key={c.peer.mp_id} className="border-t border-border">
+              <button onClick={() => setPeerId(peerId === c.peer.mp_id ? null : c.peer.mp_id)} aria-expanded={peerId === c.peer.mp_id} aria-controls={`network-mobile-${c.peer.mp_id}`} className={`flex w-full items-center gap-3 px-2 py-3 text-left ${peerId === c.peer.mp_id ? "bg-muted" : ""}`}><Avatar node={c.peer} /><span className="min-w-0 flex-1"><span className="block text-sm font-medium">{c.peer.name}</span><span className="text-xs text-muted-foreground">{c.peer.current_club ?? "Klub nieznany"} · {isQuestion(c.edge) ? `${c.edge.coauthored_count} wspólnych spraw` : `${percent(c.edge.agreement)} zgodnych głosów`}</span></span><ChevronRight size={16} className={`shrink-0 ${peerId === c.peer.mp_id ? "rotate-90" : ""}`} /></button>
+              <div id={`network-mobile-${c.peer.mp_id}`} hidden={peerId !== c.peer.mp_id}>{peerId === c.peer.mp_id && <ConnectionDetail connection={c} selected={selected} onExplore={selectPerson} compact />}</div>
+            </div>)}
+          </div>
+          {!connections.length && <p className="px-5 pb-6 text-sm text-muted-foreground" role="status">Brak relacji spełniających te warunki w dostępnej próbie. Zmień osobę, warstwę lub filtr. Brak wyniku nie oznacza braku współpracy.</p>}
+          <p className="border-t border-border px-5 py-3 text-xs leading-relaxed text-muted-foreground">Kolory i etykiety oznaczają obecny klub.<span className="hidden md:inline"> Położenie osób służy czytelności, nie mierzy odległości politycznej.</span></p>
+        </section>
+
+        <aside className="min-w-0 space-y-5" aria-label="Wyjaśnienie powiązania" aria-live="polite">
+          <div className="hidden md:block">{focused ? <ConnectionDetail connection={focused} selected={selected} onExplore={selectPerson} /> : <div className="rounded-2xl border border-border p-6"><GitBranch size={22} className="mb-4 text-muted-foreground" /><h2 className="text-lg font-medium">Każda linia ma swoją historię</h2><p className="mt-3 text-sm leading-relaxed text-muted-foreground">Wybierz osobę i relację, aby zobaczyć wspólne działania oraz ich źródła.</p></div>}</div>
+          {deviation && deviation.n > 0 && <div className="rounded-2xl bg-muted/60 p-5"><p className="mb-2 text-xs text-muted-foreground">{selected.name} · głosowania w próbie</p><h3 className="text-base font-medium">Inaczej niż większość klubu</h3><p className="mt-3 text-2xl font-semibold tabular-nums">{deviation.deviations} <span className="text-base font-normal text-muted-foreground">z {deviation.n} głosowań</span></p><p className="mt-2 text-xs leading-relaxed text-muted-foreground">Porównanie z klubem w dniu głosowania. Pomijamy remisy, nieobecności i zbyt małe grupy. To opis zachowania w próbie.</p></div>}
+          <Link href={`/posel/${selected.mp_id}`} className="flex items-center justify-between px-1 py-3 text-sm hover:underline">Profil: {selected.name} <ArrowUpRight size={16} /></Link>
+        </aside>
+      </div>
+
+      <details className="mt-8 border-t border-border py-5">
+        <summary className="flex cursor-pointer items-center gap-2 text-sm font-medium"><Info size={16} />Jak czytać tę mapę i skąd pochodzą dane?</summary>
+        <div className="mt-5 grid gap-6 text-sm leading-relaxed text-muted-foreground md:grid-cols-2">
+          <div><h3 className="mb-2 font-medium text-foreground">Wspólne sprawy</h3><p>Łączymy autorów tej samej interpelacji lub zapytania poselskiego. Powtarzająca się współpraca zwiększa siłę relacji, a dokument podpisany przez dużą grupę waży mniej. Analizujemy do {data.sampling.questions.scan_limit} najnowszych dokumentów z tego okresu. Lista źródeł pokazuje do pięciu przykładów.</p><p className="mt-2">Filtr innych klubów porównuje obecne kluby. Nie rozstrzyga, do jakich klubów należeli autorzy w chwili złożenia dokumentu.</p></div>
+          <div><h3 className="mb-2 font-medium text-foreground">Podobieństwo głosów</h3><p>Porównujemy zgodność pary z oczekiwaną zgodnością ich klubów w tych samych głosowaniach, korzystając z przynależności zapisanej przy każdym głosie. Wymagamy co najmniej 20 porównywalnych głosowań. Nadwyżka jest opisową miarą, nie testem istotności ani dowodem współpracy.</p><p className="mt-2">Próba obejmuje do {data.sampling.votings.limit} najnowszych kwalifikujących się głosowań. Nie opisuje całej kadencji. Podobne głosy nie wskazują motywacji ani przyszłej zmiany partii.</p></div>
+          {data.limitations.length > 0 && <ul className="list-disc space-y-2 pl-5 md:col-span-2">{data.limitations.map((l, i) => <li key={i}>{l}</li>)}</ul>}
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function ConnectionDetail({ connection, selected, onExplore, compact = false }: { connection: Connection; selected: NetworkNode; onExplore: (id: number) => void; compact?: boolean }) {
+  const { edge, peer } = connection;
+  const question = isQuestion(edge);
+  const evidence: Evidence[] = edge.evidence;
+  return <section className={compact ? "bg-muted/40 px-3 py-5" : "rounded-2xl border border-border bg-card p-5 sm:p-6"}>
+    <p className="mb-4 text-xs uppercase tracking-wider text-muted-foreground">Dlaczego są połączeni?</p>
+    {!compact && <div className="mb-5 flex items-center gap-3"><Avatar node={peer} /><div><h2 className="font-semibold">{peer.name}</h2><p className="text-xs text-muted-foreground">{peer.current_club ?? "Klub nieznany"}</p></div></div>}
+    <p className="text-4xl font-semibold tracking-tight tabular-nums">{question ? edge.coauthored_count : percent(edge.agreement)}</p>
+    <p className="mt-2 text-sm leading-relaxed">{question ? `wspólnych interpelacji i zapytań z osobą: ${selected.name}.` : `zgodnych głosów z osobą: ${selected.name}, w ${edge.n} porównywalnych głosowaniach.`}</p>
+    {!question && <div className="mt-4 rounded-lg bg-muted p-3 text-sm"><p>Typowa zgodność ich klubów: <strong>{percent(edge.baseline_agreement)}</strong></p><p className="mt-1">Nadwyżka zgodności: <strong>{edge.excess >= 0 ? "+" : ""}{(edge.excess * 100).toLocaleString("pl-PL", { maximumFractionDigits: 1 })} pkt proc.</strong></p></div>}
+    <div className="mt-6 border-t border-border pt-4"><h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">Sprawdź źródła · przykłady</h3>
+      {evidence.length ? <><EvidenceList evidence={evidence.slice(0, 2)} />{evidence.length > 2 && <details className="mt-4"><summary className="cursor-pointer text-xs font-medium underline underline-offset-4">Więcej przykładów ({evidence.length - 2})</summary><div className="mt-4"><EvidenceList evidence={evidence.slice(2)} /></div></details>}</> : <p className="text-sm text-muted-foreground">Brak źródeł do wyświetlenia.</p>}
+    </div>
+    <button onClick={() => onExplore(peer.mp_id)} className="mt-6 inline-flex min-h-11 w-full items-center justify-between gap-2 rounded-lg bg-primary px-4 py-3 text-left text-sm font-medium text-primary-foreground">Odkryj powiązania tej osoby <ArrowRight size={16} /></button>
+  </section>;
+}
+
+function EvidenceList({ evidence }: { evidence: Evidence[] }) {
+  return <ol className="space-y-4">{evidence.map((e, i) => <li key={`${e.url}-${i}`}><p className="mb-1 text-xs text-muted-foreground">{date(e.date)}</p>{sourceUrl(e.url) ? <a href={sourceUrl(e.url)} target="_blank" rel="noopener noreferrer" className="group inline-flex gap-2 text-sm leading-relaxed hover:underline"><span className="line-clamp-3">{e.title}</span><ArrowUpRight className="mt-1 shrink-0 text-muted-foreground" size={14} aria-hidden="true" /></a> : <p className="text-sm">{e.title}</p>}</li>)}</ol>;
+}

--- a/frontend/app/powiazania/page.tsx
+++ b/frontend/app/powiazania/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowUpRight, Network } from "lucide-react";
+import { getNetworkPageData } from "@/lib/db/network";
+import { NetworkExplorer } from "./NetworkExplorer";
+
+export const metadata: Metadata = {
+  title: "Powiązania — Tygodnik Sejmowy",
+  description: "Odkrywaj wspólne działania posłów i podobieństwa głosowań. Każde powiązanie prowadzi do źródeł.",
+  alternates: { canonical: "/powiazania" },
+};
+export const dynamic = "force-dynamic";
+
+export default async function NetworkPage() {
+  const { snapshot, unavailable, stale } = await getNetworkPageData();
+  return (
+    <main className="mx-auto max-w-[1440px] px-4 py-5 sm:px-8 sm:py-12">
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-3 sm:mb-8">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Network size={16} aria-hidden="true" /> Atlas / Powiązania
+          <span className="rounded-full bg-highlight px-2.5 py-1 text-xs text-foreground">Eksperyment</span>
+        </div>
+        <Link href="/atlas" className="inline-flex min-h-11 items-center gap-1 text-sm hover:underline"><span className="sm:hidden">Atlas</span><span className="hidden sm:inline">Wróć do Atlasu</span><ArrowUpRight size={14} /></Link>
+      </div>
+      <h1 className="max-w-3xl text-4xl font-semibold tracking-tight sm:text-6xl">Co ich łączy?</h1>
+      <p className="mt-3 mb-5 max-w-2xl text-base leading-relaxed text-muted-foreground sm:mt-4 sm:mb-8 sm:text-lg">
+        <span className="hidden sm:inline">Wspólne sprawy, podobne głosy, nieoczywiste połączenia. </span>Wybierz osobę i sprawdź, jakie działania stoją za każdą relacją.
+      </p>
+      {snapshot ? <NetworkExplorer data={snapshot} stale={stale} /> : (
+        <section className="rounded-2xl border border-border bg-muted/40 p-8 sm:p-12" role="status">
+          <h2 className="text-xl font-medium">{unavailable ? "Nie udało się pobrać mapy" : "Pierwsza mapa jest jeszcze przed nami"}</h2>
+          <p className="mt-3 max-w-xl text-muted-foreground">{unavailable
+            ? "Dane są chwilowo niedostępne. Spróbuj odświeżyć stronę za chwilę."
+            : "Powiązania pojawią się po zakończeniu pierwszej analizy danych. Przy każdej relacji znajdziesz dokumenty, daty i opis sposobu obliczenia."}</p>
+          <Link href="/posel" className="mt-5 inline-flex items-center gap-2 underline underline-offset-4">Przeglądaj posłów <ArrowUpRight size={16} /></Link>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/components/chrome/nav-items.ts
+++ b/frontend/components/chrome/nav-items.ts
@@ -20,6 +20,7 @@ export const SIDEBAR_MAIN_NAV = [
 export const SECONDARY_NAV = [
   { href: "/szukaj",       label: "Szukaj",      hint: "wyszukiwarka" },
   { href: "/atlas",        label: "Atlas",       hint: "wykresy" },
+  { href: "/powiazania",   label: "Powiązania",  hint: "eksperyment" },
   { href: "/sondaze",      label: "Sondaże",     hint: "poparcie partii" },
   { href: "/proces",       label: "Procesy",     hint: "ścieżka ustaw" },
   { href: "/mowa",         label: "Mowa",        hint: "transkrypcje" },

--- a/frontend/lib/db/network.ts
+++ b/frontend/lib/db/network.ts
@@ -1,0 +1,28 @@
+import "server-only";
+import { supabase } from "@/lib/supabase";
+import { isNetworkSnapshot, type NetworkSnapshot } from "@/lib/network";
+
+export async function getNetworkPageData() {
+  try {
+    const snapshot = await getNetworkSnapshot();
+    return { snapshot, unavailable: false, stale: !!snapshot && Date.now() - Date.parse(snapshot.generated_at) > 48 * 3600000 };
+  } catch {
+    return { snapshot: null, unavailable: true, stale: false };
+  }
+}
+
+export async function getNetworkSnapshot(term = 10): Promise<NetworkSnapshot | null> {
+  // Explicit local research preview, disabled in production. No bundled sample data.
+  if (process.env.NODE_ENV === "development" && process.env.SUPAGRAF_NETWORK_PREVIEW_FILE) {
+    const { readFile } = await import("node:fs/promises");
+    const value: unknown = JSON.parse(await readFile(process.env.SUPAGRAF_NETWORK_PREVIEW_FILE, "utf8"));
+    if (!isNetworkSnapshot(value) || value.term !== term) throw new Error("Invalid network preview");
+    return value;
+  }
+  const { data, error } = await supabase().from("politician_network_snapshots")
+    .select("payload").eq("term", term).maybeSingle();
+  if (error) throw new Error("Network snapshot unavailable");
+  if (!data) return null;
+  if (!isNetworkSnapshot(data.payload) || data.payload.term !== term) throw new Error("Invalid network snapshot");
+  return data.payload;
+}

--- a/frontend/lib/network.ts
+++ b/frontend/lib/network.ts
@@ -1,0 +1,58 @@
+export type NetworkNode = {
+  mp_id: number;
+  name: string;
+  current_club: string | null;
+  active: boolean;
+  photo_url?: string | null;
+};
+export type Evidence = { date: string | null; title: string; url: string };
+export type QuestionEdge = {
+  a: number; b: number; weight: number; coauthored_count: number; evidence: Evidence[];
+};
+export type VoteEdge = {
+  a: number; b: number; n: number; agreement: number;
+  baseline_agreement: number; excess: number; evidence: Evidence[];
+};
+export type NetworkSnapshot = {
+  schema_version: "1";
+  term: number;
+  generated_at: string;
+  window: { days: number; from: string; to: string };
+  sampling: {
+    questions: { selected: number; scan_limit: number; with_multiple_authors: number };
+    votings: { eligible: number; selected: number; limit: number; selection: string };
+  };
+  nodes: NetworkNode[];
+  layers: {
+    questions: { edges: QuestionEdge[] };
+    votes: { edges: VoteEdge[]; mp_deviations: { mp_id: number; n: number; deviations: number; rate: number }[] };
+  };
+  limitations: string[];
+};
+
+export function isNetworkSnapshot(value: unknown): value is NetworkSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Partial<NetworkSnapshot>;
+  return v.schema_version === "1" && typeof v.term === "number"
+    && typeof v.generated_at === "string" && !Number.isNaN(Date.parse(v.generated_at))
+    && !!v.window && typeof v.window.days === "number" && typeof v.window.from === "string" && typeof v.window.to === "string"
+    && Array.isArray(v.nodes) && v.nodes.every(n => Number.isInteger(n.mp_id) && typeof n.name === "string" && (n.current_club === null || typeof n.current_club === "string"))
+    && Array.isArray(v.layers?.questions?.edges) && v.layers.questions.edges.every(e => Number.isInteger(e.a) && Number.isInteger(e.b) && Number.isFinite(e.weight) && Number.isInteger(e.coauthored_count) && validEvidence(e.evidence))
+    && Array.isArray(v.layers?.votes?.edges) && v.layers.votes.edges.every(e => Number.isInteger(e.a) && Number.isInteger(e.b) && Number.isInteger(e.n) && Number.isFinite(e.agreement) && Number.isFinite(e.baseline_agreement) && Number.isFinite(e.excess) && validEvidence(e.evidence))
+    && Array.isArray(v.layers?.votes?.mp_deviations) && v.layers.votes.mp_deviations.every(d => Number.isInteger(d.mp_id) && Number.isInteger(d.n) && Number.isInteger(d.deviations))
+    && Number.isInteger(v.sampling?.questions?.selected) && Number.isInteger(v.sampling?.questions?.scan_limit)
+    && Number.isInteger(v.sampling?.votings?.selected) && Number.isInteger(v.sampling?.votings?.limit)
+    && Array.isArray(v.limitations) && v.limitations.every(l => typeof l === "string");
+}
+
+function validEvidence(value: unknown): value is Evidence[] {
+  return Array.isArray(value) && value.every(e => e && typeof e.title === "string" && typeof e.url === "string" && (e.date === null || typeof e.date === "string"));
+}
+
+export function sourceUrl(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "https:" && (parsed.hostname === "api.sejm.gov.pl" || parsed.hostname === "www.sejm.gov.pl" || parsed.hostname === "sejm.gov.pl")) return url;
+  } catch { /* Malformed source must never become an executable link. */ }
+  return undefined;
+}

--- a/scripts/test_network_migrations.mjs
+++ b/scripts/test_network_migrations.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { PGlite } from "../.tmp_supagraf/sql-test/node_modules/@electric-sql/pglite/dist/index.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const migration = async (name) => readFile(join(root, "supabase", "migrations", name), "utf8");
+const db = new PGlite();
+
+async function rejectsSql(sql, pattern) {
+  let error;
+  try {
+    await db.exec(sql);
+  } catch (caught) {
+    error = caught;
+  }
+  assert(error, `expected SQL to fail: ${sql}`);
+  assert.match(String(error.message), pattern);
+}
+
+await db.exec(`
+  create role anon nologin;
+  create role authenticated nologin;
+  create role service_role nologin bypassrls;
+  grant usage on schema public to anon, authenticated, service_role;
+
+  create type public.vote_choice as enum
+    ('YES','NO','ABSTAIN','ABSENT','PRESENT','VOTE_VALID');
+  create type public.voting_kind as enum ('ELECTRONIC','ON_LIST','TRADITIONAL');
+  create table public.clubs (
+    id bigint primary key, term integer not null, club_id text not null,
+    unique (term, club_id)
+  );
+  create table public.mps (term integer not null, mp_id integer not null,
+    primary key (term, mp_id));
+  create table public.votings (
+    id bigint primary key, term integer not null, date timestamptz not null,
+    kind public.voting_kind not null
+  );
+  create table public.votes (
+    voting_id bigint not null references public.votings(id), term integer not null,
+    mp_id integer not null, club_ref text, vote public.vote_choice not null
+  );
+  create table public._stage_votings (
+    term integer not null, natural_id text not null, payload jsonb not null
+  );
+  create table public.mp_club_membership (
+    term integer not null, mp_id integer not null, club_id bigint not null
+  );
+
+  create view public.mp_vote_discipline as
+  select v.voting_id, v.mp_id, v.term, c.id as club_id_at_vote,
+         v.vote as club_modal_choice, v.vote as mp_choice, true as aligned
+  from public.votes v join public.clubs c
+    on c.term = v.term and c.club_id = v.club_ref
+  where false;
+`);
+
+await db.exec(await migration("20260910063533_politician_network_snapshots.sql"));
+await db.exec(await migration("20260910063557_fix_vote_club_history.sql"));
+
+await db.exec(`
+  insert into public._stage_votings values
+    (10, '1__1', '{"totalVoted":2,"notParticipating":0,"votes":[{"vote":"YES"}]}'::jsonb),
+    (10, '1__2', '{"totalVoted":1,"notParticipating":1,"votes":[{"vote":"YES"},{"vote":"ABSENT"}]}'::jsonb);
+`);
+assert.deepEqual(
+  (await db.query("select natural_id from public.incomplete_staged_votings(10) order by natural_id")).rows,
+  [{ natural_id: "1__1" }],
+);
+await db.exec("set role service_role");
+assert.deepEqual(
+  (await db.query("select natural_id from public.incomplete_staged_votings(10) order by natural_id")).rows,
+  [{ natural_id: "1__1" }],
+);
+await db.exec("reset role");
+
+await db.exec(`
+  insert into public.clubs values (1,10,'A'),(2,10,'B'),(3,10,'C'),(4,10,'D');
+  insert into public.votings values
+    (1,10,'2026-01-01','ELECTRONIC'), (2,10,'2026-01-02','ELECTRONIC'),
+    (10,10,'2026-02-01','ELECTRONIC'), (11,10,'2026-02-02','ELECTRONIC'),
+    (12,10,'2026-02-03','ELECTRONIC'), (20,10,'2026-03-01','ON_LIST');
+  insert into public.votes values
+    (1,10,1,'A','NO'), (1,10,2,'A','YES'), (1,10,3,'A','YES'),
+    (1,10,4,'A','YES'), (1,10,5,'A','YES'),
+    (1,10,10,'B','YES'), (1,10,11,'B','YES'), (1,10,12,'B','YES'), (1,10,13,'B','YES'),
+    (1,10,20,'C','YES'), (1,10,21,'C','YES'), (1,10,22,'C','YES'),
+    (1,10,23,'C','NO'), (1,10,24,'C','NO'), (1,10,25,'C','NO'),
+    (2,10,30,'D','PRESENT'), (2,10,31,'D','PRESENT'), (2,10,32,'D','PRESENT'),
+    (2,10,33,'D','PRESENT'), (2,10,34,'D','PRESENT'),
+    (20,10,40,'A','YES'), (20,10,41,'A','YES'), (20,10,42,'A','YES'),
+    (20,10,43,'A','YES'), (20,10,44,'A','YES'),
+    (10,10,99,'A','YES'), (11,10,99,'B','YES'), (12,10,99,'A','YES');
+  insert into public.mp_club_membership values (10,1,2);
+`);
+
+const discipline = await db.query(`
+  select mp_id, club_id_at_vote, club_modal_choice::text, mp_choice::text, aligned
+  from public.mp_vote_discipline order by mp_id
+`);
+assert.equal(discipline.rows.length, 5, "only the five eligible club A roll-call rows remain");
+assert.deepEqual(discipline.rows[0], {
+  mp_id: 1, club_id_at_vote: 1, club_modal_choice: "YES", mp_choice: "NO", aligned: false,
+});
+assert.deepEqual(discipline.rows.map((row) => row.mp_id), [1, 2, 3, 4, 5]);
+
+const transitions = await db.query(`
+  select mp_id, change_date::text, from_club_short, to_club_short
+  from public.detect_mp_club_transitions(10) where mp_id = 99 order by change_date
+`);
+assert.deepEqual(transitions.rows, [
+  { mp_id: 99, change_date: "2026-02-01", from_club_short: null, to_club_short: "A" },
+  { mp_id: 99, change_date: "2026-02-02", from_club_short: "A", to_club_short: "B" },
+  { mp_id: 99, change_date: "2026-02-03", from_club_short: "B", to_club_short: "A" },
+]);
+
+await db.exec("set role anon");
+assert.deepEqual((await db.query("select * from public.politician_network_snapshots")).rows, []);
+await rejectsSql(
+  `insert into public.politician_network_snapshots values
+   (10, now(), '{"schema_version":"1","term":10}'::jsonb)`,
+  /permission denied|row-level security/i,
+);
+await db.exec("reset role; set role service_role");
+await db.exec(`
+  insert into public.politician_network_snapshots values
+    (10, now(), '{"schema_version":"1","term":10,"nodes":[]}'::jsonb)
+  on conflict (term) do update set generated_at=excluded.generated_at, payload=excluded.payload;
+`);
+await db.exec(`
+  insert into public.politician_network_snapshots values
+    (10, now(), '{"schema_version":"1","term":10,"nodes":[1]}'::jsonb)
+  on conflict (term) do update set generated_at=excluded.generated_at, payload=excluded.payload;
+`);
+assert.equal((await db.query("select payload->'nodes' as nodes from public.politician_network_snapshots")).rows[0].nodes[0], 1);
+await rejectsSql(
+  `insert into public.politician_network_snapshots values
+   (11, now(), '{"schema_version":"2","term":11}'::jsonb)`,
+  /check constraint/i,
+);
+await rejectsSql(
+  `insert into public.politician_network_snapshots values
+   (11, now(), '{"schema_version":"1","term":12}'::jsonb)`,
+  /check constraint/i,
+);
+await rejectsSql(
+  `insert into public.politician_network_snapshots values
+   (11, now(), '{"term":11}'::jsonb)`,
+  /check constraint/i,
+);
+await rejectsSql(
+  `insert into public.politician_network_snapshots values
+   (11, now(), '{"schema_version":null,"term":11}'::jsonb)`,
+  /check constraint/i,
+);
+await rejectsSql(
+  `insert into public.politician_network_snapshots values
+   (11, now(), '{"schema_version":"1"}'::jsonb)`,
+  /check constraint/i,
+);
+await rejectsSql(
+  `insert into public.politician_network_snapshots values
+   (11, now(), '{"schema_version":"1","term":null}'::jsonb)`,
+  /check constraint/i,
+);
+
+await db.close();
+console.log("PGlite migration checks passed");

--- a/supabase/migrations/20260910063533_politician_network_snapshots.sql
+++ b/supabase/migrations/20260910063533_politician_network_snapshots.sql
@@ -1,0 +1,20 @@
+-- A single atomic publication per term. Readers never see a half-built graph.
+create table public.politician_network_snapshots (
+  term integer primary key check (term > 0),
+  generated_at timestamptz not null,
+  payload jsonb not null check (jsonb_typeof(payload) = 'object'),
+  check (payload ? 'schema_version'
+         and jsonb_typeof(payload->'schema_version') = 'string'
+         and payload->>'schema_version' = '1'),
+  check (payload ? 'term'
+         and jsonb_typeof(payload->'term') = 'number'
+         and (payload->>'term')::integer = term)
+);
+alter table public.politician_network_snapshots enable row level security;
+create policy network_public_read on public.politician_network_snapshots
+  for select to anon, authenticated using (true);
+grant select on public.politician_network_snapshots to anon, authenticated;
+grant select, insert, update, delete on public.politician_network_snapshots to service_role;
+comment on table public.politician_network_snapshots is
+  'Experimental, source-backed politician network. Published by ETL only after a complete build; methodology and coverage included in payload.';
+notify pgrst, 'reload schema';

--- a/supabase/migrations/20260910063557_fix_vote_club_history.sql
+++ b/supabase/migrations/20260910063557_fix_vote_club_history.sql
@@ -1,0 +1,146 @@
+-- Use the club recorded on each vote.  mp_club_membership is a term-level set
+-- and cannot identify which of an MP's clubs applied on a given date.
+-- A modal choice is meaningful only for at least five participating members
+-- and when exactly one choice has the highest count.  Rows from smaller clubs
+-- and tied club ballots are omitted rather than labelled aligned arbitrarily.
+create or replace view public.mp_vote_discipline as
+with choice_counts as (
+  select
+    v.voting_id,
+    v.term,
+    v.club_ref,
+    v.vote,
+    count(*)::integer as choice_count
+  from public.votes v
+  join public.votings vt on vt.id = v.voting_id
+  where vt.kind = 'ELECTRONIC'::public.voting_kind
+    and v.vote in (
+      'YES'::public.vote_choice,
+      'NO'::public.vote_choice,
+      'ABSTAIN'::public.vote_choice
+    )
+    and v.club_ref is not null
+  group by v.voting_id, v.term, v.club_ref, v.vote
+), choice_stats as (
+  select
+    cc.*,
+    sum(cc.choice_count) over (
+      partition by cc.voting_id, cc.term, cc.club_ref
+    ) as club_size,
+    max(cc.choice_count) over (
+      partition by cc.voting_id, cc.term, cc.club_ref
+    ) as max_count
+  from choice_counts cc
+), club_modal as (
+  select
+    voting_id,
+    term,
+    club_ref,
+    (array_agg(vote) filter (where choice_count = max_count))[1] as modal_choice
+  from choice_stats
+  group by voting_id, term, club_ref, club_size
+  having club_size >= 5
+     and count(*) filter (where choice_count = max_count) = 1
+)
+select
+  v.voting_id,
+  v.mp_id,
+  v.term,
+  c.id                    as club_id_at_vote,
+  cm.modal_choice         as club_modal_choice,
+  v.vote                  as mp_choice,
+  (v.vote = cm.modal_choice) as aligned
+from public.votes v
+join club_modal cm
+  on cm.voting_id = v.voting_id
+ and cm.term = v.term
+ and cm.club_ref = v.club_ref
+join public.clubs c
+  on c.term = v.term
+ and c.club_id = v.club_ref
+where v.vote in (
+  'YES'::public.vote_choice,
+  'NO'::public.vote_choice,
+  'ABSTAIN'::public.vote_choice
+);
+
+comment on view public.mp_vote_discipline is
+  'Per-vote-per-MP alignment against the unique club modal choice. Club at vote '
+  'comes from votes.club_ref. Includes electronic YES/NO/ABSTAIN ballots only; '
+  'excludes tied ballots and clubs with fewer than five participating members.';
+
+-- Keep every adjacent club change.  The old rn_in_club=1 filter discarded a
+-- later return to a previously represented club (for example A -> B -> A).
+create or replace function public.detect_mp_club_transitions(p_term integer)
+returns table (
+  mp_id integer,
+  change_date date,
+  from_club_short text,
+  to_club_short text
+)
+language sql
+stable
+as $$
+  with sorted_votes as (
+    select
+      v.mp_id,
+      vt.id as voting_id,
+      vt.date::date as voting_date,
+      v.club_ref as club_short,
+      lag(v.club_ref) over (
+        partition by v.mp_id order by vt.date, vt.id
+      ) as prev_club
+    from public.votes v
+    join public.votings vt on vt.id = v.voting_id
+    where vt.term = p_term
+      and v.club_ref is not null
+  ), transitions as (
+    select mp_id, voting_id, voting_date, prev_club, club_short
+    from sorted_votes
+    where prev_club is distinct from club_short
+  )
+  select distinct on (mp_id, voting_date, club_short)
+    mp_id,
+    voting_date as change_date,
+    prev_club as from_club_short,
+    club_short as to_club_short
+  from transitions
+  order by mp_id, voting_date, club_short, voting_id;
+$$;
+
+comment on function public.detect_mp_club_transitions(integer) is
+  'Returns the initial club and every adjacent club transition per MP, including returns to a previous club.';
+
+alter function public.detect_mp_club_transitions(integer) set statement_timeout = '60s';
+
+-- Detect watermarks created by the old "votes array is non-empty" predicate
+-- without transferring every full ballot JSON document through PostgREST.
+create or replace function public.incomplete_staged_votings(p_term integer)
+returns table (natural_id text)
+language sql
+stable
+security invoker
+as $$
+  select s.natural_id
+  from public._stage_votings s
+  where s.term = p_term
+    and not case
+      when jsonb_typeof(s.payload->'votes') = 'array'
+       and jsonb_typeof(s.payload->'totalVoted') = 'number'
+       and jsonb_typeof(s.payload->'notParticipating') = 'number'
+      then jsonb_array_length(s.payload->'votes')
+             = (s.payload->>'totalVoted')::integer + (s.payload->>'notParticipating')::integer
+       and (select count(*) from jsonb_array_elements(s.payload->'votes') row
+            where row->>'vote' = 'ABSENT') = (s.payload->>'notParticipating')::integer
+       and (select count(*) from jsonb_array_elements(s.payload->'votes') row
+            where row->>'vote' <> 'ABSENT') = (s.payload->>'totalVoted')::integer
+      else false
+    end;
+$$;
+
+revoke all on function public.incomplete_staged_votings(integer) from public;
+grant select on table public._stage_votings to service_role;
+grant execute on function public.incomplete_staged_votings(integer) to service_role;
+
+comment on function public.incomplete_staged_votings(integer) is
+  'Service-role ETL repair helper: returns only natural IDs of staged ballots whose vote rows disagree with participation totals.';

--- a/supagraf/cli.py
+++ b/supagraf/cli.py
@@ -15,6 +15,30 @@ from supagraf.stage import mp_office_expenses as stage_mp_office_expenses
 from supagraf.stage import promises as stage_promises
 
 app = typer.Typer(no_args_is_help=True, add_completion=False)
+
+
+@app.command("network")
+def cmd_network(
+    term: int = typer.Option(10, min=1),
+    days: int = typer.Option(180, min=1, max=365),
+    output: Path | None = typer.Option(None, "--output", help="Save the research snapshot as JSON"),
+    publish: bool = typer.Option(False, "--publish", help="Publish to the database after a successful build"),
+):
+    """Build the experimental network. Read-only unless --publish is supplied."""
+    import json
+    from supagraf.network import build_network
+
+    payload = build_network(term=term, days=days)
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    if publish:
+        from supagraf.network_publish import publish_network
+        publish_network(payload)
+    typer.echo(json.dumps({"term": term, "nodes": len(payload["nodes"]),
+                           "sampling": payload["sampling"], "published": publish}, ensure_ascii=False))
+
+
 enrich_app = typer.Typer(no_args_is_help=True, add_completion=False)
 app.add_typer(enrich_app, name="enrich", help="LLM/embedding enrichment over loaded prints")
 

--- a/supagraf/network.py
+++ b/supagraf/network.py
@@ -1,0 +1,556 @@
+"""Bounded, read-only politician-network snapshot from public Sejm data."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import date, datetime, timedelta, timezone
+from itertools import combinations
+from typing import Any, Callable, Iterable
+import json
+import sys
+from pathlib import Path
+
+import httpx
+
+from supagraf.db import supabase
+
+SCHEMA_VERSION = "1"
+MAX_VOTINGS, VOTING_SCAN_LIMIT, QUESTION_SCAN_LIMIT = 120, 600, 2_000
+TOP_EDGES_PER_MP, MIN_COMPARABLE_VOTES = 8, 20
+VALID_VOTES = frozenset(("YES", "NO", "ABSTAIN"))
+SOURCE_VOTES = VALID_VOTES | frozenset(("ABSENT", "PRESENT", "VOTE_VALID"))
+SUBSTANTIVE_POLARITIES = frozenset(("pass", "reject", "amendment", "minority"))
+
+
+def question_url(term: int, kind: str, num: int) -> str:
+    path = "interpellations" if kind == "interpellation" else "writtenQuestions"
+    return f"https://api.sejm.gov.pl/sejm/term{term}/{path}/{num}"
+
+
+def voting_url(term: int, sitting: int | None, num: int | None) -> str | None:
+    return (
+        None
+        if sitting is None or num is None
+        else f"https://api.sejm.gov.pl/sejm/term{term}/votings/{sitting}/{num}"
+    )
+
+
+def _date(value: Any) -> str | None:
+    return None if value is None else str(value)[:10]
+
+
+def _pair(a: int, b: int) -> tuple[int, int]:
+    return (a, b) if a < b else (b, a)
+
+
+def _top(edges: list[dict[str, Any]], layer: str) -> list[dict[str, Any]]:
+    key = (
+        (lambda e: (-e["weight"], -e["coauthored_count"], e["a"], e["b"]))
+        if layer == "questions"
+        else (lambda e: (-e["excess"], -e["agreement"], -e["n"], e["a"], e["b"]))
+    )
+    per_mp: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for edge in edges:
+        per_mp[edge["a"]].append(edge)
+        per_mp[edge["b"]].append(edge)
+    keep = {
+        (e["a"], e["b"])
+        for rows in per_mp.values()
+        for e in sorted(rows, key=key)[:TOP_EDGES_PER_MP]
+    }
+    return sorted((e for e in edges if (e["a"], e["b"]) in keep), key=key)
+
+
+def build_question_edges(
+    questions: Iterable[dict[str, Any]], *, term: int
+) -> list[dict[str, Any]]:
+    """Fractional one-mode projection of question-author hyperedges."""
+    totals: dict[tuple[int, int], dict[str, Any]] = {}
+    for q in questions:
+        authors = sorted({int(x) for x in q.get("authors", []) if x is not None})
+        if len(authors) < 2:
+            continue
+        evidence = {
+            "question_id": int(q["id"]),
+            "num": int(q["num"]),
+            "date": _date(q.get("sent_date") or q.get("receipt_date")),
+            "title": str(q.get("title") or ""),
+            "url": question_url(
+                term, str(q.get("kind") or "interpellation"), int(q["num"])
+            ),
+        }
+        for a, b in combinations(authors, 2):
+            edge = totals.setdefault(
+                (a, b),
+                {"a": a, "b": b, "weight": 0.0, "coauthored_count": 0, "evidence": []},
+            )
+            edge["weight"] += 1 / (len(authors) - 1)
+            edge["coauthored_count"] += 1
+            edge["evidence"].append(evidence)
+    out = []
+    for edge in totals.values():
+        edge["weight"] = round(edge["weight"], 6)
+        edge["evidence"] = sorted(
+            edge["evidence"],
+            key=lambda x: (x["date"] or "", x["question_id"]),
+            reverse=True,
+        )[:5]
+        out.append(edge)
+    return _top(out, "questions")
+
+
+def _modal(rows: list[dict[str, Any]]) -> dict[str, str]:
+    clubs: dict[str, list[str]] = defaultdict(list)
+    for row in rows:
+        clubs[str(row["club_ref"])].append(str(row["vote"]))
+    out: dict[str, str] = {}
+    for club, votes in clubs.items():
+        counts, maximum = Counter(votes), max(Counter(votes).values())
+        winners = [vote for vote, n in counts.items() if n == maximum]
+        if len(votes) >= 5 and len(winners) == 1:
+            out[club] = winners[0]
+    return out
+
+
+def build_vote_layer(
+    votings: Iterable[dict[str, Any]], *, term: int
+) -> dict[str, list[dict[str, Any]]]:
+    """MP pair agreement and leave-one-out deviations, using vote-time clubs."""
+    pairs: dict[tuple[int, int], Counter[str]] = defaultdict(Counter)
+    evidence: dict[tuple[int, int], list[dict[str, Any]]] = defaultdict(list)
+    deviations: dict[int, Counter[str]] = defaultdict(Counter)
+    for voting in votings:
+        rows = [
+            r
+            for r in voting.get("votes", [])
+            if r.get("vote") in VALID_VOTES and r.get("club_ref")
+        ]
+        if (
+            not rows
+            or max(Counter(str(r["vote"]) for r in rows).values()) / len(rows) >= 0.95
+        ):
+            continue
+        modal = _modal(rows)
+        ev = {
+            "voting_id": int(voting["id"]),
+            "date": _date(voting.get("date")),
+            "title": str(voting.get("title") or voting.get("topic") or ""),
+            "url": voting_url(term, voting.get("sitting"), voting.get("voting_number")),
+        }
+        for left, right in combinations(sorted(rows, key=lambda r: int(r["mp_id"])), 2):
+            left_club, right_club = str(left["club_ref"]), str(right["club_ref"])
+            # Same condition for observed and baseline agreement: cross-club,
+            # uniquely modal clubs. This prevents denominator drift.
+            if (
+                left_club == right_club
+                or left_club not in modal
+                or right_club not in modal
+            ):
+                continue
+            pair = _pair(int(left["mp_id"]), int(right["mp_id"]))
+            stat = pairs[pair]
+            stat["n"] += 1
+            stat["agree"] += left["vote"] == right["vote"]
+            stat["baseline_agree"] += modal[left_club] == modal[right_club]
+            if left["vote"] == right["vote"]:
+                evidence[pair].append(
+                    {**ev, "_surprising": modal[left_club] != modal[right_club]}
+                )
+        clubs: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in rows:
+            clubs[str(row["club_ref"])].append(row)
+        for members in clubs.values():
+            if len(members) < 6:
+                continue
+            for member in members:
+                counts = Counter(str(x["vote"]) for x in members if x is not member)
+                maximum = max(counts.values(), default=0)
+                winners = [v for v, n in counts.items() if n == maximum]
+                if maximum and len(winners) == 1:
+                    d = deviations[int(member["mp_id"])]
+                    d["n"] += 1
+                    d["deviations"] += member["vote"] != winners[0]
+    edges = []
+    for (a, b), stat in pairs.items():
+        n = int(stat["n"])
+        if n < MIN_COMPARABLE_VOTES or not stat["agree"]:
+            continue
+        agreement, baseline = stat["agree"] / n, stat["baseline_agree"] / n
+        proof = sorted(
+            evidence[(a, b)],
+            key=lambda x: (int(x["_surprising"]), x["date"] or "", x["voting_id"]),
+            reverse=True,
+        )[:5]
+        for item in proof:
+            item.pop("_surprising")
+        edges.append(
+            {
+                "a": a,
+                "b": b,
+                "n": n,
+                "agreement": round(agreement, 6),
+                "baseline_agreement": round(baseline, 6),
+                "excess": round(agreement - baseline, 6),
+                "evidence": proof,
+            }
+        )
+    rows = [
+        {
+            "mp_id": mp,
+            "n": int(s["n"]),
+            "deviations": int(s["deviations"]),
+            "rate": round(s["deviations"] / s["n"], 6),
+        }
+        for mp, s in deviations.items()
+        if s["n"]
+    ]
+    return {
+        "edges": _top(edges, "votes"),
+        "mp_deviations": sorted(rows, key=lambda d: (-d["rate"], -d["n"], d["mp_id"])),
+    }
+
+
+def _pages(
+    client: Any,
+    table: str,
+    columns: str,
+    configure: Callable[[Any], Any],
+    *,
+    limit: int | None = None,
+    page_size: int = 1_000,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    start = 0
+    while limit is None or len(out) < limit:
+        size = min(page_size, limit - len(out)) if limit is not None else page_size
+        page = (
+            configure(client.table(table).select(columns))
+            .range(start, start + size - 1)
+            .execute()
+            .data
+            or []
+        )
+        out.extend(page)
+        if len(page) < size:
+            break
+        start += size
+    return out
+
+
+def _in_pages(
+    client: Any,
+    table: str,
+    columns: str,
+    column: str,
+    values: list[int],
+    *,
+    chunk: int = 100,
+    page_size: int = 1_000,
+) -> list[dict[str, Any]]:
+    """Avoid oversized PostgREST URLs when a bounded read has many IDs."""
+    out: list[dict[str, Any]] = []
+    secondary = {
+        "question_authors": "mp_id",
+        "voting_print_links": "print_id",
+        "votes": "mp_id",
+    }.get(table)
+    for start in range(0, len(values), chunk):
+        part = values[start : start + chunk]
+        out.extend(
+            _pages(
+                client,
+                table,
+                columns,
+                lambda q, part=part: q.in_(column, part).order(column).order(secondary)
+                if secondary
+                else q.in_(column, part).order(column),
+                page_size=page_size,
+            )
+        )
+    return out
+
+
+def _validate_source_ballots(
+    voting: dict[str, Any], rows: list[dict[str, Any]], *, mp_key: str
+) -> None:
+    """Reject incomplete or malformed ballot sets before a snapshot is emitted."""
+    expected = int(voting.get("totalVoted", voting.get("total_voted", 0))) + int(
+        voting.get("notParticipating", voting.get("not_participating", 0))
+    )
+    ids: list[int] = []
+    for row in rows:
+        try:
+            mp_id = int(row.get(mp_key))
+        except (TypeError, ValueError):
+            raise RuntimeError("invalid ballot MP id") from None
+        if mp_id <= 0 or row.get("vote") not in SOURCE_VOTES:
+            raise RuntimeError("invalid ballot row")
+        ids.append(mp_id)
+    if expected <= 0 or len(rows) != expected or len(set(ids)) != len(ids):
+        raise RuntimeError("incomplete ballot set")
+
+
+def _ballots_from_stage(
+    client: Any, selected: list[dict[str, Any]], term: int
+) -> dict[int, list[dict[str, Any]]]:
+    keys = [f"{int(v['sitting'])}__{int(v['voting_number'])}" for v in selected]
+    stage: list[dict[str, Any]] = []
+    for start in range(0, len(keys), 50):
+        part = keys[start : start + 50]
+        stage.extend(
+            _pages(
+                client,
+                "_stage_votings",
+                "natural_id,payload",
+                lambda q, part=part: q.eq("term", term)
+                .in_("natural_id", part)
+                .order("natural_id"),
+            )
+        )
+    payload_by_key = {str(row["natural_id"]): row.get("payload") or {} for row in stage}
+    out: dict[int, list[dict[str, Any]]] = {}
+    for voting, key in zip(selected, keys):
+        payload = payload_by_key.get(key)
+        votes = payload.get("votes") if isinstance(payload, dict) else None
+        if not isinstance(votes, list) or not votes:
+            raise RuntimeError("incomplete stage ballots")
+        _validate_source_ballots(payload, votes, mp_key="MP")
+        out[int(voting["id"])] = [
+            {
+                "mp_id": row.get("MP"),
+                "club_ref": row.get("club"),
+                "vote": row.get("vote"),
+            }
+            for row in votes
+        ]
+    return out
+
+
+def _ballots_from_official_api(
+    selected: list[dict[str, Any]], term: int
+) -> dict[int, list[dict[str, Any]]]:
+    """Fallback used only when staged ballots are unavailable; validates all rows."""
+    out: dict[int, list[dict[str, Any]]] = {}
+    with httpx.Client(timeout=12.0, headers={"Accept": "application/json"}) as http:
+        for voting in selected:
+            url = voting_url(term, voting.get("sitting"), voting.get("voting_number"))
+            if not url:
+                raise RuntimeError("selected voting has no official URL")
+            response = http.get(url)
+            response.raise_for_status()
+            payload = response.json()
+            votes = payload.get("votes") if isinstance(payload, dict) else None
+            if not isinstance(votes, list) or not votes:
+                raise RuntimeError("incomplete official ballots")
+            _validate_source_ballots(payload, votes, mp_key="MP")
+            out[int(voting["id"])] = [
+                {
+                    "mp_id": row.get("MP"),
+                    "club_ref": row.get("club"),
+                    "vote": row.get("vote"),
+                }
+                for row in votes
+            ]
+    return out
+
+
+def _load_ballots(
+    client: Any, selected: list[dict[str, Any]], term: int
+) -> tuple[dict[int, list[dict[str, Any]]], str]:
+    try:
+        ballots = _ballots_from_stage(client, selected, term)
+        _require_complete_ballots(selected, ballots)
+        return ballots, "stage_payload"
+    except Exception:
+        # No partial output: either every selected ballot arrives from the
+        # fallback, or the caller receives a generic failure from main().
+        ballots = _ballots_from_official_api(selected, term)
+        _require_complete_ballots(selected, ballots)
+        return ballots, "official_api"
+
+
+def _require_complete_ballots(
+    selected: list[dict[str, Any]], ballots: dict[int, list[dict[str, Any]]]
+) -> None:
+    for voting in selected:
+        rows = ballots.get(int(voting["id"]))
+        if not rows:
+            raise RuntimeError("incomplete ballot set")
+        _validate_source_ballots(voting, rows, mp_key="mp_id")
+
+
+def build_network(
+    *,
+    term: int = 10,
+    days: int = 180,
+    client: Any | None = None,
+    today: date | None = None,
+) -> dict[str, Any]:
+    """Read PostgREST only and return a compact JSON-safe public-data snapshot."""
+    if days < 1:
+        raise ValueError("days must be positive")
+    client, today = client or supabase(), today or datetime.now(timezone.utc).date()
+    since = (today - timedelta(days=days)).isoformat()
+    mps = _pages(
+        client,
+        "mps",
+        "mp_id,first_last_name,club_ref,active,photo_url",
+        lambda q: q.eq("term", term).order("mp_id"),
+    )
+    nodes = [
+        {
+            "mp_id": int(m["mp_id"]),
+            "name": str(m.get("first_last_name") or ""),
+            "photo_url": m.get("photo_url"),
+            "current_club": m.get("club_ref"),
+            "active": bool(m.get("active")),
+        }
+        for m in mps
+    ]
+    questions = _pages(
+        client,
+        "questions",
+        "id,kind,num,title,sent_date,receipt_date",
+        lambda q: q.eq("term", term)
+        .gte("sent_date", since)
+        .lte("sent_date", today.isoformat())
+        .order("sent_date", desc=True)
+        .order("id", desc=True),
+        limit=QUESTION_SCAN_LIMIT,
+    )
+    ids = [int(q["id"]) for q in questions]
+    authors = (
+        _in_pages(client, "question_authors", "question_id,mp_id", "question_id", ids)
+        if ids
+        else []
+    )
+    by_question: dict[int, list[int]] = defaultdict(list)
+    for row in authors:
+        by_question[int(row["question_id"])].append(int(row["mp_id"]))
+    for q in questions:
+        q["authors"] = by_question[int(q["id"])]
+    candidates = _pages(
+        client,
+        "votings",
+        "id,date,title,topic,sitting,voting_number,motion_polarity,kind,total_voted,not_participating",
+        lambda q: q.eq("term", term)
+        .eq("kind", "ELECTRONIC")
+        .gte("date", since)
+        .lt("date", (today + timedelta(days=1)).isoformat())
+        .order("date", desc=True)
+        .order("id", desc=True),
+        limit=VOTING_SCAN_LIMIT,
+    )
+    eligible = [
+        v for v in candidates if v.get("motion_polarity") in SUBSTANTIVE_POLARITIES
+    ]
+    candidate_ids = [int(v["id"]) for v in eligible]
+    links = (
+        _in_pages(
+            client,
+            "voting_print_links",
+            "voting_id,print_id",
+            "voting_id",
+            candidate_ids,
+        )
+        if candidate_ids
+        else []
+    )
+    print_ids = sorted({int(x["print_id"]) for x in links})
+    prints = (
+        _in_pages(
+            client, "prints", "id,number,is_primary,parent_number", "id", print_ids
+        )
+        if print_ids
+        else []
+    )
+    print_map = {int(p["id"]): p for p in prints}
+    blocks: dict[int, str] = {}
+    for link in links:
+        p = print_map.get(int(link["print_id"]))
+        block = p and (
+            p.get("number") if p.get("is_primary") else p.get("parent_number")
+        )
+        if block:
+            blocks[int(link["voting_id"])] = str(block)
+    selected: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for voting in eligible:
+        block = blocks.get(int(voting["id"]))
+        if block and block in seen:
+            continue
+        selected.append(voting)
+        if block:
+            seen.add(block)
+        if len(selected) == MAX_VOTINGS:
+            break
+    selected_ids = [int(v["id"]) for v in selected]
+    by_voting, ballot_transport = (
+        _load_ballots(client, selected, term) if selected_ids else ({}, "none")
+    )
+    for voting in selected:
+        voting["votes"] = by_voting[int(voting["id"])]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "term": term,
+        "window": {"days": days, "from": since, "to": today.isoformat()},
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "sampling": {
+            "questions": {
+                "scan_limit": QUESTION_SCAN_LIMIT,
+                "selected": len(questions),
+                "with_multiple_authors": sum(len(q["authors"]) > 1 for q in questions),
+                "without_authors": sum(not q["authors"] for q in questions),
+                "author_rows": len(authors),
+                "cap_reached": len(questions) == QUESTION_SCAN_LIMIT,
+            },
+            "votings": {
+                "scan_limit": VOTING_SCAN_LIMIT,
+                "candidate_rows": len(candidates),
+                "eligible": len(eligible),
+                "selected": len(selected),
+                "limit": MAX_VOTINGS,
+                "ballot_transport": ballot_transport,
+                "selection": "latest substantive ELECTRONIC; at most one per linked primary-print block when available",
+            },
+        },
+        "nodes": nodes,
+        "layers": {
+            "questions": {"edges": build_question_edges(questions, term=term)},
+            "votes": build_vote_layer(selected, term=term),
+        },
+        "limitations": [
+            "Krawędzie pokazują wyłącznie wspólne autorstwo pytania lub zgodność oddanych głosów; nie wyjaśniają motywów ani nie przewidują zmiany klubu.",
+            "Pominięto nieobecności, obecność bez głosu, głosy listowe, głosy proceduralne i głosy, w których 95% lub więcej ważnych głosów było identycznych.",
+            "To ograniczona próba najnowszych głosowań, a nie pełna kadencja; liczby próby są podane przy wykresie.",
+            "Nazwa aktualnego klubu służy do opisu, a porównanie głosów używa klubu wpisanego przy tym głosowaniu.",
+        ],
+    }
+
+
+def main() -> int:
+    """Small safe runner: never serialize environment or transport errors."""
+    try:
+        snapshot = build_network()
+        output = Path(".tmp_supagraf/network-preview.json")
+        output.parent.mkdir(exist_ok=True)
+        output.write_text(
+            json.dumps(snapshot, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        print(
+            json.dumps(
+                {"output": str(output), "sampling": snapshot["sampling"]},
+                ensure_ascii=False,
+            )
+        )
+    except Exception:  # credentials and response bodies can be sensitive/noisy
+        print(
+            "Nie udało się odczytać danych sieci. Sprawdź konfigurację i dostępność bazy.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supagraf/network_publish.py
+++ b/supagraf/network_publish.py
@@ -1,0 +1,35 @@
+"""Atomic publication of a fully built network; failed builds keep the last result."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from supagraf.db import supabase
+
+
+def refresh_network(*, term: int = 10, days: int = 180) -> dict[str, Any]:
+    from supagraf.network import build_network
+
+    payload = build_network(term=term, days=days)
+    return publish_network(payload)
+
+
+def publish_network(payload: dict[str, Any]) -> dict[str, Any]:
+    term = payload.get("term")
+    if payload.get("schema_version") != "1" or not isinstance(term, int) or term <= 0:
+        raise ValueError("Network builder returned an incompatible snapshot")
+    # A single upsert is transactional. Do not delete/clear the prior graph first.
+    supabase().table("politician_network_snapshots").upsert(
+        {
+            "term": term,
+            "generated_at": payload["generated_at"],
+            "payload": payload,
+        },
+        on_conflict="term",
+    ).execute()
+    return {
+        "nodes": len(payload["nodes"]),
+        "question_edges": len(payload["layers"]["questions"]["edges"]),
+        "vote_edges": len(payload["layers"]["votes"]["edges"]),
+        "generated_at": payload["generated_at"],
+    }

--- a/supagraf/sync/daily.py
+++ b/supagraf/sync/daily.py
@@ -27,6 +27,7 @@ from loguru import logger
 from supagraf.sync.context import SyncContext
 from supagraf.sync.http import SejmApi
 from supagraf.sync.loaders import run_loaders, run_refreshes
+from supagraf.sync.load_recovery import PendingLoad, clear_pending, merge_pending, read_pending, write_pending
 from supagraf.sync.runlog import RunLedger, ensure_schema
 from supagraf.sync.stage import SyncResult
 
@@ -83,7 +84,7 @@ def _sync_phase(ctx: SyncContext, ledger: RunLedger, only: tuple[str, ...] | Non
         _run(ledger, "sync:polls", polls)
 
 
-def _load_phase(ctx: SyncContext, ledger: RunLedger, full: bool) -> None:
+def _load_phase(ctx: SyncContext, ledger: RunLedger, full: bool) -> bool:
     from supagraf.backfill import backfill_print_committee_sitting_links
     from supagraf.backfill.agenda_refs import relink_agenda_print_refs
     from supagraf.backfill.mp_club_history import backfill_mp_club_history
@@ -92,8 +93,11 @@ def _load_phase(ctx: SyncContext, ledger: RunLedger, full: bool) -> None:
     from supagraf.fetch.acts import refresh_stale_eli
 
     term, dirty = ctx.term, ctx.dirty
+    first_step = len(ledger.steps)
     _run(ledger, "load", lambda: {"dirty": sorted(dirty),
                                   **run_loaders(term, dirty, full=full, changed_keys=ctx.changed_keys)})
+    if ledger.steps[-1].status == "failed":
+        return False
     if {"prints", "processes"} & dirty and "proceedings" not in dirty:
         _run(ledger, "load:relink_agenda_refs", lambda: relink_agenda_print_refs(term=term))
     if {"prints", "committee_sittings"} & dirty or full:
@@ -114,6 +118,7 @@ def _load_phase(ctx: SyncContext, ledger: RunLedger, full: bool) -> None:
         ctx.mark("acts", bool(out.get("fetched_acts")))
         return {k: v for k, v in out.items() if k != "sample_eli"}
     _run(ledger, "backfill:refresh_stale_eli", stale_eli)
+    return not any(s.status == "failed" for s in ledger.steps[first_step:])
 
 
 def _enrich_phase(ctx: SyncContext, ledger: RunLedger, workers: int | None) -> None:
@@ -145,6 +150,21 @@ def _embed_phase(ctx: SyncContext, ledger: RunLedger) -> None:
     _run(ledger, "embed:promises", lambda: cmd_enrich_promises(kind="embed", limit=limit))
 
 
+def _network_phase(ctx: SyncContext, ledger: RunLedger, *, skip_load: bool, load_succeeded: bool) -> None:
+    """Publish only when source dependencies are healthy. Retry every daily run.
+
+    A bounded rebuild also expires documents outside the rolling time window,
+    even when upstream is unchanged, and retries earlier publication failures.
+    """
+    dependencies = {"sync:mps", "sync:clubs", "sync:questions", "sync:votings",
+                    "sync:prints", "sync:processes", "load", "backfill:sitting_links"}
+    if skip_load or not load_succeeded or any(s.name in dependencies for s in ledger.failed_steps):
+        ledger.skip("network", "source sync/load incomplete or --skip-load; previous snapshot preserved")
+        return
+    from supagraf.network_publish import refresh_network
+    _run(ledger, "network", lambda: refresh_network(term=ctx.term))
+
+
 def run_daily(
     *,
     term: int = 10,
@@ -169,6 +189,7 @@ def run_daily(
     own_api = api is None
     api = api or SejmApi(concurrency=concurrency)
     ctx = SyncContext(term=term, api=api, full=full, window_days=window_days)
+    load_succeeded = True
     try:
         if skip_fetch:
             ledger.skip("sync", "--skip-fetch (all resources treated as dirty)")
@@ -176,27 +197,63 @@ def run_daily(
         else:
             _sync_phase(ctx, ledger, only)
 
-        if skip_load:
-            ledger.skip("load", "--skip-load")
-        elif not ctx.dirty and not full:
-            ledger.skip("load", "nothing changed upstream")
-        else:
-            _load_phase(ctx, ledger, full)
+        if full:
+            # Preserve the complete plan for a retry even if --full found no diff.
+            ctx.dirty |= set(RESOURCES) | EXTERNAL
+            ctx.changed_keys.clear()
 
-        if skip_enrich:
+        pending: PendingLoad | None = None
+        with ledger.step("load:recover") as step:
+            pending = merge_pending(
+                PendingLoad(dirty=set(ctx.dirty), changed_keys={k: set(v) for k, v in ctx.changed_keys.items()}),
+                read_pending(term),
+            )
+            ctx.dirty, ctx.changed_keys = pending.dirty, pending.changed_keys
+            step.counts = {"dirty": sorted(ctx.dirty)}
+        if ledger.steps[-1].status == "failed":
+            load_succeeded = False
+            ledger.skip("load", "pending-load cursor unavailable")
+        elif ctx.dirty or full:
+            with ledger.step("load:checkpoint") as step:
+                write_pending(term, pending or PendingLoad())
+                step.counts = {"dirty": sorted(ctx.dirty)}
+            if ledger.steps[-1].status == "failed":
+                load_succeeded = False
+                ledger.skip("load", "pending-load checkpoint failed")
+            elif skip_load:
+                ledger.skip("load", "--skip-load; pending checkpoint preserved")
+            else:
+                load_succeeded = _load_phase(ctx, ledger, full)
+                if load_succeeded:
+                    with ledger.step("load:clear_checkpoint"):
+                        clear_pending(term)
+                    load_succeeded = ledger.steps[-1].status != "failed"
+        elif skip_load:
+            ledger.skip("load", "--skip-load")
+        else:
+            ledger.skip("load", "nothing changed upstream")
+
+        if not load_succeeded:
+            ledger.skip("enrich", "load failed")
+        elif skip_enrich:
             ledger.skip("enrich", "--skip-enrich")
         else:
             _enrich_phase(ctx, ledger, workers)
 
-        if skip_embed or os.environ.get("SUPAGRAF_DAILY_SKIP_EMBED") == "1":
+        if not load_succeeded:
+            ledger.skip("embed", "load failed")
+        elif skip_embed or os.environ.get("SUPAGRAF_DAILY_SKIP_EMBED") == "1":
             ledger.skip("embed", "--skip-embed / SUPAGRAF_DAILY_SKIP_EMBED")
         else:
             _embed_phase(ctx, ledger)
 
-        if skip_load:
+        if not load_succeeded:
+            ledger.skip("refresh", "load failed")
+        elif skip_load:
             ledger.skip("refresh", "--skip-load")
         else:
             _run(ledger, "refresh", lambda: run_refreshes(term, ctx.dirty, full=full))
+        _network_phase(ctx, ledger, skip_load=skip_load, load_succeeded=load_succeeded)
     finally:
         if own_api:
             api.close()

--- a/supagraf/sync/load_recovery.py
+++ b/supagraf/sync/load_recovery.py
@@ -1,0 +1,67 @@
+"""Durable checkpoint for staged resources that still need SQL loading."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+from supagraf.sync import cursors
+
+
+@dataclass
+class PendingLoad:
+    dirty: set[str] = field(default_factory=set)
+    changed_keys: dict[str, set[int]] = field(default_factory=dict)
+
+
+def cursor_name(term: int) -> str:
+    return f"pending_load.term{term}"
+
+
+def read_pending(term: int) -> PendingLoad:
+    raw = cursors.get_cursor(cursor_name(term))
+    if not raw:
+        return PendingLoad()
+    value = json.loads(raw)
+    dirty = {str(name) for name in value.get("dirty", [])}
+    keys = {
+        str(name): {int(key) for key in items}
+        for name, items in value.get("changed_keys", {}).items()
+        if name in dirty
+    }
+    return PendingLoad(dirty=dirty, changed_keys=keys)
+
+
+def merge_pending(current: PendingLoad, previous: PendingLoad) -> PendingLoad:
+    """Merge plans without narrowing a resource whose keys are unknown.
+
+    A dirty resource absent from ``changed_keys`` means a whole-term load.  It
+    remains whole-term even if the other plan happens to carry targeted keys.
+    """
+    dirty = current.dirty | previous.dirty
+    keys: dict[str, set[int]] = {}
+    for resource in dirty:
+        plans = [p for p in (current, previous) if resource in p.dirty]
+        if all(p.changed_keys.get(resource) for p in plans):
+            keys[resource] = set().union(*(p.changed_keys[resource] for p in plans))
+    return PendingLoad(dirty=dirty, changed_keys=keys)
+
+
+def write_pending(term: int, pending: PendingLoad) -> None:
+    cursors.set_cursor(
+        cursor_name(term),
+        json.dumps(
+            {
+                "dirty": sorted(pending.dirty),
+                "changed_keys": {
+                    name: sorted(keys)
+                    for name, keys in sorted(pending.changed_keys.items())
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+
+def clear_pending(term: int) -> None:
+    write_pending(term, PendingLoad())

--- a/supagraf/sync/resources/votings.py
+++ b/supagraf/sync/resources/votings.py
@@ -4,13 +4,15 @@ The index lists `{date, proceeding, votingsNum}`; per-MP votes only exist
 on `/votings/{sitting}/{num}`. A sitting is touched when the index reports
 more votings than the stage holds, or when it still has unsealed votings
 (detail captured before the vote rows were published). Sealed votings
-(`etl_watermarks` entity `voting`) are never refetched.
+(`etl_watermarks` entity `voting`) are refetched if their staged rows fail
+the completeness check introduced after legacy seals were written.
 """
 from __future__ import annotations
 
 from collections import defaultdict
 
 from supagraf.etl import watermark
+from supagraf.db import supabase
 from supagraf.schema.votings import Voting
 from supagraf.sync import stage
 from supagraf.sync.context import SyncContext
@@ -22,6 +24,31 @@ TABLE = "_stage_votings"
 
 def seal_key(term: int, sitting: int, num: int) -> str:
     return f"term{term}__{sitting}__{num}"
+
+
+def has_complete_vote_rows(payload: dict) -> bool:
+    """Whether the detail contains the complete per-MP ballot snapshot.
+
+    The API can briefly publish a non-empty, partial ``votes`` array.  A row is
+    immutable only after both participation totals agree with the array.
+    ``VOTE_VALID`` (list ballots) counts as participating, hence the generic
+    non-ABSENT check rather than summing YES/NO/ABSTAIN/PRESENT.
+    """
+    votes = payload.get("votes")
+    total_voted = payload.get("totalVoted")
+    not_participating = payload.get("notParticipating")
+    if not isinstance(votes, list) or not isinstance(total_voted, int) or not isinstance(not_participating, int):
+        return False
+    if len(votes) != total_voted + not_participating:
+        return False
+    absent = sum(1 for row in votes if isinstance(row, dict) and row.get("vote") == "ABSENT")
+    participating = sum(1 for row in votes if isinstance(row, dict) and row.get("vote") != "ABSENT")
+    return absent == not_participating and participating == total_voted
+
+
+def _incomplete_staged_ids(term: int) -> set[str]:
+    rows = supabase().rpc("incomplete_staged_votings", {"p_term": term}).execute().data or []
+    return {str(row["natural_id"]) for row in rows}
 
 
 def plan_sittings(index: list[dict], stored: set[str], sealed: set[str], term: int, full: bool) -> list[int]:
@@ -41,7 +68,13 @@ def sync(ctx: SyncContext) -> SyncResult:
     index = ctx.api.get_json(f"{ctx.base}/votings") or []
     res.listed = sum(int(g.get("votingsNum") or 0) for g in index)
     stored_ids = set(stage.read_index(TABLE, ctx.term))
-    sealed = watermark.load_sealed("voting")
+    # Old updater versions sealed any non-empty vote list.  Ignore such a seal
+    # when the staged payload fails the stronger completeness invariant; the
+    # refetch repairs the stage and the existing watermark becomes valid.
+    incomplete = _incomplete_staged_ids(ctx.term)
+    sealed = watermark.load_sealed("voting") - {
+        seal_key(ctx.term, *map(int, nid.split("__"))) for nid in incomplete
+    }
     sittings = plan_sittings(index, stored_ids, sealed, ctx.term, ctx.full)
     res.notes["sittings_touched"] = sittings
 
@@ -59,7 +92,8 @@ def sync(ctx: SyncContext) -> SyncResult:
                              stored=stage.read_payloads(TABLE, ctx.term, targets))
     sittings_written = {int(nid.split("__")[0]) for nid in written}
     res.notes["written_sittings"] = sorted(sittings_written)
-    to_seal = [seal_key(ctx.term, *map(int, nid.split("__"))) for nid, d, _ in items if d.get("votes")]
+    to_seal = [seal_key(ctx.term, *map(int, nid.split("__")))
+               for nid, d, _ in items if has_complete_vote_rows(d)]
     if to_seal and not res.errors:
         watermark.bulk_seal("voting", to_seal, source="predicate_votes_captured")
     ctx.mark("votings", res.dirty, sittings_written)

--- a/tests/supagraf/unit/sync/conftest.py
+++ b/tests/supagraf/unit/sync/conftest.py
@@ -96,4 +96,9 @@ def fake_stage(monkeypatch) -> FakeStage:
     monkeypatch.setattr(watermark, "load_sealed", lambda entity: fs.sealed.get(entity, set()))
     monkeypatch.setattr(watermark, "bulk_seal", lambda entity, keys, source: fs.sealed.setdefault(entity, set()).update(keys))
     monkeypatch.setattr(watermark, "seal", lambda entity, key, source="predicate": fs.sealed.setdefault(entity, set()).add(key))
+    from supagraf.sync.resources import votings
+    monkeypatch.setattr(votings, "_incomplete_staged_ids", lambda term: {
+        nid for nid, payload in fs.tables.get("_stage_votings", {}).items()
+        if not votings.has_complete_vote_rows(payload)
+    })
     return fs

--- a/tests/supagraf/unit/sync/test_daily.py
+++ b/tests/supagraf/unit/sync/test_daily.py
@@ -11,7 +11,10 @@ from supagraf.sync.stage import SyncResult
 @pytest.fixture
 def stubs(monkeypatch):
     calls: dict[str, list] = {"loaders": [], "refresh": [], "resources": []}
+    pending = daily.PendingLoad()
     monkeypatch.setattr(daily, "ensure_schema", lambda: None)
+    import supagraf.network_publish as network_publish
+    monkeypatch.setattr(network_publish, "refresh_network", lambda **kwargs: calls.setdefault("network", []).append(kwargs) or {})
 
     def fake_resource(name):
         def _sync(ctx):
@@ -28,6 +31,18 @@ def stubs(monkeypatch):
     monkeypatch.setattr(daily, "_resource_fn", fake_resource)
     monkeypatch.setattr(daily, "run_loaders", lambda term, dirty, full=False, changed_keys=None: calls["loaders"].append((sorted(dirty), full)) or {})
     monkeypatch.setattr(daily, "run_refreshes", lambda term, dirty, full=False: calls["refresh"].append((sorted(dirty), full)) or {})
+
+    def read_pending(_term):
+        return daily.PendingLoad(set(pending.dirty), {k: set(v) for k, v in pending.changed_keys.items()})
+
+    def write_pending(_term, value):
+        pending.dirty = set(value.dirty)
+        pending.changed_keys = {k: set(v) for k, v in value.changed_keys.items()}
+
+    monkeypatch.setattr(daily, "read_pending", read_pending)
+    monkeypatch.setattr(daily, "write_pending", write_pending)
+    monkeypatch.setattr(daily, "clear_pending", lambda _term: write_pending(_term, daily.PendingLoad()))
+    calls["pending"] = pending
     import supagraf.backfill.agenda_refs as ar
     monkeypatch.setattr(ar, "relink_agenda_print_refs", lambda term: calls.setdefault("relink", []).append(term))
 
@@ -92,6 +107,22 @@ def test_full_runs_every_loader(stubs):
     assert stubs["loaders"][0][1] is True
 
 
+def test_failed_full_load_is_retried_as_whole_term(monkeypatch, stubs):
+    monkeypatch.setattr(daily, "_resource_fn", lambda name: lambda ctx: SyncResult(resource=name))
+    attempts = []
+
+    def flaky_load(term, dirty, full=False, changed_keys=None):
+        attempts.append(set(dirty))
+        if len(attempts) == 1:
+            raise RuntimeError("failed full reload")
+        return {}
+
+    monkeypatch.setattr(daily, "run_loaders", flaky_load)
+    daily.run_daily(full=True, skip_enrich=True, skip_embed=True, persist_ledger=False)
+    daily.run_daily(skip_enrich=True, skip_embed=True, persist_ledger=False)
+    assert attempts == [set(daily.RESOURCES) | daily.EXTERNAL] * 2
+
+
 def test_only_restricts_sync(stubs):
     daily.run_daily(only=("prints",), skip_enrich=True, skip_embed=True, skip_load=True, persist_ledger=False)
     assert stubs["resources"] == ["prints"]
@@ -106,3 +137,60 @@ def test_schema_missing_is_fatal(monkeypatch):
     monkeypatch.setattr(daily, "ensure_schema", boom)
     with pytest.raises(SchemaMissing):
         daily.run_daily(persist_ledger=False)
+
+
+def test_failed_load_skips_dependent_phases(monkeypatch, stubs):
+    def fail_load(*args, **kwargs):
+        raise RuntimeError("load broke")
+
+    monkeypatch.setattr(daily, "run_loaders", fail_load)
+    monkeypatch.setattr(daily, "_enrich_phase", lambda *args: pytest.fail("enrich ran after failed load"))
+    monkeypatch.setattr(daily, "_embed_phase", lambda *args: pytest.fail("embed ran after failed load"))
+
+    led = daily.run_daily(persist_ledger=False)
+
+    steps = {s.name: s for s in led.steps}
+    assert steps["load"].status == "failed"
+    assert steps["enrich"].status == "skipped" and steps["enrich"].counts["reason"] == "load failed"
+    assert steps["embed"].status == "skipped" and steps["embed"].counts["reason"] == "load failed"
+    assert steps["refresh"].status == "skipped" and steps["refresh"].counts["reason"] == "load failed"
+    assert steps["network"].status == "skipped"
+    assert "network" not in stubs
+    assert stubs["refresh"] == []
+    assert "relink" not in stubs
+    assert "sitting_links" not in stubs
+    assert stubs.get("rpc", []) == []
+
+
+def test_failed_load_is_retried_next_run_when_upstream_is_unchanged(monkeypatch, stubs):
+    sync_runs = 0
+    load_attempts = []
+
+    def resource(name):
+        def sync(ctx):
+            nonlocal sync_runs
+            result = SyncResult(resource=name)
+            if name == "prints" and sync_runs == 0:
+                result.upserted = 1
+                ctx.mark("prints", True)
+            if name == daily.RESOURCES[-1]:
+                sync_runs += 1
+            return result
+        return sync
+
+    def flaky_load(term, dirty, full=False, changed_keys=None):
+        load_attempts.append((set(dirty), {k: set(v) for k, v in (changed_keys or {}).items()}))
+        if len(load_attempts) == 1:
+            raise RuntimeError("transient load failure")
+        return {}
+
+    monkeypatch.setattr(daily, "_resource_fn", resource)
+    monkeypatch.setattr(daily, "run_loaders", flaky_load)
+
+    first = daily.run_daily(skip_enrich=True, skip_embed=True, persist_ledger=False)
+    second = daily.run_daily(skip_enrich=True, skip_embed=True, persist_ledger=False)
+
+    assert first.exit_code == 1
+    assert load_attempts == [({"prints"}, {}), ({"prints"}, {})]
+    assert second.exit_code == 0
+    assert stubs["pending"].dirty == set()

--- a/tests/supagraf/unit/sync/test_load_recovery.py
+++ b/tests/supagraf/unit/sync/test_load_recovery.py
@@ -1,0 +1,26 @@
+from supagraf.sync.load_recovery import PendingLoad, merge_pending
+
+
+def test_merge_pending_unions_known_target_keys():
+    merged = merge_pending(
+        PendingLoad({"votings"}, {"votings": {64}}),
+        PendingLoad({"votings"}, {"votings": {63}}),
+    )
+    assert merged.changed_keys == {"votings": {63, 64}}
+
+
+def test_merge_pending_never_narrows_a_whole_term_retry():
+    merged = merge_pending(
+        PendingLoad({"votings"}, {"votings": {64}}),
+        PendingLoad({"votings"}, {}),
+    )
+    assert merged.dirty == {"votings"}
+    assert merged.changed_keys == {}
+
+
+def test_empty_key_set_also_means_whole_term():
+    merged = merge_pending(
+        PendingLoad({"votings"}, {"votings": {64}}),
+        PendingLoad({"votings"}, {"votings": set()}),
+    )
+    assert merged.changed_keys == {}

--- a/tests/supagraf/unit/sync/test_resources.py
+++ b/tests/supagraf/unit/sync/test_resources.py
@@ -108,18 +108,68 @@ def test_votings_plan_sittings():
 
 
 def test_votings_sync_fetches_missing_detail_only(routes, ctx, fake_stage, monkeypatch):
-    fake_stage.seed("_stage_votings", {"64__1": {"votingNumber": 1}})
+    fake_stage.seed("_stage_votings", {"64__1": {
+        "votingNumber": 1, "totalVoted": 1, "notParticipating": 0,
+        "votes": [{"MP": 1, "vote": "YES"}],
+    }})
     fake_stage.sealed["voting"] = {"term10__64__1"}
     monkeypatch.setattr(votings, "Voting", type("V", (), {"model_validate": staticmethod(lambda p: p)}))
     routes.add(f"{B}/votings", [{"date": "2026-09-03", "proceeding": 64, "votingsNum": 2}])
     routes.add(f"{B}/votings/64", [{"votingNumber": 1}, {"votingNumber": 2}])
-    routes.add(f"{B}/votings/64/2", {"sitting": 64, "votingNumber": 2, "votes": [{"MP": 1}]})
+    routes.add(f"{B}/votings/64/2", {"sitting": 64, "votingNumber": 2,
+                                              "totalVoted": 1, "notParticipating": 0,
+                                              "votes": [{"MP": 1, "vote": "YES"}]})
     res = votings.sync(ctx)
     assert res.fetched == 1 and res.upserted == 1 and res.skipped == 1
     assert routes.count("/votings/64/1") == 0
     assert fake_stage.sealed["voting"] == {"term10__64__1", "term10__64__2"}
     assert "votings" in ctx.dirty
     assert ctx.changed_keys["votings"] == {64}
+
+
+def test_vote_rows_complete_only_when_participation_totals_match():
+    complete = {"totalVoted": 2, "notParticipating": 1,
+                "votes": [{"vote": "YES"}, {"vote": "VOTE_VALID"}, {"vote": "ABSENT"}]}
+    assert votings.has_complete_vote_rows(complete)
+    assert not votings.has_complete_vote_rows({**complete, "votes": complete["votes"][:1]})
+    assert not votings.has_complete_vote_rows({**complete, "votes": [{"vote": "YES"}] * 3})
+
+
+def test_votings_refetches_previously_sealed_partial_payload(routes, ctx, fake_stage, monkeypatch):
+    partial = {"votingNumber": 1, "totalVoted": 2, "notParticipating": 0,
+               "votes": [{"MP": 1, "vote": "YES"}]}
+    complete = {**partial, "votes": [{"MP": 1, "vote": "YES"}, {"MP": 2, "vote": "NO"}]}
+    fake_stage.seed("_stage_votings", {"64__1": partial})
+    fake_stage.sealed["voting"] = {"term10__64__1"}
+    monkeypatch.setattr(votings, "Voting", type("V", (), {"model_validate": staticmethod(lambda p: p)}))
+    routes.add(f"{B}/votings", [{"date": "2026-09-03", "proceeding": 64, "votingsNum": 1}])
+    routes.add(f"{B}/votings/64", [{"votingNumber": 1}])
+    routes.add(f"{B}/votings/64/1", complete)
+
+    res = votings.sync(ctx)
+
+    assert res.fetched == 1 and res.upserted == 1
+    assert routes.count("/votings/64/1") == 1
+    assert votings.has_complete_vote_rows(fake_stage.tables["_stage_votings"]["64__1"])
+
+
+def test_votings_reads_payloads_only_for_planned_targets(routes, ctx, fake_stage, monkeypatch):
+    complete = {"votingNumber": 1, "totalVoted": 1, "notParticipating": 0,
+                "votes": [{"MP": 1, "vote": "YES"}]}
+    fake_stage.seed("_stage_votings", {"64__1": complete})
+    fake_stage.sealed["voting"] = {"term10__64__1"}
+    routes.add(f"{B}/votings", [{"date": "2026-09-03", "proceeding": 64, "votingsNum": 1}])
+    seen_ids = []
+    original = fake_stage.read_payloads
+
+    def bounded_read(table, term, ids=None, *, key_col="natural_id"):
+        seen_ids.append(ids)
+        assert ids is not None, "voting sync must not transfer every staged ballot payload"
+        return original(table, term, ids, key_col=key_col)
+
+    monkeypatch.setattr(votings.stage, "read_payloads", bounded_read)
+    votings.sync(ctx)
+    assert seen_ids == [[]]
 
 
 # ---- mps / clubs / committees ------------------------------------------------

--- a/tests/supagraf/unit/test_network.py
+++ b/tests/supagraf/unit/test_network.py
@@ -1,0 +1,108 @@
+import pytest
+
+from supagraf.network import (
+    _require_complete_ballots,
+    _validate_source_ballots,
+    build_question_edges,
+    build_vote_layer,
+)
+
+
+def test_question_projection_is_fractional_with_official_url():
+    edges = build_question_edges(
+        [
+            {
+                "id": 7,
+                "kind": "interpellation",
+                "num": 12,
+                "sent_date": "2026-09-01",
+                "title": "T",
+                "authors": [3, 1, 2],
+            }
+        ],
+        term=10,
+    )
+    assert len(edges) == 3
+    assert {edge["weight"] for edge in edges} == {0.5}
+    assert edges[0]["evidence"][0]["url"].endswith("/interpellations/12")
+
+
+def _voting(number: int, *, swapped: bool = False, tied: bool = False) -> dict:
+    a, b = ("B", "A") if swapped else ("A", "B")
+    a_votes = ["YES", "YES", "YES", "YES", "NO", "NO"]
+    b_votes = ["YES", "YES", "NO", "NO", "NO", "NO"]
+    if tied:
+        b_votes = ["YES", "YES", "YES", "NO", "NO", "NO"]
+    rows = [
+        {"mp_id": i + 1, "club_ref": a, "vote": vote} for i, vote in enumerate(a_votes)
+    ] + [
+        {"mp_id": i + 7, "club_ref": b, "vote": vote} for i, vote in enumerate(b_votes)
+    ]
+    return {
+        "id": number,
+        "date": "2026-09-01",
+        "title": f"G {number}",
+        "sitting": 1,
+        "voting_number": number,
+        "votes": rows,
+    }
+
+
+def test_vote_edge_has_one_shared_cross_club_denominator_and_agreeing_evidence():
+    layer = build_vote_layer(
+        [_voting(i, swapped=i % 2 == 0) for i in range(1, 21)], term=10
+    )
+    edge = next(e for e in layer["edges"] if (e["a"], e["b"]) == (1, 7))
+    assert edge["n"] == 20
+    assert edge["agreement"] == 1.0
+    assert edge["baseline_agreement"] == 0.0
+    assert edge["excess"] == 1.0
+    assert edge["evidence"] and all(
+        item["url"] and item["voting_id"] for item in edge["evidence"]
+    )
+
+
+def test_tied_club_and_under_twenty_comparisons_emit_no_edge():
+    assert (
+        build_vote_layer([_voting(i, tied=True) for i in range(1, 21)], term=10)[
+            "edges"
+        ]
+        == []
+    )
+    assert build_vote_layer([_voting(i) for i in range(1, 20)], term=10)["edges"] == []
+
+
+def test_near_unanimous_votes_are_excluded():
+    vote = _voting(1)
+    for row in vote["votes"]:
+        row["vote"] = "YES"
+    assert build_vote_layer([vote] * 20, term=10)["edges"] == []
+
+
+def test_missing_ballot_rows_fail_snapshot_build():
+    with pytest.raises(RuntimeError, match="incomplete ballot set"):
+        _require_complete_ballots(
+            [
+                {"id": 1, "total_voted": 1, "not_participating": 0},
+                {"id": 2, "total_voted": 1, "not_participating": 0},
+            ],
+            {1: [{"mp_id": 1, "vote": "YES"}]},
+        )
+
+
+def test_nonempty_partial_duplicate_or_invalid_ballots_fail():
+    voting = {"totalVoted": 3, "notParticipating": 0}
+    with pytest.raises(RuntimeError, match="incomplete ballot set"):
+        _validate_source_ballots(voting, [{"MP": 1, "vote": "YES"}], mp_key="MP")
+    with pytest.raises(RuntimeError, match="incomplete ballot set"):
+        _validate_source_ballots(
+            {"totalVoted": 2, "notParticipating": 0},
+            [{"MP": 1, "vote": "YES"}, {"MP": 1, "vote": "NO"}],
+            mp_key="MP",
+        )
+    with pytest.raises(RuntimeError, match="invalid ballot MP id"):
+        _validate_source_ballots(
+            {"totalVoted": 1, "notParticipating": 0},
+            [{"MP": None, "vote": "YES"}],
+            mp_key="MP",
+        )

--- a/tests/supagraf/unit/test_network_publish.py
+++ b/tests/supagraf/unit/test_network_publish.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock
+
+import pytest
+
+from supagraf import network, network_publish
+from supagraf.sync.context import SyncContext
+from supagraf.sync.daily import _network_phase
+from supagraf.sync.runlog import RunLedger
+
+
+def test_failed_build_does_not_touch_previous_snapshot(monkeypatch):
+    client = Mock()
+    monkeypatch.setattr(network_publish, "supabase", lambda: client)
+    monkeypatch.setattr(
+        network, "build_network", Mock(side_effect=RuntimeError("incomplete source"))
+    )
+    with pytest.raises(RuntimeError):
+        network_publish.refresh_network()
+    client.table.assert_not_called()
+
+
+def test_success_publishes_one_complete_snapshot(monkeypatch):
+    payload = {
+        "schema_version": "1",
+        "term": 10,
+        "generated_at": "2026-09-10T00:00:00Z",
+        "nodes": [],
+        "layers": {"questions": {"edges": []}, "votes": {"edges": []}},
+    }
+    client = Mock()
+    monkeypatch.setattr(network_publish, "supabase", lambda: client)
+    monkeypatch.setattr(network, "build_network", lambda **_: payload)
+    network_publish.refresh_network()
+    client.table.return_value.upsert.assert_called_once_with(
+        {"term": 10, "generated_at": payload["generated_at"], "payload": payload},
+        on_conflict="term",
+    )
+    client.table.return_value.delete.assert_not_called()
+
+
+@pytest.mark.parametrize("failed", ["sync:questions", "sync:votings", "load"])
+def test_incomplete_source_blocks_network_publication(monkeypatch, failed):
+    refresh = Mock()
+    monkeypatch.setattr(network_publish, "refresh_network", refresh)
+    ledger = RunLedger(kind="daily", term=10, persist=False)
+    with ledger.step(failed) as step:
+        step.fail("source incomplete")
+    _network_phase(
+        SyncContext.model_construct(term=10, api=Mock()),
+        ledger,
+        skip_load=False,
+        load_succeeded=True,
+    )
+    refresh.assert_not_called()
+    assert ledger.steps[-1].name == "network" and ledger.steps[-1].status == "skipped"
+
+
+def test_daily_retries_network_without_dirty_sources(monkeypatch):
+    refresh = Mock(return_value={"nodes": 0})
+    monkeypatch.setattr(network_publish, "refresh_network", refresh)
+    ledger = RunLedger(kind="daily", term=10, persist=False)
+    _network_phase(
+        SyncContext.model_construct(term=10, api=Mock()),
+        ledger,
+        skip_load=False,
+        load_succeeded=True,
+    )
+    refresh.assert_called_once_with(term=10)

--- a/tests/supagraf/unit/test_vote_club_history_migration.py
+++ b/tests/supagraf/unit/test_vote_club_history_migration.py
@@ -1,0 +1,35 @@
+"""Regression guard for the historical club SQL definitions."""
+from pathlib import Path
+
+
+MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "supabase"
+    / "migrations"
+    / "20260910063557_fix_vote_club_history.sql"
+)
+
+
+def _statements() -> str:
+    return "\n".join(
+        line for line in MIGRATION.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("--")
+    )
+
+
+def test_discipline_uses_club_recorded_on_vote_and_rejects_ambiguous_modal():
+    sql = _statements()
+    assert "cm.club_ref = v.club_ref" in sql
+    assert "c.club_id = v.club_ref" in sql
+    assert "having club_size >= 5" in sql
+    assert "count(*) filter (where choice_count = max_count) = 1" in sql
+    assert "vt.kind = 'ELECTRONIC'::public.voting_kind" in sql
+    assert "'PRESENT'::public.vote_choice" not in sql
+    assert "'VOTE_VALID'::public.vote_choice" not in sql
+    assert "mp_club_membership" not in sql
+
+
+def test_transition_function_does_not_drop_returns_to_an_old_club():
+    sql = _statements()
+    assert "prev_club is distinct from club_short" in sql
+    assert "rn_in_club" not in sql


### PR DESCRIPTION
Dodaje eksperymentalny widok `/powiazania`: wspólne autorstwo interpelacji i zapytań oraz podobieństwo głosowań względem zachowania klubów. Każda relacja zawiera źródła i zakres próby. Widok korzysta ze zdjęć z bazy; na telefonie prezentuje listę z rozwijanymi szczegółami.

ETL publikuje kompletny snapshot atomowo po udanym przebiegu. Poprawki zachowują historyczną przynależność klubową, ponawiają nieudane ładowanie i nie oznaczają niepełnych kart głosowania jako gotowych.

Walidacja: 407 testów jednostkowych zaliczonych, 2 pominięte; lokalne testy SQL w PGlite; lint zmienionych plików; produkcyjny build Next.js z kontrolą typów. Test przeglądarkowy sprawdza zdjęcia, ich niedostępność, źródła i interakcje mobilne oraz szerokości 320–1280 px.

Przed uruchomieniem funkcji na produkcji zastosować migracje `20260910063533_politician_network_snapshots.sql` i `20260910063557_fix_vote_club_history.sql`, a następnie uruchomić `uv run python -m supagraf network --publish`. Procedura i ograniczenia analizy są opisane w `docs/network-experiments.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an experimental “Powiązania” view showing connections between Polish MPs based on shared questions and voting patterns.
  - Added search, filtering, mobile-friendly browsing, connection details, and supporting evidence.
  - Added navigation access from the Atlas area.
  - Added automated generation and publication of network snapshots.

- **Bug Fixes**
  - Improved recovery after interrupted data loads.
  - Voting data is now checked for completeness before being finalized.
  - Corrected detection of historical club changes and vote-discipline results.

- **Documentation**
  - Added Polish-language documentation for the network experiment and local preview workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->