### PR TITLE
Fix process timeline for non-law documents

### DIFF
--- a/frontend/app/proces/[term]/[number]/_components/Timeline.tsx
+++ b/frontend/app/proces/[term]/[number]/_components/Timeline.tsx
@@ -186,18 +186,18 @@ const PHASE_META: Record<PhaseKey, { label: string; actor: string; note: string 
   },
   senate: {
     label: "Senat",
-    actor: "30 dni na decyzję",
-    note: "Senat przyjmie, odrzuci lub zaproponuje poprawki.",
+    actor: "Senat",
+    note: "Senat może przyjąć ustawę, zaproponować poprawki albo ją odrzucić. Termin zależy od trybu prac.",
   },
   president: {
     label: "Prezydent",
-    actor: "21 dni",
-    note: "Podpis, weto albo skierowanie do Trybunału Konstytucyjnego.",
+    actor: "Prezydent",
+    note: "Prezydent może podpisać ustawę, zawetować ją albo przed podpisaniem skierować ją do Trybunału Konstytucyjnego. Termin zależy od trybu prac.",
   },
   promulgation: {
-    label: "Dz.U.",
-    actor: "wejście w życie",
-    note: "14 dni od ogłoszenia, chyba że ustawa stanowi inaczej.",
+    label: "Publikacja w Dz.U.",
+    actor: "Dziennik Ustaw",
+    note: "Po podpisie ustawa jest ogłaszana w Dzienniku Ustaw. Datę wejścia w życie określa jej treść; poszczególne przepisy mogą mieć różne terminy.",
   },
 };
 
@@ -257,14 +257,17 @@ export function Timeline({
   stages,
   votings,
   processStillOpen,
+  projectFutureLawPath,
 }: {
   stages: ProcessStage[];
   votings: LinkedVoting[];
   processStillOpen: boolean;
+  projectFutureLawPath: boolean;
 }) {
   const real = buildStations(stages, votings);
-  const future = processStillOpen ? projectFutureStations(stages) : [];
+  const future = processStillOpen && projectFutureLawPath ? projectFutureStations(stages) : [];
   const stations: Station[] = [...real, ...future];
+  const sectionTitle = projectFutureLawPath ? "Ścieżka projektu ustawy" : "Przebieg sprawy";
   const hasFailedTerminal = stages.some(
     (s) => s.depth === 0 && (s.stageType === "Rejected" || s.stageType === "Withdrawn"),
   );
@@ -280,9 +283,9 @@ export function Timeline({
     return (
       <section className="px-0 py-10 border-b border-border" style={{ background: "var(--muted)" }}>
         <div className="max-w-[1280px] mx-auto px-4 md:px-8 lg:px-14">
-          <SectionHead title="Ścieżka projektu" />
+          <SectionHead title={sectionTitle} />
           <p className="text-muted-foreground">
-            Brak etapów procesu legislacyjnego dla tego druku.
+            Brak etapów procesu dla tego druku.
           </p>
         </div>
       </section>
@@ -294,7 +297,7 @@ export function Timeline({
   return (
     <section className="py-12 md:py-14 border-b border-border" style={{ background: "var(--muted)" }}>
       <div className="max-w-[1280px] mx-auto px-4 md:px-8 lg:px-14">
-        <SectionHead title="Ścieżka projektu" />
+        <SectionHead title={sectionTitle} />
 
         {/* Horizontal station strip — md+ */}
         <div

--- a/frontend/app/proces/[term]/[number]/page.tsx
+++ b/frontend/app/proces/[term]/[number]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPrint } from "@/lib/db/prints";
 import { getProcessCitations } from "@/lib/db/statements";
+import { shouldProjectLawTimeline } from "@/lib/process-timeline";
 import { documentCategoryLabel, opinionSourceLabel, opinionSourceShort, promiseStatusLabel } from "@/lib/labels";
 import { PrintCard } from "@/components/print/PrintCard";
 import { PageBreadcrumb } from "@/components/chrome/PageBreadcrumb";
@@ -140,7 +141,12 @@ export default async function DrukPage({
         <Hero print={print} outcome={outcome} />
       </div>
 
-      <Timeline stages={stages} votings={relatedVotings} processStillOpen={!!processStillOpen} />
+      <Timeline
+        stages={stages}
+        votings={relatedVotings}
+        processStillOpen={!!processStillOpen}
+        projectFutureLawPath={shouldProjectLawTimeline(print.documentCategory)}
+      />
 
       <div className="max-w-[1280px] mx-auto px-4 md:px-8 lg:px-14">
         <Summary print={print} />

--- a/frontend/lib/process-timeline.ts
+++ b/frontend/lib/process-timeline.ts
@@ -1,0 +1,3 @@
+export function shouldProjectLawTimeline(documentCategory: string | null | undefined): boolean {
+  return documentCategory === "projekt_ustawy";
+}

--- a/frontend/scripts/test_legislative_facts.mjs
+++ b/frontend/scripts/test_legislative_facts.mjs
@@ -16,6 +16,7 @@ function load(path) {
 }
 const { predictStages } = load(root + "lib/voting/predict_stages.ts");
 const { voteMeaning } = load(root + "lib/weekly-stories.ts");
+const { shouldProjectLawTimeline } = load(root + "lib/process-timeline.ts");
 const date = s => new Date(s + "T00:00:00Z");
 const base = { sejmVoteDate: date("2026-09-01"), passed: true, motionPolarity: "pass", documentType: "BILL" };
 test("passage alone supplies no Senate, signature or publication date", () => {
@@ -45,6 +46,12 @@ test("resolution and unclassified motion do not acquire a law timeline", () => {
  assert.equal(predictStages({ ...base, documentType:null }).length,1);
  assert.equal(predictStages({ ...base, motionPolarity:null }).length,1);
  assert.equal(predictStages({ ...base, motionPolarity:"reject", passed:false }).length,1);
+});
+test("only a bill receives projected Senate, President and publication stages", () => {
+ assert.equal(shouldProjectLawTimeline("projekt_ustawy"), true);
+ for (const category of ["projekt_uchwaly", "wniosek_personalny", "sprawozdanie_komisji", null]) {
+  assert.equal(shouldProjectLawTimeline(category), false);
+ }
 });
 test("a recorded publication date is never called entry into force", () => {
  const stage=predictStages({ ...base, promulgationDate:date("2026-09-12") })[3];


### PR DESCRIPTION
Live validation of `/proces/10/3077` showed a personal appointment document receiving the generic future law stages “Senat → Prezydent → Dz.U.”.

This projects future legislative stages only for `projekt_ustawy`. Other document categories show their recorded events under a neutral “Przebieg sprawy” heading. It also removes fixed ordinary-procedure timing from the generic projection and keeps publication separate from entry into force.

Validation: 9 factual regression tests passed; TypeScript and focused ESLint passed; isolated Next.js production build passed; `git diff --check` is clean.