### PR TITLE
Test editorial image publisher atomicity

### DIFF
--- a/tests/supagraf/unit/test_editorial_publish.py
+++ b/tests/supagraf/unit/test_editorial_publish.py
@@ -1,0 +1,34 @@
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+
+def test_publisher_validates_all_assets_before_any_write(tmp_path, monkeypatch):
+    source = Path(__file__).resolve().parents[3] / 'scripts/illustrations/publish_selected.py'
+    spec = importlib.util.spec_from_file_location('editorial_publish_under_test', source)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    writes = []
+    class DB:
+        def table(self, *_): return self
+        def select(self, *_): return self
+        def eq(self, *_): return self
+        def limit(self, *_): return self
+        def execute(self): return SimpleNamespace(data=[{'id': 123, 'title': 'Lake', 'short_title': None}])
+        def upsert(self, *args, **kwargs): writes.append(args); return self
+    monkeypatch.setattr(module, 'supabase', lambda: DB())
+    assets = tmp_path / 'term-10'
+    assets.mkdir()
+    image = assets / 'lake.png'
+    Image.new('RGB', (60, 40)).save(image)
+    item = {'term': 10, 'number': '1', 'url': '/editorial/term-10/lake.png', 'sha256': hashlib.sha256(image.read_bytes()).hexdigest(), 'provider': 'generated', 'caption': 'Lake', 'alt': 'Lake'}
+    manifest = tmp_path / 'manifest.json'
+    manifest.write_text(json.dumps([item, {**item, 'number': '2', 'sha256': '0' * 64}]))
+    with pytest.raises(ValueError, match='asset hash mismatch'):
+        module.publish(manifest, tmp_path, dry_run=False, rollback_dir=tmp_path / 'rollback')
+    assert writes == []


### PR DESCRIPTION
Adds a regression that rejects the whole batch before any write when one approved asset hash is wrong.