### PR TITLE
Integrate compact editorial illustrations

### DIFF
--- a/frontend/app/tygodnik/_components/StoryPhoto.tsx
+++ b/frontend/app/tygodnik/_components/StoryPhoto.tsx
@@ -11,11 +11,11 @@ export function StoryPhoto({ image }: { image: StoryImage }) {
   const generated = image.provider === "generated";
   return <figure className={styles.storyPhoto}>
     <Image src={image.url} alt={image.alt} width={image.width} height={image.height}
-      sizes="(max-width: 760px) calc(100vw - 40px), 720px" loading="lazy"
+      sizes="(max-width: 760px) 160px, 240px" loading="lazy"
       onError={() => setFailed(true)} />
     <figcaption>
       <details>
-        <summary>Źródło zdjęcia</summary>
+        <summary>{generated ? "O ilustracji" : "Źródło zdjęcia"}</summary>
         <p>{image.caption}</p>
         {generated
           ? <p>Ilustracja AI: FLUX.2 [klein] 4B · materiał redakcyjny</p>

--- a/frontend/app/tygodnik/_components/weekly.module.css
+++ b/frontend/app/tygodnik/_components/weekly.module.css
@@ -11,7 +11,7 @@
 .storyMeta { display:flex; flex-wrap:wrap; align-items:center; gap:8px 16px; font-size:12px; color:var(--muted-foreground); margin-bottom:12px; }
 .storyTitle { font-size:clamp(24px,3vw,31px); font-weight:650; line-height:1.25; letter-spacing:-.025em; margin:0 0 20px; text-wrap:pretty; overflow-wrap:anywhere; }
 .storyTitle a:hover { text-decoration:underline; text-decoration-thickness:1px; text-underline-offset:5px; }
-.storyBody { max-width:720px; }
+.storyBody { max-width:720px; display:flow-root; }
 .summary { font-size:16px; color:var(--secondary-foreground); line-height:1.75; margin:0; }
 .summary + .summary { margin-top:16px; }
 .summaryLabel { color:var(--foreground); font-weight:550; }
@@ -93,10 +93,16 @@
 .markdown table { border-collapse:collapse; font-size:14px; }
 .markdown :is(th,td) { border:1px solid var(--border); padding:8px 12px; text-align:left; }
 
-.storyPhoto { margin:22px 0; }
-.storyPhoto img { width:100%; height:auto; max-height:400px; object-fit:contain; object-position:left center; }
+.storyPhoto { float:right; width:min(34%, 240px); margin:0 0 16px 24px; }
+.storyPhoto img { display:block; width:100%; height:auto; border-radius:4px; object-fit:contain; }
 .storyPhoto figcaption { display:flex; flex-direction:column; gap:4px; margin-top:9px; font-size:11px; line-height:1.6; color:var(--muted-foreground); }
 .storyPhoto figcaption a { text-decoration:underline; text-underline-offset:3px; }
 
 .storyPhoto summary { cursor:pointer; width:fit-content; }
 .storyPhoto details p { margin-top:6px; }
+
+/* Keep voting evidence and actions below the illustrated introduction. */
+.mainVote, .links, .voteDetails, .debateDetails { clear:both; }
+@media(max-width:760px) {
+  .storyPhoto { width:clamp(112px, 34%, 160px); margin:0 0 12px 16px; }
+}

--- a/supabase/migrations/20260912163000_withdraw_rejected_ballot_photo.sql
+++ b/supabase/migrations/20260912163000_withdraw_rejected_ballot_photo.sql
@@ -1,0 +1,4 @@
+-- Withdraw the explicitly rejected stock photograph. The catalog rule is disabled.
+UPDATE public.print_images
+SET status = 'no_match', image = NULL, checked_at = now(), catalog_hash = '663d4c88a7ba5cdc1f101a3339eb7355cb03a235adb02d72a37069bf51880851'
+WHERE image->>'file' = 'File:2010 Poland elections round 2 ballot box.jpg';

--- a/supagraf/enrich/image_catalog.json
+++ b/supagraf/enrich/image_catalog.json
@@ -9,7 +9,9 @@
     "id": "elections",
     "pattern": "\\b(?:kodeks\\w* wyborcz\\w*|komisj\\w* wyborcz\\w*|obwod\\w* głosowania)\\b",
     "file": "File:2010 Poland elections round 2 ballot box.jpg",
-    "caption": "Urna podczas wyborów prezydenckich w Polsce w 2010 r. Zdjęcie archiwalne, ilustracyjne."
+    "caption": "Urna podczas wyborów prezydenckich w Polsce w 2010 r. Zdjęcie archiwalne, ilustracyjne.",
+    "enabled": false,
+    "editorial_note": "Rejected by the editor: dated ballot-box snapshot does not fit the publication."
   },
   {
     "id": "bathing",

--- a/supagraf/enrich/story_images.py
+++ b/supagraf/enrich/story_images.py
@@ -34,7 +34,7 @@ def trusted_url(url: str, hosts: set[str]) -> bool:
 def match_rule(title: str, catalog: list[dict]) -> dict | None:
     matches = [rule for rule in catalog if re.search(rule["pattern"], title, re.I)]
     # Ambiguous multiple subjects are better left without a picture.
-    return matches[0] if len(matches) == 1 else None
+    return matches[0] if len(matches) == 1 and matches[0].get("enabled", True) else None
 
 
 def parse_image(page: dict, rule: dict) -> dict | None:

--- a/tests/supagraf/unit/test_story_images.py
+++ b/tests/supagraf/unit/test_story_images.py
@@ -24,7 +24,7 @@ def page():
 
 
 def test_concrete_subject_only_and_ambiguity_abstains():
-    assert match_rule('Zmiana Kodeksu wyborczego', CATALOG)['id'] == 'elections'
+    assert match_rule('Zmiana Kodeksu wyborczego', CATALOG) is None
     assert match_rule('Jakość wody w kąpieliskach', CATALOG)['id'] == 'bathing'
     assert match_rule('Sprawozdanie komisji', CATALOG) is None
     assert match_rule('Kodeks wyborczy i elektrownie wiatrowe', CATALOG) is None
@@ -73,7 +73,7 @@ class Client:
 
     def execute(self):
         if self.table_name == 'prints':
-            return SimpleNamespace(data=[{'id': 1, 'number': '123', 'title': 'Kodeks wyborczy', 'short_title': None}])
+            return SimpleNamespace(data=[{'id': 1, 'number': '123', 'title': 'Jakość wody w kąpieliskach', 'short_title': None}])
         return SimpleNamespace(data=copy.deepcopy(self.saved))
 
     def upsert(self, payload, **_):


### PR DESCRIPTION
Uses reviewed images as compact text-adjacent editorial asides and withdraws the rejected ballot image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Story photos now use a more compact, responsive layout, floating alongside article text on larger screens and adapting for mobile displays.
  * Photo details now vary appropriately based on whether an image is generated or sourced.

* **Bug Fixes**
  * Rejected imagery is no longer selected for publication.
  * Article content and voting sections now remain clear of floating photos for improved readability.
  * Updated image matching behavior and validation to prevent unsuitable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->