### PR TITLE
Keep weekly story text full width on mobile

### DIFF
--- a/frontend/app/tygodnik/_components/BriefList.tsx
+++ b/frontend/app/tygodnik/_components/BriefList.tsx
@@ -46,7 +46,9 @@ function Story({ story, term }: { story: WeeklyStory; term: number }) {
             {!amendmentsOnly && result.label.startsWith("Wniosek") && !/odrzucenie projektu/.test(result.label) && <p className={styles.procedure}>{result.question}</p>}
           </div>
         )}
-        {story.image && <StoryPhoto key={story.image.url} image={story.image} />}
+        <div className={styles.storyIntro}>
+          {story.image && <StoryPhoto key={story.image.url} image={story.image} />}
+          <div className={styles.storyIntroText}>
         {story.projectSummaries && story.projectSummaries.length > 0 ? (
           story.projectSummaries.map(p => <div key={p.number} className={styles.summary}>
             <Link href={`/proces/${term}/${p.number}`} className={styles.summaryLabel}>Projekt {p.number}: </Link>
@@ -56,6 +58,8 @@ function Story({ story, term }: { story: WeeklyStory; term: number }) {
           {hasProjects && <span className={styles.summaryLabel}>Założenia projektu: </span>}
           <WeeklySummary term={term} text={story.summary} />
         </div>}
+          </div>
+        </div>
         {main && !amendmentsOnly && <figure className={styles.mainVote}>
           <figcaption>Głosowanie nr {main.voting_number} · {result?.question}</figcaption>
           <VoteBreakdown vote={main} />

--- a/frontend/app/tygodnik/_components/StoryPhoto.tsx
+++ b/frontend/app/tygodnik/_components/StoryPhoto.tsx
@@ -11,7 +11,7 @@ export function StoryPhoto({ image }: { image: StoryImage }) {
   const generated = image.provider === "generated";
   return <figure className={styles.storyPhoto}>
     <Image src={image.url} alt={image.alt} width={image.width} height={image.height}
-      sizes="(max-width: 760px) 160px, 240px" loading="lazy"
+      sizes="240px" loading="lazy"
       onError={() => setFailed(true)} />
     <figcaption>
       <details>
@@ -24,3 +24,4 @@ export function StoryPhoto({ image }: { image: StoryImage }) {
     </figcaption>
   </figure>;
 }
+

--- a/frontend/app/tygodnik/_components/weekly.module.css
+++ b/frontend/app/tygodnik/_components/weekly.module.css
@@ -103,6 +103,10 @@
 
 /* Keep voting evidence and actions below the illustrated introduction. */
 .mainVote, .links, .voteDetails, .debateDetails { clear:both; }
+.storyIntro { display:flow-root; }
+.storyIntroText { min-width:0; }
 @media(max-width:760px) {
-  .storyPhoto { width:clamp(112px, 34%, 160px); margin:0 0 12px 16px; }
+  .storyIntro { display:flex; flex-direction:column; }
+  .storyIntroText { order:0; width:100%; }
+  .storyIntro .storyPhoto { order:1; float:none; width:min(100%, 240px); margin:16px 0 20px; }
 }


### PR DESCRIPTION
Moves the supporting illustration after the summary on mobile while preserving the compact desktop aside.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated weekly story introductions with a responsive layout that places text before the photo on mobile devices.
  * Adjusted mobile photo sizing and removed the previous floating-photo presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->