### PR TITLE
Add editorial cover treatment

### DIFF
--- a/frontend/app/tygodnik/_components/BriefList.tsx
+++ b/frontend/app/tygodnik/_components/BriefList.tsx
@@ -32,11 +32,16 @@ function Story({ story, term }: { story: WeeklyStory; term: number }) {
 
   return (
     <article className={styles.story} id={`sprawa-${story.id}`} aria-labelledby={`tytul-${story.id}`}>
+      <div className={story.image ? styles.storyLeadIllustrated : styles.storyLead}>
+        {story.image && <StoryPhoto key={story.image.url} image={story.image} />}
+        <div className={styles.storyHeading}>
       <div className={styles.storyMeta}>
         {(story.phase !== "Debata i głosowania" || !main) && !story.title.toLocaleLowerCase("pl").includes(story.phase.toLocaleLowerCase("pl")) && <span>{story.phase}</span>}
         {main?.date && <time dateTime={main.date}>{new Date(main.date).toLocaleDateString("pl-PL", { day: "numeric", month: "long" })}</time>}
       </div>
       <h2 id={`tytul-${story.id}`} className={styles.storyTitle}>{href ? <Link href={href}>{story.title}</Link> : story.title}</h2>
+        </div>
+      </div>
       <div className={styles.storyBody}>
         {main && result && (
           <div className={styles.result}>
@@ -47,7 +52,6 @@ function Story({ story, term }: { story: WeeklyStory; term: number }) {
           </div>
         )}
         <div className={styles.storyIntro}>
-          {story.image && <StoryPhoto key={story.image.url} image={story.image} />}
           <div className={styles.storyIntroText}>
         {story.projectSummaries && story.projectSummaries.length > 0 ? (
           story.projectSummaries.map(p => <div key={p.number} className={styles.summary}>

--- a/frontend/app/tygodnik/_components/StoryPhoto.tsx
+++ b/frontend/app/tygodnik/_components/StoryPhoto.tsx
@@ -11,7 +11,7 @@ export function StoryPhoto({ image }: { image: StoryImage }) {
   const generated = image.provider === "generated";
   return <figure className={styles.storyPhoto}>
     <Image src={image.url} alt={image.alt} width={image.width} height={image.height}
-      sizes="240px" loading="lazy"
+      sizes="(max-width: 760px) 100vw, 240px" loading="lazy"
       onError={() => setFailed(true)} />
     <figcaption>
       <details>

--- a/frontend/app/tygodnik/_components/weekly.module.css
+++ b/frontend/app/tygodnik/_components/weekly.module.css
@@ -93,20 +93,24 @@
 .markdown table { border-collapse:collapse; font-size:14px; }
 .markdown :is(th,td) { border:1px solid var(--border); padding:8px 12px; text-align:left; }
 
-.storyPhoto { float:right; width:min(34%, 240px); margin:0 0 16px 24px; }
-.storyPhoto img { display:block; width:100%; height:auto; border-radius:4px; object-fit:contain; }
-.storyPhoto figcaption { display:flex; flex-direction:column; gap:4px; margin-top:9px; font-size:11px; line-height:1.6; color:var(--muted-foreground); }
-.storyPhoto figcaption a { text-decoration:underline; text-underline-offset:3px; }
-
+.storyLeadIllustrated { display:grid; grid-template-columns:minmax(0,1fr) 240px; gap:28px; align-items:start; margin-bottom:20px; }
+.storyHeading { min-width:0; grid-column:1; grid-row:1; }
+.storyLeadIllustrated .storyTitle { margin-bottom:0; }
+.storyPhoto { float:none; position:relative; grid-column:2; grid-row:1; width:100%; margin:0; }
+.storyPhoto img { display:block; width:100%; height:auto; border-radius:8px; }
+.storyPhoto figcaption { position:absolute; top:10px; right:10px; max-width:calc(100% - 20px); font-size:11px; line-height:1.6; color:var(--foreground); z-index:2; }
+.storyPhoto details { background:color-mix(in srgb,var(--background) 94%,transparent); border:1px solid var(--border); border-radius:8px; padding:5px 9px; }
 .storyPhoto summary { cursor:pointer; width:fit-content; }
-.storyPhoto details p { margin-top:6px; }
-
-/* Keep voting evidence and actions below the illustrated introduction. */
-.mainVote, .links, .voteDetails, .debateDetails { clear:both; }
+.storyPhoto details[open] { max-width:320px; }
+.storyPhoto details p { margin:8px 0 0; overflow-wrap:anywhere; }
+.storyPhoto figcaption a { text-decoration:underline; text-underline-offset:3px; }
 .storyIntro { display:flow-root; }
 .storyIntroText { min-width:0; }
 @media(max-width:760px) {
-  .storyIntro { display:flex; flex-direction:column; }
-  .storyIntroText { order:0; width:100%; }
-  .storyIntro .storyPhoto { order:1; float:none; width:min(100%, 240px); margin:16px 0 20px; }
+  .storyLeadIllustrated { display:block; margin-bottom:20px; }
+  .storyLeadIllustrated .storyPhoto { width:calc(100% + 40px); margin:0 -20px; }
+  .storyLeadIllustrated .storyPhoto img { border-radius:0; mask-image:linear-gradient(to bottom,#000 0%,#000 52%,transparent 100%); }
+  .storyLeadIllustrated .storyHeading { position:relative; margin-top:-48px; }
+  .storyLeadIllustrated .storyMeta { margin-bottom:10px; }
+  .storyLeadIllustrated .storyTitle { font-size:clamp(26px,7vw,32px); line-height:1.16; letter-spacing:-.035em; }
 }


### PR DESCRIPTION
Introduces the approved responsive editorial cover: a compact desktop thumbnail and full-width mobile cover fading into the heading. Validation: targeted lint and desktop/mobile visual QA.