### PR TITLE
Refine weekly desktop article layout

### DIFF
--- a/frontend/app/tygodnik/_components/BriefList.tsx
+++ b/frontend/app/tygodnik/_components/BriefList.tsx
@@ -32,17 +32,12 @@ function Story({ story, term }: { story: WeeklyStory; term: number }) {
 
   return (
     <article className={styles.story} id={`sprawa-${story.id}`} aria-labelledby={`tytul-${story.id}`}>
-      <div className={story.image ? styles.storyLeadIllustrated : styles.storyLead}>
-        {story.image && <StoryPhoto key={story.image.url} image={story.image} />}
-        <div className={styles.storyHeading}>
       <div className={styles.storyMeta}>
         {(story.phase !== "Debata i głosowania" || !main) && !story.title.toLocaleLowerCase("pl").includes(story.phase.toLocaleLowerCase("pl")) && <span>{story.phase}</span>}
         {main?.date && <time dateTime={main.date}>{new Date(main.date).toLocaleDateString("pl-PL", { day: "numeric", month: "long" })}</time>}
       </div>
       <h2 id={`tytul-${story.id}`} className={styles.storyTitle}>{href ? <Link href={href}>{story.title}</Link> : story.title}</h2>
-        </div>
-      </div>
-      <div className={styles.storyBody}>
+      <div className={`${styles.storyBody} ${story.image ? styles.storyBodyIllustrated : ""}`}>
         {main && result && (
           <div className={styles.result}>
             <p><strong>{amendmentsOnly ? senateResult : result.label}</strong></p>
@@ -51,6 +46,7 @@ function Story({ story, term }: { story: WeeklyStory; term: number }) {
             {!amendmentsOnly && result.label.startsWith("Wniosek") && !/odrzucenie projektu/.test(result.label) && <p className={styles.procedure}>{result.question}</p>}
           </div>
         )}
+        {story.image && <StoryPhoto key={story.image.url} image={story.image} />}
         <div className={styles.storyIntro}>
           <div className={styles.storyIntroText}>
         {story.projectSummaries && story.projectSummaries.length > 0 ? (

--- a/frontend/app/tygodnik/_components/StoryPhoto.tsx
+++ b/frontend/app/tygodnik/_components/StoryPhoto.tsx
@@ -8,20 +8,10 @@ import styles from "./weekly.module.css";
 export function StoryPhoto({ image }: { image: StoryImage }) {
   const [failed, setFailed] = useState(false);
   if (failed) return null;
-  const generated = image.provider === "generated";
   return <figure className={styles.storyPhoto}>
     <Image src={image.url} alt={image.alt} width={image.width} height={image.height}
-      sizes="(max-width: 760px) 100vw, 240px" loading="lazy"
+      sizes="(max-width: 760px) calc(100vw - 40px), 320px" loading="lazy"
       onError={() => setFailed(true)} />
-    <figcaption>
-      <details>
-        <summary>{generated ? "O ilustracji" : "Źródło zdjęcia"}</summary>
-        <p>{image.caption}</p>
-        {generated
-          ? <p>Ilustracja AI: FLUX.2 [klein] 4B · materiał redakcyjny</p>
-          : <p>Fot. {image.author} · <a href={image.source_url}>Wikimedia Commons</a> · <a href={image.license_url}>{image.license}</a></p>}
-      </details>
-    </figcaption>
   </figure>;
 }
 

--- a/frontend/app/tygodnik/_components/weekly.module.css
+++ b/frontend/app/tygodnik/_components/weekly.module.css
@@ -1,4 +1,4 @@
-.edition { --vote-yes:#159b78; --vote-no:#e25467; --vote-abstain:#e3ae42; max-width:960px; margin:0 auto; padding:40px 32px 64px; }
+.edition { --vote-yes:#159b78; --vote-no:#e25467; --vote-abstain:#e3ae42; max-width:1080px; margin:0 auto; padding:40px 32px 64px; }
 .header { padding-bottom:28px; }
 .header h1 { font-size:clamp(30px,4vw,42px); line-height:1.15; letter-spacing:-.04em; font-weight:650; margin:0 0 22px; }
 .toolbar { display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:20px; }
@@ -11,7 +11,9 @@
 .storyMeta { display:flex; flex-wrap:wrap; align-items:center; gap:8px 16px; font-size:12px; color:var(--muted-foreground); margin-bottom:12px; }
 .storyTitle { font-size:clamp(24px,3vw,31px); font-weight:650; line-height:1.25; letter-spacing:-.025em; margin:0 0 20px; text-wrap:pretty; overflow-wrap:anywhere; }
 .storyTitle a:hover { text-decoration:underline; text-decoration-thickness:1px; text-underline-offset:5px; }
-.storyBody { max-width:720px; display:flow-root; }
+.storyBody { max-width:720px; }
+.storyBodyIllustrated { max-width:none; display:grid; grid-template-columns:minmax(0,1fr) minmax(260px,320px); column-gap:48px; align-items:start; }
+.storyBodyIllustrated > :not(.storyPhoto) { grid-column:1; }
 .summary { font-size:16px; color:var(--secondary-foreground); line-height:1.75; margin:0; }
 .summary + .summary { margin-top:16px; }
 .summaryLabel { color:var(--foreground); font-weight:550; }
@@ -93,24 +95,10 @@
 .markdown table { border-collapse:collapse; font-size:14px; }
 .markdown :is(th,td) { border:1px solid var(--border); padding:8px 12px; text-align:left; }
 
-.storyLeadIllustrated { display:grid; grid-template-columns:minmax(0,1fr) 240px; gap:28px; align-items:start; margin-bottom:20px; }
-.storyHeading { min-width:0; grid-column:1; grid-row:1; }
-.storyLeadIllustrated .storyTitle { margin-bottom:0; }
-.storyPhoto { float:none; position:relative; grid-column:2; grid-row:1; width:100%; margin:0; }
-.storyPhoto img { display:block; width:100%; height:auto; border-radius:8px; }
-.storyPhoto figcaption { position:absolute; top:10px; right:10px; max-width:calc(100% - 20px); font-size:11px; line-height:1.6; color:var(--foreground); z-index:2; }
-.storyPhoto details { background:color-mix(in srgb,var(--background) 94%,transparent); border:1px solid var(--border); border-radius:8px; padding:5px 9px; }
-.storyPhoto summary { cursor:pointer; width:fit-content; }
-.storyPhoto details[open] { max-width:320px; }
-.storyPhoto details p { margin:8px 0 0; overflow-wrap:anywhere; }
-.storyPhoto figcaption a { text-decoration:underline; text-underline-offset:3px; }
-.storyIntro { display:flow-root; }
-.storyIntroText { min-width:0; }
+.storyPhoto { grid-column:2; grid-row:1 / span 8; width:100%; margin:0; }
+.storyPhoto img { display:block; width:100%; height:auto; max-height:260px; object-fit:cover; object-position:center; border-radius:6px; }
 @media(max-width:760px) {
-  .storyLeadIllustrated { display:block; margin-bottom:20px; }
-  .storyLeadIllustrated .storyPhoto { width:calc(100% + 40px); margin:0 -20px; }
-  .storyLeadIllustrated .storyPhoto img { border-radius:0; mask-image:linear-gradient(to bottom,#000 0%,#000 52%,transparent 100%); }
-  .storyLeadIllustrated .storyHeading { position:relative; margin-top:-48px; }
-  .storyLeadIllustrated .storyMeta { margin-bottom:10px; }
-  .storyLeadIllustrated .storyTitle { font-size:clamp(26px,7vw,32px); line-height:1.16; letter-spacing:-.035em; }
+  .storyBodyIllustrated { display:block; }
+  .storyPhoto { margin:18px 0; }
+  .storyPhoto img { max-height:360px; object-fit:contain; object-position:left center; }
 }


### PR DESCRIPTION
Removes the illustration/source disclosure block from weekly story images and moves desktop images out of the heading into a 320 px article column. Text keeps a readable measure, mobile stays single-column, and image failures still collapse cleanly. Validated with targeted ESLint, TypeScript, 21 weekly-story tests, a full Next.js build, and Playwright at 1440 px and 390 px.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Design Updates**
  * Weekly edition pages now use a wider content layout.
  * Stories with images display content and photography in a two-column layout, with responsive behavior on mobile.
  * Story images now appear with rounded, cropped styling and updated sizing.
* **Content Changes**
  * Simplified story image presentation by removing captions, source and license links, generated-image indicators, and related metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->